### PR TITLE
Remove now unnecessary fixed dependency version for `cheerio`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "babel-jest": "^27.5.1",
         "babel-loader": "^9.2.1",
         "binary-search": "^1.3.6",
-        "cheerio": "1.0.0-rc.3",
         "css-loader": "^7.1.2",
         "csv-parse": "^2.5.0",
         "csv-stringify": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "babel-jest": "^27.5.1",
     "babel-loader": "^9.2.1",
     "binary-search": "^1.3.6",
-    "cheerio": "1.0.0-rc.3",
     "css-loader": "^7.1.2",
     "csv-parse": "^2.5.0",
     "csv-stringify": "^3.1.1",


### PR DESCRIPTION
- We need to add this fixed version when we upgraded to Node 16 here: 98ebfb3c54d5cf7372fb7bf50c648bacace2efa1
- Now we're on Node 20 and this is not necessary anymore