### PR TITLE
Add cloud trigger functions to enrich movement with location metadata

### DIFF
--- a/firebase-rules-template.json
+++ b/firebase-rules-template.json
@@ -43,6 +43,15 @@
         "location": {
           ".validate": "newData.isString() && newData.val().length > 0"
         },
+        "locationName": {
+          ".validate": "newData.isString()"
+        },
+        "locationCountry": {
+          ".validate": "newData.isString()"
+        },
+        "locationTimezone": {
+          ".validate": "newData.isString()"
+        },
         "memberNr": {
           ".validate": "newData.isString()"
         },
@@ -159,6 +168,15 @@
         },
         "location": {
           ".validate": "newData.isString() && newData.val().length > 0"
+        },
+        "locationName": {
+          ".validate": "newData.isString()"
+        },
+        "locationCountry": {
+          ".validate": "newData.isString()"
+        },
+        "locationTimezone": {
+          ".validate": "newData.isString()"
         },
         "memberNr": {
           ".validate": "newData.isString()"

--- a/functions/enrichMovements.js
+++ b/functions/enrichMovements.js
@@ -1,0 +1,118 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+const getEnrichedData = (aerodromeSnapshot, icaoCode) => {
+  if (!aerodromeSnapshot.exists()) {
+    functions.logger.warn(`Aerodrome data not found for ICAO code: ${icaoCode}. Clearing enriched data.`);
+    return {
+      locationName: null,
+      locationCountry: null,
+      locationTimezone: null
+    };
+  }
+
+  const aerodromeData = aerodromeSnapshot.val();
+  return {
+    locationName: aerodromeData.name || null,
+    locationCountry: aerodromeData.country || null,
+    locationTimezone: aerodromeData.timezone || null,
+  };
+}
+
+async function enrichMovementWithAerodromeMetadata(movement, movementType, movementKey) {
+  if (!movement?.location) {
+    functions.logger.warn(`No location found for ${movementType} ${movementKey}`);
+    return;
+  }
+
+  const icaoCode = movement.location.toUpperCase();
+
+  try {
+    const aerodromeSnapshot = await admin.database()
+      .ref('aerodromes')
+      .child(icaoCode)
+      .once('value');
+
+    const enrichedData = getEnrichedData(aerodromeSnapshot, icaoCode)
+
+    const hasChanges = movement.locationName !== enrichedData.locationName ||
+                      movement.locationCountry !== enrichedData.locationCountry ||
+                      movement.locationTimezone !== enrichedData.locationTimezone;
+
+    if (hasChanges) {
+      const movementPath = movementType === 'departure' ? 'departures' : 'arrivals';
+      await admin.database()
+        .ref(movementPath)
+        .child(movementKey)
+        .update(enrichedData);
+
+      functions.logger.info(
+        `Enriched ${movementType} ${movementKey} with aerodrome metadata for ${icaoCode}: ${enrichedData.locationName}, ${enrichedData.country}`
+      );
+    }
+
+  } catch (error) {
+    functions.logger.error(
+      `Failed to enrich ${movementType} ${movementKey} with aerodrome metadata:`,
+      error
+    );
+    throw error;
+  }
+}
+
+async function enrichOnCreate(snapshot, movementType) {
+  const movementKey = snapshot.ref.key;
+  const movement = snapshot.val();
+
+  functions.logger.info(`Enriching new ${movementType} ${movementKey} with aerodrome metadata`);
+
+  await enrichMovementWithAerodromeMetadata(movement, movementType, movementKey);
+}
+
+async function enrichOnUpdate(change, movementType) {
+  const movementKey = change.after.ref.key;
+  const beforeMovement = change.before.val();
+  const afterMovement = change.after.val();
+
+  const locationChanged = beforeMovement.location !== afterMovement.location;
+  const missingMetadata = !afterMovement.locationName ||
+                         !afterMovement.locationCountry ||
+                         !afterMovement.locationTimezone;
+
+  if (locationChanged || missingMetadata) {
+    functions.logger.info(
+      `Enriching updated ${movementType} ${movementKey} (location changed: ${locationChanged}, missing metadata: ${missingMetadata})`
+    );
+
+    await enrichMovementWithAerodromeMetadata(afterMovement, movementType, movementKey);
+  }
+}
+
+const instance = functions.config().rtdb.instance;
+
+const handleUpdate = (change, movementType) => {
+  if (!change.before.exists() || !change.after.exists()) {
+    return null;
+  }
+  return enrichOnUpdate(change, movementType);
+};
+
+exports.enrichDepartureOnCreate = functions.database
+  .instance(instance)
+  .ref('/departures/{departureId}')
+  .onCreate((snapshot) => enrichOnCreate(snapshot, 'departure'));
+
+exports.enrichDepartureOnUpdate = functions.database
+  .instance(instance)
+  .ref('/departures/{departureId}')
+  .onWrite((change) => handleUpdate(change, 'departure'));
+
+exports.enrichArrivalOnCreate = functions.database
+  .instance(instance)
+  .ref('/arrivals/{arrivalId}')
+  .onCreate((snapshot) => enrichOnCreate(snapshot, 'arrival'));
+
+exports.enrichArrivalOnUpdate = functions.database
+  .instance(instance)
+  .ref('/arrivals/{arrivalId}')
+  .onWrite((change) => handleUpdate(change, 'arrival'));

--- a/functions/index.js
+++ b/functions/index.js
@@ -10,6 +10,7 @@ admin.initializeApp({
 });
 
 const { scheduledAerodromesUpdate } = require('./updateAerodromes');
+const enrichMovements = require('./enrichMovements');
 
 const auth = require('./auth');
 const { generateSignInLink } = require('./auth/generateSignInLink');
@@ -35,3 +36,8 @@ exports.scheduledAerodromesUpdate = scheduledAerodromesUpdate;
 exports.setAssociatedMovementOnDeletedDeparture = associatedMovementsTriggers.setAssociatedMovementOnDeletedDeparture;
 exports.setAssociatedMovementOnDeletedArrival = associatedMovementsTriggers.setAssociatedMovementOnDeletedArrival;
 exports.updateCustomsInvoiceRecipientsOnUpdate = invoiceRecipientsTrigger.updateCustomsInvoiceRecipientsOnUpdate;
+
+exports.enrichDepartureOnCreate = enrichMovements.enrichDepartureOnCreate;
+exports.enrichDepartureOnUpdate = enrichMovements.enrichDepartureOnUpdate;
+exports.enrichArrivalOnCreate = enrichMovements.enrichArrivalOnCreate;
+exports.enrichArrivalOnUpdate = enrichMovements.enrichArrivalOnUpdate;


### PR DESCRIPTION
- The selected aerodrome is looked up in the aerodromes collection and the data of the found aerodrome is added to the movement (full name, country, timezone)
- If there is no document found for the selected ICAO code, these meta data fields are set to `null`