### PR TITLE
Update payment status on arrival via RTDB trigger instead of from client

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -24,6 +24,7 @@ const webhook = require('./webhook');
 const setAssociatedMovementsCronJob = require('./associatedMovements/setAssociatedMovementsCronJob');
 const associatedMovementsTriggers = require('./associatedMovements/setAssociatedMovementsTriggers');
 const invoiceRecipientsTrigger = require('./invoiceRecipients/invoiceRecipientsTrigger');
+const updateArrivalPaymentStatus = require('./updateArrivalPaymentStatus');
 
 exports.auth = auth;
 exports.generateSignInLink = generateSignInLink;
@@ -46,3 +47,5 @@ exports.enrichDepartureOnCreate = enrichMovements.enrichDepartureOnCreate;
 exports.enrichDepartureOnUpdate = enrichMovements.enrichDepartureOnUpdate;
 exports.enrichArrivalOnCreate = enrichMovements.enrichArrivalOnCreate;
 exports.enrichArrivalOnUpdate = enrichMovements.enrichArrivalOnUpdate;
+
+exports.updateArrivalPaymentStatusOnCardPaymentUpdate = updateArrivalPaymentStatus.updateArrivalPaymentStatusOnCardPaymentUpdate;

--- a/functions/updateArrivalPaymentStatus.js
+++ b/functions/updateArrivalPaymentStatus.js
@@ -1,0 +1,64 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+const instance = functions.config().rtdb.instance;
+
+const handleUpdate = async (change) => {
+  if (!change.before.exists() || !change.after.exists()) {
+    return null;
+  }
+
+  const cardPaymentKey = change.after.ref.key;
+  const beforeValue = change.before.val();
+  const afterValue = change.after.val();
+
+  const wasSetToSuccess = beforeValue.status !== afterValue.status && afterValue.status === 'success';
+
+  if (!wasSetToSuccess) {
+    return
+  }
+
+  if (!afterValue.arrivalReference) {
+    functions.logger.info(
+      `Unable to set arrival payment status for card-payment ${cardPaymentKey}, because arrivalReference is missing`
+    );
+  }
+
+  try {
+    const arrivalSnapshot = await admin.database()
+      .ref('arrivals')
+      .child(afterValue.arrivalReference)
+      .once('value');
+
+    const arrivalValues = arrivalSnapshot.val()
+
+    if (arrivalValues.paymentMethod && arrivalValues.paymentMethod.status === 'pending') {
+      functions.logger.info(
+        `Setting payment status of arrival ${afterValue.arrivalReference} to completed (card payment ${cardPaymentKey})`
+      );
+
+      await admin.database()
+        .ref('arrivals')
+        .child(afterValue.arrivalReference)
+        .update({
+          paymentMethod: {
+            ...arrivalValues.paymentMethod,
+            status: 'completed'
+          }
+        });
+    }
+  } catch (error) {
+    functions.logger.error(
+      `Failed to update payment status of arrival ${afterValue.arrivalReference}`,
+      error
+    );
+    throw error;
+  }
+};
+
+exports.updateArrivalPaymentStatusOnCardPaymentUpdate = functions
+  .region('europe-west1')
+  .database
+  .instance(instance)
+  .ref('/card-payments/{paymentId}')
+  .onWrite(handleUpdate);

--- a/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.js
+++ b/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.js
@@ -64,10 +64,6 @@ class PaymentMethod extends Component {
     if (successParam === 'true') {
       this.props.setMethod('checkout')
       this.props.setStep(Step.COMPLETED)
-      this.props.saveMovementPaymentMethod('arrival', this.props.itemKey, {
-        method: 'checkout',
-        status: 'completed'
-      })
       return
     }
 


### PR DESCRIPTION
- There is a new webhook which sets the status for online checkouts in the `card-payments` document
- When the status there is set to `success`, we update the status in the arrival, which should be more reliable than the current solution