### PR TITLE
Refactor `AerodromeDropdownContainer` to modern way of implementing it

### DIFF
--- a/src/containers/AerodromeDropdownContainer.js
+++ b/src/containers/AerodromeDropdownContainer.js
@@ -1,55 +1,37 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { loadAerodromes } from '../modules/aerodromes';
+import React, {useEffect} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import {loadAerodromes} from '../modules/aerodromes';
 import AerodromeDropdown from '../components/AerodromeDropdown';
 
-class AerodromeDropdownContainer extends Component {
+const AerodromeDropdownContainer = ({ value, onChange, onFocus, onBlur, readOnly, dataCy }) => {
+  const dispatch = useDispatch();
+  const aerodromes = useSelector((state) => state.aerodromes);
 
-  componentWillMount() {
-    this.props.loadAerodromes();
-  }
+  useEffect(() => {
+    dispatch(loadAerodromes());
+  }, [dispatch]);
 
-  render() {
-    return (
-      <AerodromeDropdown
-        aerodromes={this.props.aerodromes}
-        value={this.props.value}
-        onChange={this.props.onChange}
-        onFocus={this.props.onFocus}
-        onBlur={this.props.onBlur}
-        readOnly={this.props.readOnly}
-        dataCy={this.props.dataCy}
-      />
-    );
-  }
-}
+  return (
+    <AerodromeDropdown
+      aerodromes={aerodromes}
+      value={value}
+      onChange={onChange}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      readOnly={readOnly}
+      dataCy={dataCy}
+    />
+  );
+};
 
 AerodromeDropdownContainer.propTypes = {
-  loadAerodromes: PropTypes.func.isRequired,
-  aerodromes: PropTypes.object.isRequired,
   value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func.isRequired,
   onBlur: PropTypes.func.isRequired,
   readOnly: PropTypes.bool,
-  dataCy: PropTypes.string
+  dataCy: PropTypes.string,
 };
 
-const mapStateToProps = (state, ownProps) => {
-  return {
-    aerodromes: state.aerodromes,
-    value: ownProps.value,
-  };
-};
-
-const mapDispatchToProps = (dispatch, ownProps) => {
-  return {
-    loadAerodromes: () => dispatch(loadAerodromes()),
-    onChange: ownProps.onChange,
-    onFocus: ownProps.onFocus,
-    onBlur: ownProps.onBlur,
-  };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(AerodromeDropdownContainer);
+export default AerodromeDropdownContainer;


### PR DESCRIPTION
- Functional component with destructured props instead of a class
- useSelector replaces mapStateToProps — reads directly from the Redux store
- useDispatch replaces mapDispatchToProps — you no longer need connect() at all
- useEffect with [] replaces componentWillMount — runs once after first render. (componentWillMount actually ran before render, but for data fetching the difference is negligible and useEffect is the correct modern pattern)
- PropTypes for injected Redux props are removed since they're no longer passed from a parent — only the truly external props remain