### PR TITLE
Fix flash of unstyled text (FOUT) for material icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="favicons/mstile-144x144.png?v=2">
     <meta name="theme-color" content="#ffffff">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="reset.css"/>
   </head>
   <body>


### PR DESCRIPTION
- Sometimes, the icon text is displayed (usually only for a short time) instead of the actual icon
- This should be fixed by adding the CDN URL to index.html. The static font files are kept in the project as a backup.
- Furthermore, on my iPhone, the "account_box" icon isn't displayed properly (text is displayed instead of the icon). Perhaps, this is fixed too, now.