### PR TITLE
Only show fees on arrival finish screen if amount is > 0

### DIFF
--- a/src/components/wizards/ArrivalWizard/Finish/Finish.js
+++ b/src/components/wizards/ArrivalWizard/Finish/Finish.js
@@ -32,8 +32,7 @@ const Finish = props => {
   } = props
   const heading = getHeading(headingType);
 
-
-  const showPayment = (isHomeBase === false || __CONF__.homebasePayment) && !isUpdate && !!fees
+  const showPayment = (isHomeBase === false || __CONF__.homebasePayment) && !isUpdate && !!fees && fees.totalGross > 0
 
   const {
     landings,


### PR DESCRIPTION
Before, we showed the fees if the fees object was defined, even if the amount was 0, which didn't make sense.