### PR TITLE
Fix navigating with arrow down in options list in Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -230,11 +230,6 @@ class Dropdown extends Component {
       return;
     }
 
-    if (e.which === KEY_CODE_ARROW_DOWN) {
-      this.input.focus();
-      return;
-    }
-
     if (e.which !== KEY_CODE_ARROW_DOWN && e.which !== KEY_CODE_ARROW_UP) {
       return;
     }


### PR DESCRIPTION
- Arrow down input was ignored and it wasn't possible to navigate down in the options list (only going up was possible)
- Was broken since commit ba28857e (march 2025) where we changed that the options shouldn't be visible as soon as the dropdown field was receiving focus, but only after the user started typing