### PR TITLE
Use payment method auth conditions `kiosk`/`notKiosk` for LSZE

### DIFF
--- a/projects/lsze.json
+++ b/projects/lsze.json
@@ -52,7 +52,17 @@
   },
   "theme": "lsze",
   "title": "Flightbox - Flugplatz Bad Ragaz",
-  "paymentMethods": ["checkout", "invoice"],
+  "paymentMethods": [
+    {
+      "name": "checkout",
+      "authCondition": "notKiosk"
+    },
+    {
+      "name": "card_external",
+      "authCondition": "kiosk"
+    },
+    "invoice"
+  ],
   "homebasePayment": true,
   "loginForm": "email",
   "enabledFlightTypes": [


### PR DESCRIPTION
- `card_external` should be available at the kiosk only
- `checkout` should be available if not kiosk