### PR TITLE
Introduce firebase URL config property for code and cloud functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ firebase functions:config:set rtdb.instance={RTDB NAME}
 
 (e.g. `firebase functions:config:set rtdb.instance=lszt-test`)
 
+
+If the database is not in the default location and the database URL is not `{instance}.firebaseio.com`, you also have
+to set the database URL additionally:
+
+```
+firebase functions:config:set rtdb.url={RTDB URL}
+```
+
+(e.g. `firebase functions:config:set rtdb.url=https://lszt-test-eu.europe-west1.firebasedatabase.app`)
+
 ##### Deploy app
 
 Before executing this command, make sure the correct project was built using the Node version

--- a/functions/index.js
+++ b/functions/index.js
@@ -3,10 +3,13 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 
-const dbInstance = functions.config().rtdb.instance;
+const config = functions.config()
+
+const dbUrl = config.rtdb.url
+const dbInstance = config.rtdb.instance;
 
 admin.initializeApp({
-  databaseURL: `https://${dbInstance}.firebaseio.com`
+  databaseURL: dbUrl || `https://${dbInstance}.firebaseio.com`
 });
 
 const { scheduledAerodromesUpdate } = require('./updateAerodromes');

--- a/src/util/firebase.js
+++ b/src/util/firebase.js
@@ -9,7 +9,7 @@ function initialize() {
 
   const config = {
     apiKey: __FIREBASE_API_KEY__,
-    databaseURL: `https://${__FIREBASE_DATABASE_NAME__ || __FIREBASE_PROJECT_ID__}.firebaseio.com`
+    databaseURL: __FIREBASE_DATABASE_URL__ || `https://${__FIREBASE_DATABASE_NAME__ || __FIREBASE_PROJECT_ID__}.firebaseio.com`
   };
 
   Firebase.initializeApp(config);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,7 @@ const globals = {
   __THEME__: JSON.stringify(projectConf.theme),
   __FIREBASE_PROJECT_ID__: JSON.stringify(env.firebaseProjectId),
   __FIREBASE_DATABASE_NAME__: JSON.stringify(env.firebaseDatabaseName),
+  __FIREBASE_DATABASE_URL__: JSON.stringify(env.firebaseDatabaseUrl),
   __FIREBASE_API_KEY__: JSON.stringify(env.firebaseApiKey),
   __DISABLE_IP_AUTHENTICATION__: env.disableIpAuthentication === true,
   __FLIGHTNET_COMPANY__: JSON.stringify(projectConf.flightnetCompany),


### PR DESCRIPTION
- New conf property `environments.[test|production].firebaseDatabaseUrl`
- New function config property `rtdb.url`
- Needed for realtime databases of different regions where the domain is not 'firebaseio.com'
- Existing properties `environments.[test|production].firebaseDatabaseName` and `rtdb.instance` (cloud functions) are still needed too