### PR TITLE
Make phone optional in message form

### DIFF
--- a/firebase-rules-template.json
+++ b/firebase-rules-template.json
@@ -321,7 +321,7 @@
       ],
       "$message_id": {
         ".write": "auth !== null && !data.exists() && newData.exists()",
-        ".validate": "newData.hasChildren(['name', 'email', 'phone', 'message', 'timestamp', 'negativeTimestamp'])",
+        ".validate": "newData.hasChildren(['name', 'email', 'message', 'timestamp', 'negativeTimestamp'])",
         "name": {
           ".validate": "newData.isString() && newData.val().length > 0"
         },
@@ -329,7 +329,7 @@
           ".validate": "newData.isString() && newData.val().matches(/^(([^<>()\\[\\]\\.,;:\\s@\"]+(\\.[^<>()\\[\\]\\.,;:\\s@\"]+)*)|(\".+\"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$/)"
         },
         "phone": {
-          ".validate": "newData.isString() && newData.val().length > 0"
+          ".validate": "newData.isString()"
         },
         "message": {
           ".validate": "newData.isString() && newData.val().length > 0"

--- a/src/components/MessageForm/MessageForm.tsx
+++ b/src/components/MessageForm/MessageForm.tsx
@@ -5,7 +5,7 @@ import {Field, Form} from 'react-final-form'
 import H1 from '../H1';
 import Button from '../Button';
 import validate from './validate';
-import {renderInputField, renderTextArea} from './renderField';
+import {renderInputField, renderPhoneField, renderTextArea} from './renderField';
 import Intro from './Intro';
 import Dialog from './Dialog';
 
@@ -40,8 +40,7 @@ class MessageForm extends React.Component<any, any> {
               />
               <Field
                 name="phone"
-                type="tel"
-                component={renderInputField}
+                component={renderPhoneField}
                 label={t('message.phone')}
               />
               <Field

--- a/src/components/MessageForm/renderField.spec.tsx
+++ b/src/components/MessageForm/renderField.spec.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {renderWithTheme, screen} from '../../../test/renderWithTheme';
+
+import {renderPhoneField} from './renderField';
+
+const baseProps = (value: string) => ({
+  input: {
+    name: 'phone',
+    value,
+    onChange: jest.fn(),
+    onBlur: jest.fn(),
+    onFocus: jest.fn(),
+  },
+  meta: {touched: false, error: null},
+  name: 'phone',
+  label: 'Phone',
+});
+
+describe('MessageForm renderPhoneField', () => {
+  it('renders with type tel', () => {
+    renderWithTheme(renderPhoneField(baseProps('+41791234567')));
+    const input = screen.getByDisplayValue('+41791234567');
+    expect(input).toHaveAttribute('type', 'tel');
+  });
+
+  it('renders empty input when no value', () => {
+    renderWithTheme(renderPhoneField(baseProps('')));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe('');
+    expect(input).toHaveAttribute('type', 'tel');
+  });
+});

--- a/src/components/MessageForm/renderField.tsx
+++ b/src/components/MessageForm/renderField.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import LabeledComponent from '../../components/LabeledComponent';
 import Input from '../../components/Input';
+import PhoneInput from '../PhoneInput';
 import TextArea from '../../components/TextArea';
 
 const StyledLabeledComponent = styled(LabeledComponent)`
@@ -28,6 +29,18 @@ export const renderInputField = (props) => {
       {...props.input}
       name={props.name}
       type={props.type}
+      readOnly={props.readOnly}
+      data-cy={props.input.name}
+    />
+  );
+  return renderLabeledComponent(props, cmp);
+};
+
+export const renderPhoneField = (props) => {
+  const cmp = (
+    <PhoneInput
+      {...props.input}
+      name={props.name}
       readOnly={props.readOnly}
       data-cy={props.input.name}
     />

--- a/src/components/MessageForm/validate.spec.ts
+++ b/src/components/MessageForm/validate.spec.ts
@@ -3,12 +3,12 @@ import validate from './validate';
 describe('components', () => {
   describe('MessageForm', () => {
     describe('validate', () => {
-      it('returns errors for all missing fields', () => {
+      it('returns errors for all missing required fields', () => {
         const errors = validate({});
         expect(Object.keys(errors)).toContain('name');
-        expect(Object.keys(errors)).toContain('phone');
         expect(Object.keys(errors)).toContain('email');
         expect(Object.keys(errors)).toContain('message');
+        expect(Object.keys(errors)).not.toContain('phone');
       });
 
       it('returns no errors when all fields are valid', () => {
@@ -21,10 +21,45 @@ describe('components', () => {
         expect(Object.keys(errors)).toHaveLength(0);
       });
 
+      it('returns no errors when phone is omitted', () => {
+        const errors = validate({
+          name: 'Hans Muster',
+          email: 'hans@example.com',
+          message: 'Hello'
+        });
+        expect(Object.keys(errors)).toHaveLength(0);
+      });
+
+      it('returns no error for valid phone numbers', () => {
+        const valid = ['+41 79 123 45 67', '079 123 45 67', '+41791234567', '0791234567'];
+        valid.forEach(phone => {
+          const errors = validate({
+            name: 'Hans',
+            phone,
+            email: 'hans@example.com',
+            message: 'Hi'
+          });
+          expect(errors['phone']).toBeUndefined();
+        });
+      });
+
+      it('returns error for invalid phone number', () => {
+        const invalid = ['abc', '12'];
+        invalid.forEach(phone => {
+          const errors = validate({
+            name: 'Hans',
+            phone,
+            email: 'hans@example.com',
+            message: 'Hi'
+          });
+          expect(errors['phone']).toBeDefined();
+        });
+      });
+
       it('returns email error for invalid email format', () => {
         const errors = validate({
           name: 'Hans',
-          phone: '079',
+          phone: '0791234567',
           email: 'not-an-email',
           message: 'Hi'
         });
@@ -37,7 +72,6 @@ describe('components', () => {
       it('returns email error when email is missing', () => {
         const errors = validate({
           name: 'Hans',
-          phone: '079',
           email: '',
           message: 'Hi'
         });

--- a/src/components/MessageForm/validate.tsx
+++ b/src/components/MessageForm/validate.tsx
@@ -10,7 +10,7 @@ const getConfig = () => ({
   },
   phone: {
     types: {
-      required: true,
+      match: /^\+?[\d\s\-().\/]{7,20}$/,
     },
     message: i18n.t('message.validate.phone'),
   },

--- a/src/components/MessageList/MessageContent.spec.tsx
+++ b/src/components/MessageList/MessageContent.spec.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {renderWithTheme, screen} from '../../../test/renderWithTheme';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({t: key => key}),
+}));
+
+import MessageContent from './MessageContent';
+
+const baseItem = {
+  key: '-abc123',
+  name: 'Hans Muster',
+  timestamp: 1700000000000,
+  email: 'hans@example.com',
+  message: 'Hello there',
+};
+
+describe('MessageContent', () => {
+  it('renders phone row when phone is present', () => {
+    renderWithTheme(<MessageContent item={{...baseItem, phone: '0791234567'}} />);
+    expect(screen.getByText('0791234567')).toBeDefined();
+    expect(screen.getByText('message.phoneLabel')).toBeDefined();
+  });
+
+  it('does not render phone row when phone is missing', () => {
+    renderWithTheme(<MessageContent item={baseItem} />);
+    expect(screen.queryByText('message.phoneLabel')).toBeNull();
+  });
+
+  it('does not render phone row when phone is empty string', () => {
+    renderWithTheme(<MessageContent item={{...baseItem, phone: ''}} />);
+    expect(screen.queryByText('message.phoneLabel')).toBeNull();
+  });
+
+  it('renders email and message', () => {
+    renderWithTheme(<MessageContent item={baseItem} />);
+    expect(screen.getByText('hans@example.com')).toBeDefined();
+    expect(screen.getByText('Hello there')).toBeDefined();
+  });
+});

--- a/src/components/MessageList/MessageContent.tsx
+++ b/src/components/MessageList/MessageContent.tsx
@@ -25,9 +25,11 @@ const MessageContent = props => {
         <div>
           <label>{t('message.emailLabel')} <a href={'mailto:' + props.item.email} target="_blank">{props.item.email}</a></label>
         </div>
-        <div>
-          <label>{t('message.phoneLabel')} <a href={'tel:' + props.item.phone} target="_blank">{props.item.phone}</a></label>
-        </div>
+        {props.item.phone && (
+          <div>
+            <label>{t('message.phoneLabel')} <a href={'tel:' + props.item.phone} target="_blank">{props.item.phone}</a></label>
+          </div>
+        )}
       </Contact>
       <Message>{newLineToBr(props.item.message)}</Message>
     </Wrapper>

--- a/src/components/MessageList/MessageShape.tsx
+++ b/src/components/MessageList/MessageShape.tsx
@@ -5,6 +5,6 @@ export default PropTypes.shape({
   name: PropTypes.string.isRequired,
   timestamp: PropTypes.number.isRequired,
   email: PropTypes.string.isRequired,
-  phone: PropTypes.string.isRequired,
+  phone: PropTypes.string,
   message: PropTypes.string.isRequired
 })

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -271,7 +271,7 @@
     "errorMessage": "Ihre Nachricht konnte nicht gesendet werden.",
     "validate": {
       "name": "Geben Sie hier Ihren Namen ein.",
-      "phone": "Geben Sie hier Ihre Telefonnummer ein.",
+      "phone": "Geben Sie hier eine gültige Telefonnummer ein.",
       "email": "Geben Sie hier Ihre E-Mail-Adresse ein.",
       "message": "Geben Sie hier Ihre Nachricht ein."
     }


### PR DESCRIPTION
## Summary
- Make phone field optional in the message form, with the same loose format validation as the movement wizard (7–20 chars, digits/spaces/common phone symbols)
- Use the reusable `PhoneInput` component to filter non-phone characters during input
- Update Firebase RTDB rules: remove `phone` from `hasChildren`, relax field rule to type-only check
- Conditionally render the phone row in `MessageContent` to avoid an empty label/broken link when phone is absent

## Test plan
- [x] `npm run typecheck` — no TypeScript errors
- [x] All tests pass (14 tests across 3 suites)
- [x] `validate.tsx` at 100% coverage
- [x] `MessageContent.tsx` at 100% coverage (phone present, missing, empty string)
- [x] `renderField.tsx` new `renderPhoneField` tested (type=tel, empty value)
- [ ] Manual: submit message form without phone — should succeed
- [ ] Manual: submit message form with valid phone — should succeed
- [ ] Manual: type letters in phone field — should be filtered out
- [ ] Manual: submit with too-short phone (e.g. "12") — should show validation error
- [ ] Manual: view message without phone in admin message list — phone row should be hidden