### PR TITLE
Upgrade major dependencies (low-risk)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "redux": "^5.0.1",
         "redux-saga": "^1.4.2",
         "scroll-into-view": "^1.16.2",
-        "start-server-and-test": "^2.1.5",
+        "start-server-and-test": "^3.0.0",
         "stream-browserify": "^3.0.0",
         "style-loader": "^4.0.0",
         "styled-components": "^6.3.11",
@@ -9069,13 +9069,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/duplexer2": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
@@ -9521,22 +9514,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
       }
     },
     "node_modules/eventemitter2": {
@@ -10283,13 +10260,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "9.1.0",
@@ -14690,12 +14660,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
-      "dev": true
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -15655,19 +15619,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
-      "dev": true,
-      "license": [
-        "MIT",
-        "Apache2"
-      ],
-      "dependencies": {
-        "through": "~2.3"
-      }
-    },
     "node_modules/pdfkit": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz",
@@ -16189,22 +16140,6 @@
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ps-tree": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
-      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-stream": "=3.3.4"
-      },
-      "bin": {
-        "ps-tree": "bin/ps-tree.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -17715,19 +17650,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -17785,9 +17707,9 @@
       }
     },
     "node_modules/start-server-and-test": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.1.5.tgz",
-      "integrity": "sha512-A/SbXpgXE25ScSkpLLqvGvVZT0ykN6+AzS8tVqMBCTxbJy2Nwuen59opT+afalK5aS+AuQmZs0EsLwjnuDN+/g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-3.0.0.tgz",
+      "integrity": "sha512-R//IdnWC+H+raB6zJIqw5QbIsMAjjYFwJC/OIJO6kgZljguYe4n4LlA7vkPTO7zoctFlVPfymsNShjcPOIH8nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17797,7 +17719,7 @@
         "debug": "4.4.3",
         "execa": "5.1.1",
         "lazy-ass": "1.6.0",
-        "ps-tree": "1.2.0",
+        "tree-kill": "1.2.2",
         "wait-on": "9.0.4"
       },
       "bin": {
@@ -17806,7 +17728,7 @@
         "start-test": "src/bin/start.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": "^22 || >=24"
       }
     },
     "node_modules/start-server-and-test/node_modules/execa": {
@@ -17914,16 +17836,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "~0.1.1"
       }
     },
     "node_modules/stream-composer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "final-form": "^5.0.0",
-        "i18next": "^25.8.13",
+        "i18next": "^26.0.3",
         "process": "^0.11.10",
         "react-final-form": "^7.0.0",
         "react-i18next": "^16.5.4"
@@ -11557,9 +11557,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "25.10.10",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
-      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+      "version": "26.0.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.3.tgz",
+      "integrity": "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg==",
       "funding": [
         {
           "type": "individual",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "i18next": "^26.0.3",
         "process": "^0.11.10",
         "react-final-form": "^7.0.0",
-        "react-i18next": "^16.5.4"
+        "react-i18next": "^17.0.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.2.3",
@@ -16324,9 +16324,9 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "16.6.6",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
-      "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.2.tgz",
+      "integrity": "sha512-shBftH2vaTWK2Bsp7FiL+cevx3xFJlvFxmsDFQSrJc+6twHkP0tv/bGa01VVWzpreUVVwU+3Hev5iFqRg65RwA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -16334,7 +16334,7 @@
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
-        "i18next": ">= 25.10.9",
+        "i18next": ">= 26.0.1",
         "react": ">= 16.8.0",
         "typescript": "^5 || ^6"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "typescript": "^5.0.0",
         "util": "^0.12.5",
         "webpack": "^5.105.3",
-        "webpack-cli": "^6.0.1",
+        "webpack-cli": "^7.0.2",
         "webpack-dev-server": "^5.2.2",
         "webpack-stream": "^7.0.0",
         "workbox-webpack-plugin": "^7.3.0"
@@ -2252,9 +2252,9 @@
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
-      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.0.0.tgz",
+      "integrity": "sha512-dDlz3W405VMFO4w5kIP9DOmELBcvFQGmLoKSdIRstBDubKFYwaNHV1NnlzMCQpXQFGWVALmeMORAuiLx18AvZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6418,53 +6418,6 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
-      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
-      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
-      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -19625,19 +19578,15 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
-      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.0.2.tgz",
+      "integrity": "sha512-dB0R4T+C/8YuvM+fabdvil6QE44/ChDXikV5lOOkrUeCkW5hTJv2pGLE3keh+D5hjYw8icBaJkZzpFoaHV4T+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^0.6.1",
-        "@webpack-cli/configtest": "^3.0.1",
-        "@webpack-cli/info": "^3.0.1",
-        "@webpack-cli/serve": "^3.0.1",
-        "colorette": "^2.0.14",
-        "commander": "^12.1.0",
-        "cross-spawn": "^7.0.3",
+        "@discoveryjs/json-ext": "^1.0.0",
+        "commander": "^14.0.3",
+        "cross-spawn": "^7.0.6",
         "envinfo": "^7.14.0",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
@@ -19649,14 +19598,16 @@
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.82.0"
+        "webpack": "^5.101.0",
+        "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
+        "webpack-dev-server": "^5.0.0"
       },
       "peerDependenciesMeta": {
         "webpack-bundle-analyzer": {
@@ -19668,13 +19619,13 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/webpack-dev-middleware": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,6 @@
     "i18next": "^26.0.3",
     "process": "^0.11.10",
     "react-final-form": "^7.0.0",
-    "react-i18next": "^16.5.4"
+    "react-i18next": "^17.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "redux": "^5.0.1",
     "redux-saga": "^1.4.2",
     "scroll-into-view": "^1.16.2",
-    "start-server-and-test": "^2.1.5",
+    "start-server-and-test": "^3.0.0",
     "stream-browserify": "^3.0.0",
     "style-loader": "^4.0.0",
     "styled-components": "^6.3.11",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "dependencies": {
     "final-form": "^5.0.0",
-    "i18next": "^25.8.13",
+    "i18next": "^26.0.3",
     "process": "^0.11.10",
     "react-final-form": "^7.0.0",
     "react-i18next": "^16.5.4"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "typescript": "^5.0.0",
     "util": "^0.12.5",
     "webpack": "^5.105.3",
-    "webpack-cli": "^6.0.1",
+    "webpack-cli": "^7.0.2",
     "webpack-dev-server": "^5.2.2",
     "webpack-stream": "^7.0.0",
     "workbox-webpack-plugin": "^7.3.0"


### PR DESCRIPTION
## Summary
- Upgrade `start-server-and-test` to v3
- Upgrade `webpack-cli` to v7
- Upgrade `i18next` to v26
- Upgrade `react-i18next` to v17

Each upgrade is in a separate commit for `git bisect`.

## Test plan
- [x] `npm test` — 1691 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run build --project=lszt` — build succeeds