### PR TITLE
Don't mask contact information (email, phone) for LSZM

### DIFF
--- a/projects/default.json
+++ b/projects/default.json
@@ -13,5 +13,6 @@
   ],
   "paymentMethods": ["cash"],
   "homebasePayment": false,
-  "loginForm": "usernamePassword"
+  "loginForm": "usernamePassword",
+  "maskContactInformation": true
 }

--- a/projects/lszm.json
+++ b/projects/lszm.json
@@ -76,5 +76,6 @@
     "glider_instruction_aerotow",
     "glider_instruction_winch",
     "glider_instruction_self"
-  ]
+  ],
+  "maskContactInformation": false
 }

--- a/src/components/MovementList/MovementDetails.js
+++ b/src/components/MovementList/MovementDetails.js
@@ -75,8 +75,14 @@ class MovementDetails extends React.PureComponent {
             <MovementField label="Mitgliedernummer" value={props.data.memberNr}/>
             <MovementField label="Nachname" value={props.data.lastname}/>
             <MovementField label="Vorname" value={props.data.firstname}/>
-            <MovementField label="E-Mail" value={props.isAdmin ? props.data.email : maskEmail(props.data.email)}/>
-            <MovementField label="Telefon" value={props.isAdmin ? props.data.phone : maskPhone(props.data.phone)}/>
+            <MovementField label="E-Mail"
+                           value={__CONF__.maskContactInformation === true && !props.isAdmin
+                             ? maskEmail(props.data.email)
+                             : props.data.email}/>
+            <MovementField label="Telefon"
+                           value={__CONF__.maskContactInformation === true && !props.isAdmin
+                             ? maskPhone(props.data.phone)
+                             : props.data.phone}/>
           </DetailsBox>
           {props.data.type === 'departure'
             ? (

--- a/src/components/wizards/pages/PilotPage.js
+++ b/src/components/wizards/pages/PilotPage.js
@@ -57,7 +57,7 @@ const PilotPage = (props) => {
           label="E-Mail"
           component={renderInputField}
           readOnly={props.readOnly}
-          masked={!props.isAdmin}
+          masked={__CONF__.maskContactInformation === true && !props.isAdmin}
         />
         <Field
           name="phone"
@@ -65,7 +65,7 @@ const PilotPage = (props) => {
           label="Telefon"
           component={renderInputField}
           readOnly={props.readOnly}
-          masked={!props.isAdmin}
+          masked={__CONF__.maskContactInformation === true && !props.isAdmin}
         />
       </FieldSet>
       <WizardNavigation previousStep={previousPage} cancel={props.cancel}/>


### PR DESCRIPTION
- At LSZM, nobody except of admins can view a list of movements except of their own (the guest mode on the terminal has no movement list at all), so there's no need to mask anything
- A user had a problem with the email field (it just displays "*" and cannot be cleared) - by not masking it anymore, the problem should be gone too