### PR TITLE
Fix landing fees for heavy aircraft (> 3000 kg) for LSZE

### DIFF
--- a/src/util/landingFeeStrategies/lsze.js
+++ b/src/util/landingFeeStrategies/lsze.js
@@ -18,7 +18,16 @@ const getLandingFee = (mtow, flightType, aircraftOrigin, aircraftCategory) => {
 const getGoAroundFee = (mtow, flightType, aircraftOrigin, aircraftCategory) =>
   undefined
 
+const getMtowFeeHeavy = mtow => {
+  const tons = Math.ceil(mtow / 1000)
+  return tons * 20
+}
+
 const getFee = (mtow, flightType, aircraftOrigin, aircraftCategory) => {
+  if (mtow > 3000) {
+    return getMtowFeeHeavy(mtow)
+  }
+
   const isHeli = isHelicopter(aircraftCategory)
 
   if (isHeli) {

--- a/src/util/landingFeeStrategies/lsze.spec.js
+++ b/src/util/landingFeeStrategies/lsze.spec.js
@@ -17,8 +17,20 @@ describe('util', () => {
           [2001, 'Hubschrauber', 55.5],
           [3000, 'Flugzeug', 37],
           [3000, 'Hubschrauber', 55.5],
-          [3001, 'Flugzeug', 37],
-          [3001, 'Hubschrauber', 55.5],
+
+          // > 3000 kg: CHF 20 per ton (incl. VAT)
+          [3001, 'Flugzeug', 74.01],
+          [3001, 'Hubschrauber', 74.01],
+          [4000, 'Flugzeug', 74.01],
+          [4000, 'Hubschrauber', 74.01],
+
+          [4001, 'Flugzeug', 92.51],
+          [4001, 'Hubschrauber', 92.51],
+          [5000, 'Flugzeug', 92.51],
+          [5000, 'Hubschrauber', 92.51],
+
+          [50000, 'Flugzeug', 925.07],
+          [50000, 'Hubschrauber', 925.07],
         ])(
           'getLandingFee(%i, %s, %i)',
           (mtow, aircraftCategory, expected) => {

--- a/src/util/landingFeeStrategies/lsze_data.json
+++ b/src/util/landingFeeStrategies/lsze_data.json
@@ -3,12 +3,12 @@
     "plane": [
       { "max_weight": 1000, "fee": 20 },
       { "max_weight": 2000, "fee": 30 },
-      { "max_weight": 50000, "fee": 40 }
+      { "max_weight": 3000, "fee": 40 }
     ],
     "helicopter": [
       { "max_weight": 1000, "fee": 20 },
       { "max_weight": 2000, "fee": 30 },
-      { "max_weight": 50000, "fee": 60 }
+      { "max_weight": 3000, "fee": 60 }
     ]
   }
 }


### PR DESCRIPTION
Same rules for planes and helicopters > 3000 kg (CHF 20 per ton incl. VAT; started tons rounded up)

See http://lsze.ch/fuer_piloten/taxen/index.html.