### PR TITLE
Fix firebase project id of LSZT production project

### DIFF
--- a/projects/lszt.json
+++ b/projects/lszt.json
@@ -33,7 +33,7 @@
       "firebaseApiKey": "AIzaSyDy63Y8GP6GExoP07KWJ6qneAeQalu9pK8"
     },
     "production": {
-      "firebaseProjectId": "lszt",
+      "firebaseProjectId": "project-8979611309653332047",
       "firebaseApiKey": "AIzaSyBNL_8OjB26xYYmjWbTCiPcxKgHs73FxGc"
     }
   },


### PR DESCRIPTION
ID is needed to build the correct cloud functions URL.