### PR TITLE
Remove `whatwg-fetch` polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,8 +67,7 @@
         "webpack": "^5.104.1",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2",
-        "webpack-stream": "^7.0.0",
-        "whatwg-fetch": "^2.0.4"
+        "webpack-stream": "^7.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
     "webpack": "^5.104.1",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.2",
-    "webpack-stream": "^7.0.0",
-    "whatwg-fetch": "^2.0.4"
+    "webpack-stream": "^7.0.0"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,6 @@ module.exports = {
   mode: process.env.ENV === 'production' ? 'production' : 'development',
   entry: [
     '@babel/polyfill',
-    'whatwg-fetch',
     path.resolve(__dirname, './src/app.js'),
     path.resolve(__dirname, './theme/' + projectConf.theme)
   ],


### PR DESCRIPTION
Native `fetch` support is effectively universal as of today and shouldn't be needed anymore.