### PR TITLE
fix: skip enrichment update if movement no longer exists

### DIFF
--- a/functions/enrichMovements.js
+++ b/functions/enrichMovements.js
@@ -41,10 +41,15 @@ async function enrichMovementWithAerodromeMetadata(movement, movementType, movem
 
     if (hasChanges) {
       const movementPath = movementType === 'departure' ? 'departures' : 'arrivals';
-      await admin.database()
-        .ref(movementPath)
-        .child(movementKey)
-        .update(enrichedData);
+      const movementRef = admin.database().ref(movementPath).child(movementKey);
+      const currentSnapshot = await movementRef.once('value');
+      if (!currentSnapshot.exists()) {
+        functions.logger.info(
+          `${movementType} ${movementKey} no longer exists, skipping enrichment`
+        );
+        return;
+      }
+      await movementRef.update(enrichedData);
 
       functions.logger.info(
         `Enriched ${movementType} ${movementKey} with aerodrome metadata for ${icaoCode}: ${enrichedData.locationName}, ${enrichedData.country}`

--- a/functions/enrichMovements.spec.js
+++ b/functions/enrichMovements.spec.js
@@ -79,9 +79,10 @@ describe('functions/enrichMovements', () => {
             }))
           };
         }
-        // For updating the movement path (departures/arrivals)
+        // For the movement existence check and update (departures/arrivals)
         return {
           child: jest.fn(() => ({
+            once: jest.fn().mockResolvedValue({ exists: () => true }),
             update: mockUpdate.mockResolvedValue()
           }))
         };
@@ -123,7 +124,10 @@ describe('functions/enrichMovements', () => {
           return { child: childMock };
         }
         return {
-          child: jest.fn(() => ({ update: mockUpdate.mockResolvedValue() }))
+          child: jest.fn(() => ({
+            once: jest.fn().mockResolvedValue({ exists: () => true }),
+            update: mockUpdate.mockResolvedValue()
+          }))
         };
       });
 
@@ -265,7 +269,10 @@ describe('functions/enrichMovements', () => {
       };
 
       const updateMock = jest.fn().mockResolvedValue();
-      const childForMovement = jest.fn(() => ({ update: updateMock }));
+      const childForMovement = jest.fn(() => ({
+        once: jest.fn().mockResolvedValue({ exists: () => true }),
+        update: updateMock
+      }));
 
       mockRef.mockImplementation(path => {
         if (path === 'aerodromes') {
@@ -338,7 +345,10 @@ describe('functions/enrichMovements', () => {
           };
         }
         return {
-          child: jest.fn(() => ({ update: mockUpdate.mockResolvedValue() }))
+          child: jest.fn(() => ({
+            once: jest.fn().mockResolvedValue({ exists: () => true }),
+            update: mockUpdate.mockResolvedValue()
+          }))
         };
       });
 
@@ -365,7 +375,10 @@ describe('functions/enrichMovements', () => {
           };
         }
         return {
-          child: jest.fn(() => ({ update: mockUpdate.mockResolvedValue() }))
+          child: jest.fn(() => ({
+            once: jest.fn().mockResolvedValue({ exists: () => true }),
+            update: mockUpdate.mockResolvedValue()
+          }))
         };
       });
 


### PR DESCRIPTION
After a movement is deleted, a pending enrichDepartureOnCreate or enrichArrivalOnCreate Cloud Function invocation could still run and call update() on the now-deleted node, silently re-creating it as a sparse Firebase record. Check that the movement still exists before writing enriched aerodrome metadata.