### PR TITLE
Add `type="button"` to clear buttons of components

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import ModalDialog from '../ModalDialog';
 import MaterialIcon from '../MaterialIcon';
 import MomentLocaleUtils from 'react-day-picker/moment';
@@ -53,7 +53,7 @@ class DatePicker extends Component {
         <Value onClick={this.showPicker} data-cy={this.props.dataCy}>
           {this.state.value ? this.renderValue() : '\u00a0'}
           {this.props.clearable === true && this.state.value
-            ? <ClearButton onClick={this.handleClear}>
+            ? <ClearButton onClick={this.handleClear} type="button">
                 <MaterialIcon icon="clear"/>
             </ClearButton>
             : null}

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -75,7 +75,7 @@ class Dropdown extends Component {
           data-cy={this.props.dataCy}
         />
         {this.props.clearable && !this.props.readOnly && this.state.value && (
-          <ClearButton onClick={this.handleClear}>
+          <ClearButton onClick={this.handleClear} type="button">
             <MaterialIcon icon="clear"/>
           </ClearButton>
         )}

--- a/src/components/MovementFilter/MovementFilter.js
+++ b/src/components/MovementFilter/MovementFilter.js
@@ -136,7 +136,7 @@ const MovementFilter = ({filter, expanded, setMovementsFilter, setExpanded}) => 
         flat
       />
       {(expanded || dateFilterSet) && (
-        <ClearButton onClick={handleClear(setMovementsFilter)}>
+        <ClearButton onClick={handleClear(setMovementsFilter)} type="button">
           <MaterialIcon icon="clear"/>
         </ClearButton>
       )}


### PR DESCRIPTION
Without this, the default type of the buttons is `submit` which can cause weird behaviors if enter is hit somewhere in the form (in this case the browser looks for the first submit button in the form and if it was a clear button, the field was being cleared - which of course didn't make sense)