### PR TITLE
Add phone number validation and input filtering

### DIFF
--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -1,0 +1,28 @@
+import React, { useCallback } from 'react';
+import Input from '../Input';
+
+const filterPhoneValue = (value: string) =>
+  value.replace(/[^\d\s+\-().\/]/g, '');
+
+interface PhoneInputProps {
+  onChange: (value: string) => void;
+  value?: string;
+  [key: string]: any;
+}
+
+const PhoneInput = ({ onChange, value, ...rest }: PhoneInputProps) => {
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const filtered = filterPhoneValue(e.target.value);
+      onChange(filtered);
+    },
+    [onChange]
+  );
+
+  return (
+    <Input {...rest} type="tel" value={value || ''} onChange={handleChange} />
+  );
+};
+
+export default PhoneInput;

--- a/src/components/PhoneInput/index.tsx
+++ b/src/components/PhoneInput/index.tsx
@@ -1,0 +1,3 @@
+import PhoneInput from './PhoneInput';
+
+export default PhoneInput;

--- a/src/components/wizards/pages/PilotPage.tsx
+++ b/src/components/wizards/pages/PilotPage.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {Field, Form} from 'react-final-form';
 import { useTranslation } from 'react-i18next';
 import validate from '../validate';
-import {renderInputField, renderUserDropdown} from '../renderField';
+import {renderInputField, renderPhoneField, renderUserDropdown} from '../renderField';
 import FieldSet from '../FieldSet';
 import WizardNavigation from '../../WizardNavigation';
 
@@ -71,9 +71,8 @@ const PilotPage = (props) => {
             />
             <Field
               name="phone"
-              type="tel"
               label={t('movement.details.phone')}
-              component={renderInputField}
+              component={renderPhoneField}
               readOnly={props.readOnly}
               masked={__CONF__.maskContactInformation === true && !props.isAdmin}
             />

--- a/src/components/wizards/renderField.spec.tsx
+++ b/src/components/wizards/renderField.spec.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {renderWithTheme, screen} from '../../../test/renderWithTheme';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({t: key => key}),
+  withTranslation: () => Component => {
+    const WrappedComponent = props => <Component {...props} t={key => key}/>;
+    WrappedComponent.displayName = `withTranslation(${Component.displayName || Component.name})`;
+    return WrappedComponent;
+  },
+}));
+
+import {renderPhoneField} from './renderField';
+
+const baseProps = (value: string, masked: boolean) => ({
+  input: {
+    name: 'phone',
+    value,
+    onChange: jest.fn(),
+    onBlur: jest.fn(),
+    onFocus: jest.fn(),
+  },
+  meta: {touched: false, error: null, active: false},
+  name: 'phone',
+  label: 'Phone',
+  masked,
+});
+
+describe('renderPhoneField', () => {
+  it('uses phone masking when masked', () => {
+    const phone = '+41791234567';
+    renderWithTheme(renderPhoneField(baseProps(phone, true)));
+
+    // maskPhone: all but last 2 chars replaced with *
+    const expected = '*'.repeat(phone.length - 2) + '67';
+    expect(screen.getByText(expected)).toBeDefined();
+  });
+
+  it('renders PhoneInput with type tel when not masked', () => {
+    renderWithTheme(renderPhoneField(baseProps('+41791234567', false)));
+
+    const input = screen.getByDisplayValue('+41791234567');
+    expect(input).toHaveAttribute('type', 'tel');
+  });
+});

--- a/src/components/wizards/renderField.tsx
+++ b/src/components/wizards/renderField.tsx
@@ -12,6 +12,7 @@ import AircraftDropdown from '../../containers/AircraftDropdownContainer';
 import AircraftCategoryDropdown from '../../components/AircraftCategoryDropdown';
 import UserDropdown from '../../containers/UserDropdownContainer';
 import MaskedInput from '../MaskedInput'
+import PhoneInput from '../PhoneInput'
 
 const StyledLabeledComponent = styled(LabeledComponent)`
   width: 45%;
@@ -50,6 +51,20 @@ export const renderInputField = (props) => {
       {...props.input}
       name={props.name}
       type={props.type}
+      readOnly={props.readOnly}
+      data-cy={props.input.name}
+    />
+  );
+  return renderLabeledComponent(props, cmp);
+};
+
+export const renderPhoneField = (props) => {
+  const cmp = props.masked ? (
+    <MaskedInput {...props} type="tel"/>
+  ) : (
+    <PhoneInput
+      {...props.input}
+      name={props.name}
       readOnly={props.readOnly}
       data-cy={props.input.name}
     />

--- a/src/components/wizards/validate.spec.ts
+++ b/src/components/wizards/validate.spec.ts
@@ -128,6 +128,28 @@ describe('components', () => {
       });
     });
 
+    describe('phone validation', () => {
+      it('returns no error when phone is empty', () => {
+        const validateFn = validate(null, ['phone'], []);
+        const errors = validateFn({});
+        expect(errors.phone).toBeUndefined();
+      });
+
+      it('returns no error for valid phone number', () => {
+        const validateFn = validate(null, ['phone'], []);
+        expect(validateFn({phone: '+41 79 123 45 67'}).phone).toBeUndefined();
+        expect(validateFn({phone: '079 123 45 67'}).phone).toBeUndefined();
+        expect(validateFn({phone: '+41791234567'}).phone).toBeUndefined();
+        expect(validateFn({phone: '0791234567'}).phone).toBeUndefined();
+      });
+
+      it('returns error for invalid phone number', () => {
+        const validateFn = validate(null, ['phone'], []);
+        expect(validateFn({phone: 'abc'}).phone).toBeDefined();
+        expect(validateFn({phone: '12'}).phone).toBeDefined();
+      });
+    });
+
     describe('getFilteredConfig (via validate)', () => {
       it('only validates requested fields', () => {
         // Only ask for immatriculation, not mtow

--- a/src/components/wizards/validate.tsx
+++ b/src/components/wizards/validate.tsx
@@ -50,6 +50,12 @@ const getConfig = () => ({
     },
     message: i18n.t('validate.email'),
   },
+  phone: {
+    types: {
+      match: /^\+?[\d\s\-().\/]{7,20}$/,
+    },
+    message: i18n.t('validate.phone'),
+  },
   date: {
     types: {
       required: true,

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -446,7 +446,8 @@
     "runwayArrival": "Wählen Sie hier die Pistenrichtung für die Landung aus.",
     "departureRoute": "Wählen Sie hier die Abflugroute aus.",
     "arrivalRoute": "Wählen Sie hier die Ankunftsroute aus.",
-    "landingCount": "Geben Sie hier die Anzahl Landungen ein."
+    "landingCount": "Geben Sie hier die Anzahl Landungen ein.",
+    "phone": "Geben Sie hier eine gültige Telefonnummer ein."
   },
   "help": {
     "q1": "Wann muss ich einen Abflug und wann eine Ankunft erfassen?",

--- a/src/util/validate.spec.ts
+++ b/src/util/validate.spec.ts
@@ -55,6 +55,16 @@ describe('util', () => {
         const errors = validate({email: 'user@example.com'}, config);
         expect(errors).toHaveLength(0);
       });
+
+      it('returns no error when value is empty and field is not required', () => {
+        const errors = validate({}, config);
+        expect(errors).toHaveLength(0);
+      });
+
+      it('returns no error when value is undefined and field is not required', () => {
+        const errors = validate({email: undefined}, config);
+        expect(errors).toHaveLength(0);
+      });
     });
 
     describe('values', () => {

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -51,7 +51,7 @@ function validate(
               }
               break;
             case 'match':
-              if (!validationTypes[typeKey]!.test(dataValue)) {
+              if (dataValue && !validationTypes[typeKey]!.test(dataValue)) {
                 valid = false;
               }
               break;


### PR DESCRIPTION
## Summary
- Add loose format validation for the phone field in the movement wizard (optional, 7–20 chars, digits/spaces/common phone symbols)
- Create reusable `PhoneInput` component that filters non-phone characters during input (letters, special symbols silently stripped)
- Fix `validate.ts` `match` case to skip regex check when value is falsy and field is not required, enabling optional-but-validated fields
- Add `renderPhoneField` to wizard render helpers, passing `type="tel"` to `MaskedInput` so phone masking works correctly

## Test plan
- [x] `npm test` — all tests pass
- [x] `npm run typecheck` — no TypeScript errors
- [x] Unit tests for phone validation (empty allowed, valid formats pass, invalid rejected)
- [x] Unit test for `match` skipping empty non-required fields
- [x] Regression test: `renderPhoneField` uses `maskPhone` (not `maskText`) when masked
- [ ] Manual: enter phone on PilotPage, verify letters are filtered and valid numbers accepted
- [ ] Manual: verify masked phone display still works when `maskContactInformation` is enabled