### PR TITLE
Fix styling of account menu on mobile devices (chrome on iPhone)

### DIFF
--- a/src/components/StartPage/LoginInfo.js
+++ b/src/components/StartPage/LoginInfo.js
@@ -40,6 +40,7 @@ const StyledMenuButton = styled.button`
   font-weight: bold;
   display: block;
   margin: 3px 0;
+  color: black;
 `;
 
 const StyledMenuUsername = styled.div`
@@ -50,6 +51,7 @@ const StyledMenuUsername = styled.div`
   border-bottom: 1px solid #ddd;
   color: #666;
   display: none;
+  text-decoration: none;
 
   @media (max-width: 500px) {
     display: block;


### PR DESCRIPTION
- The "Abmelden" link was displayed with a blue color
- The username email in the menu was displayed with underline even though it's not a link