### PR TITLE
fix: migrate InvoicesReport and arrivalPayment to Firebase modular SDK

### DIFF
--- a/src/modules/ui/arrivalPayment/sagas.js
+++ b/src/modules/ui/arrivalPayment/sagas.js
@@ -1,4 +1,5 @@
 import {all, call, fork, put, select, takeEvery} from 'redux-saga/effects'
+import {onValue} from 'firebase/database'
 import * as actions from './actions';
 import * as remote from './remote'
 import createChannel, {monitor} from '../../../util/createChannel'
@@ -54,26 +55,26 @@ export function* createCardPayment(channel, action) {
 }
 
 export function* monitorPaymentStatus(paymentRef, channel) {
-  paymentRef.on('value', snapshot => {
+  const unsubscribe = onValue(paymentRef, snapshot => {
     const val = snapshot.val()
     const data = val.data
     const status = val.status
 
     if (data) {
-      paymentRef.off('value')
+      unsubscribe()
       window.location.href = data
     } else if (status === 'success') {
       channel.put(actions.setStep(Step.COMPLETED))
-      paymentRef.off('value')
+      unsubscribe()
     } else if (status === 'failure') {
       channel.put(actions.setMethod(null))
       channel.put(actions.cardPaymentFailure())
       channel.put(actions.setStep(Step.OPTIONS))
-      paymentRef.off('value')
+      unsubscribe()
     } else if (status === 'cancelled') {
       channel.put(actions.setMethod(null))
       channel.put(actions.setStep(Step.OPTIONS))
-      paymentRef.off('value')
+      unsubscribe()
     }
   })
 }

--- a/src/modules/ui/arrivalPayment/sagas.spec.js
+++ b/src/modules/ui/arrivalPayment/sagas.spec.js
@@ -7,6 +7,15 @@ import {Step} from './reducer';
 jest.mock('./remote');
 jest.mock('../../../util/createChannel');
 
+let capturedOnValueCallback;
+const mockUnsubscribe = jest.fn();
+jest.mock('firebase/database', () => ({
+  onValue: jest.fn((ref, callback) => {
+    capturedOnValueCallback = callback;
+    return mockUnsubscribe;
+  }),
+}));
+
 describe('modules', () => {
   describe('ui', () => {
     describe('arrivalPayment', () => {
@@ -115,29 +124,31 @@ describe('modules', () => {
           let channel;
 
           beforeEach(() => {
-            paymentRef = {on: jest.fn(), off: jest.fn()};
+            paymentRef = {};
             channel = {put: jest.fn()};
+            capturedOnValueCallback = undefined;
+            mockUnsubscribe.mockClear();
           });
 
           it('should register firebase listener and complete', () => {
+            const {onValue} = require('firebase/database');
             const generator = sagas.monitorPaymentStatus(paymentRef, channel);
             expect(generator.next().done).toEqual(true);
-            expect(paymentRef.on).toHaveBeenCalledWith('value', expect.any(Function));
+            expect(onValue).toHaveBeenCalledWith(paymentRef, expect.any(Function));
           });
 
           it('should redirect when data is present', () => {
             const generator = sagas.monitorPaymentStatus(paymentRef, channel);
             generator.next();
 
-            const callback = paymentRef.on.mock.calls[0][1];
             const redirectUrl = 'https://payment.example.com/redirect';
             const snapshot = {val: () => ({data: redirectUrl, status: 'pending'})};
 
             // jsdom 26 defines window.location as non-configurable, so we can't
             // replace it. Verify the redirect branch via its side effects instead.
-            callback(snapshot);
+            capturedOnValueCallback(snapshot);
 
-            expect(paymentRef.off).toHaveBeenCalledWith('value');
+            expect(mockUnsubscribe).toHaveBeenCalled();
             expect(channel.put).not.toHaveBeenCalled();
           });
 
@@ -145,41 +156,38 @@ describe('modules', () => {
             const generator = sagas.monitorPaymentStatus(paymentRef, channel);
             generator.next();
 
-            const callback = paymentRef.on.mock.calls[0][1];
             const snapshot = {val: () => ({data: null, status: 'success'})};
-            callback(snapshot);
+            capturedOnValueCallback(snapshot);
 
             expect(channel.put).toHaveBeenCalledWith(actions.setStep(Step.COMPLETED));
-            expect(paymentRef.off).toHaveBeenCalledWith('value');
+            expect(mockUnsubscribe).toHaveBeenCalled();
           });
 
           it('should put failure actions on failure status', () => {
             const generator = sagas.monitorPaymentStatus(paymentRef, channel);
             generator.next();
 
-            const callback = paymentRef.on.mock.calls[0][1];
             const snapshot = {val: () => ({data: null, status: 'failure'})};
-            callback(snapshot);
+            capturedOnValueCallback(snapshot);
 
             expect(channel.put).toHaveBeenCalledTimes(3);
             expect(channel.put).toHaveBeenNthCalledWith(1, actions.setMethod(null));
             expect(channel.put).toHaveBeenNthCalledWith(2, actions.cardPaymentFailure());
             expect(channel.put).toHaveBeenNthCalledWith(3, actions.setStep(Step.OPTIONS));
-            expect(paymentRef.off).toHaveBeenCalledWith('value');
+            expect(mockUnsubscribe).toHaveBeenCalled();
           });
 
           it('should put cancelled actions on cancelled status', () => {
             const generator = sagas.monitorPaymentStatus(paymentRef, channel);
             generator.next();
 
-            const callback = paymentRef.on.mock.calls[0][1];
             const snapshot = {val: () => ({data: null, status: 'cancelled'})};
-            callback(snapshot);
+            capturedOnValueCallback(snapshot);
 
             expect(channel.put).toHaveBeenCalledTimes(2);
             expect(channel.put).toHaveBeenNthCalledWith(1, actions.setMethod(null));
             expect(channel.put).toHaveBeenNthCalledWith(2, actions.setStep(Step.OPTIONS));
-            expect(paymentRef.off).toHaveBeenCalledWith('value');
+            expect(mockUnsubscribe).toHaveBeenCalled();
           });
         });
 

--- a/src/util/InvoicesReport.js
+++ b/src/util/InvoicesReport.js
@@ -1,4 +1,5 @@
 import firebase, {getIdToken} from './firebase.js';
+import {get, query, orderByChild, startAt, endAt} from 'firebase/database';
 import {firebaseToLocal} from './movements.js';
 import dates from '../util/dates';
 import {getLabel as getFlightTypeLabel} from '../util/flightTypes';
@@ -42,14 +43,12 @@ class InvoicesReport {
   }
 
   readArrivals() {
-    return new Promise(resolve => {
-      firebase('/arrivals', (error, ref) => {
-        ref.orderByChild('dateTime')
-          .startAt(dates.isoStartOfDay(this.startDate))
-          .endAt(dates.isoEndOfDay(this.endDate))
-          .once('value', resolve, this);
-      });
-    });
+    return get(query(
+      firebase('/arrivals'),
+      orderByChild('dateTime'),
+      startAt(dates.isoStartOfDay(this.startDate)),
+      endAt(dates.isoEndOfDay(this.endDate))
+    ));
   }
 
   async fetchCustomsData(endpoint) {

--- a/src/util/InvoicesReport.spec.js
+++ b/src/util/InvoicesReport.spec.js
@@ -22,6 +22,13 @@ describe('util', () => {
 
       jest.resetModules();
       jest.mock('./firebase');
+      jest.mock('firebase/database', () => ({
+        get: jest.fn(),
+        query: jest.fn(ref => ref),
+        orderByChild: jest.fn(),
+        startAt: jest.fn(),
+        endAt: jest.fn(),
+      }));
       jest.mock('pdfmake/build/pdfmake', () => ({
         createPdf: jest.fn(() => ({getBase64: jest.fn()})),
       }));
@@ -693,20 +700,14 @@ describe('util', () => {
 
     describe('readArrivals', () => {
       it('resolves with a firebase snapshot after querying by dateTime', () => {
-        const mockRef = {
-          orderByChild: jest.fn().mockReturnThis(),
-          startAt: jest.fn().mockReturnThis(),
-          endAt: jest.fn().mockReturnThis(),
-          once: jest.fn((event, callback) => {
-            callback({forEach: () => {}});
-          }),
-        };
-        firebase.mockImplementation((path, callback) => callback(null, mockRef));
+        const arrivalsSnapshot = {forEach: () => {}};
+        const {get} = require('firebase/database');
+        get.mockResolvedValue(arrivalsSnapshot);
 
         const report = makeReport(2023, 6);
         return report.readArrivals().then(snapshot => {
-          expect(mockRef.orderByChild).toHaveBeenCalledWith('dateTime');
-          expect(snapshot).toBeDefined();
+          expect(get).toHaveBeenCalled();
+          expect(snapshot).toBe(arrivalsSnapshot);
         });
       });
     });
@@ -766,13 +767,9 @@ describe('util', () => {
 
     describe('generate', () => {
       it('calls callback with a pdf after fetching all data', () => {
-        const mockRef = {
-          orderByChild: jest.fn().mockReturnThis(),
-          startAt: jest.fn().mockReturnThis(),
-          endAt: jest.fn().mockReturnThis(),
-          once: jest.fn((event, callback) => callback({forEach: () => {}})),
-        };
-        firebase.mockImplementation((path, callback) => callback(null, mockRef));
+        const arrivalsSnapshot = {forEach: () => {}};
+        const {get} = require('firebase/database');
+        get.mockResolvedValue(arrivalsSnapshot);
 
         const fakePdf = {getBase64: jest.fn()};
         pdfMake.createPdf.mockReturnValue(fakePdf);


### PR DESCRIPTION
Replace v8 compat API calls that silently fail with the modular SDK:
- InvoicesReport.readArrivals: replace callback + .orderByChild().once() with get(query(...)) matching LandingsReport pattern
- arrivalPayment/sagas.monitorPaymentStatus: replace .on()/.off() with onValue() returning an unsubscribe function