### PR TITLE
Remove redux-form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
         "react-redux": "^7.2.9",
         "react-router-dom": "^4.2.2",
         "redux": "^4.2.1",
-        "redux-form": "^8.3.10",
         "redux-saga": "^1.4.2",
         "scroll-into-view": "^1.16.2",
         "start-server-and-test": "^2.1.3",
@@ -8128,12 +8127,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -10217,15 +10210,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -10701,12 +10685,6 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -14384,41 +14362,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
-      }
-    },
-    "node_modules/redux-form": {
-      "version": "8.3.10",
-      "resolved": "https://registry.npmjs.org/redux-form/-/redux-form-8.3.10.tgz",
-      "integrity": "sha512-Eeog8dJYUxCSZI/oBoy7VkprvMjj1lpUnHa3LwjVNZvYDNeiRZMoZoaAT+6nlK2YQ4aiBopKUMiLe4ihUOHCGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2",
-        "es6-error": "^4.1.1",
-        "hoist-non-react-statics": "^3.3.2",
-        "invariant": "^2.2.4",
-        "is-promise": "^2.1.0",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.4.2"
-      },
-      "engines": {
-        "node": ">=8.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/redux-form"
-      },
-      "peerDependencies": {
-        "immutable": "^3.8.2 || ^4.0.0",
-        "react": "^16.4.2 || ^17.0.0 || ^18.0.0",
-        "react-redux": "^6.0.1 || ^7.0.0 || ^8.0.0",
-        "redux": "^3.7.2 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "immutable": {
-          "optional": true
-        }
       }
     },
     "node_modules/redux-saga": {
@@ -23424,12 +23367,6 @@
         "hasown": "^2.0.2"
       }
     },
-    "es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
-    },
     "escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -24930,14 +24867,6 @@
       "integrity": "sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ==",
       "dev": true
     },
-    "immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -25245,12 +25174,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
-    },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "dev": true
     },
     "is-regex": {
@@ -27918,22 +27841,6 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2"
-      }
-    },
-    "redux-form": {
-      "version": "8.3.10",
-      "resolved": "https://registry.npmjs.org/redux-form/-/redux-form-8.3.10.tgz",
-      "integrity": "sha512-Eeog8dJYUxCSZI/oBoy7VkprvMjj1lpUnHa3LwjVNZvYDNeiRZMoZoaAT+6nlK2YQ4aiBopKUMiLe4ihUOHCGg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "es6-error": "^4.1.1",
-        "hoist-non-react-statics": "^3.3.2",
-        "invariant": "^2.2.4",
-        "is-promise": "^2.1.0",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.4.2"
       }
     },
     "redux-saga": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "react-redux": "^7.2.9",
     "react-router-dom": "^4.2.2",
     "redux": "^4.2.1",
-    "redux-form": "^8.3.10",
     "redux-saga": "^1.4.2",
     "scroll-into-view": "^1.16.2",
     "start-server-and-test": "^2.1.3",

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,7 +1,6 @@
 import {combineReducers} from 'redux';
 import {map} from 'ramda';
 import {all, fork} from 'redux-saga/effects';
-import {reducer as formReducer} from 'redux-form';
 
 import aerodromes, {sagas as aerodromesSagas} from './aerodromes';
 import aircrafts, {sagas as aircraftsSagas} from './aircrafts';
@@ -17,10 +16,9 @@ import ui, {sagas as uiSagas} from './ui';
 import users, {sagas as usersSagas} from './users';
 import profile, {sagas as profileSagas} from './profile';
 
-const createRootReducer = (history) => combineReducers({
+const createRootReducer = () => combineReducers({
   aerodromes,
   aircrafts,
-  form: formReducer,
   auth,
   customs,
   imports,


### PR DESCRIPTION
All forms have been migrated to `react-final-form` and the unmaintained `redux-form` dependency is not needed anymore.