### PR TITLE
Add auto-growing textarea to message form

### DIFF
--- a/src/components/MessageForm/renderField.tsx
+++ b/src/components/MessageForm/renderField.tsx
@@ -1,9 +1,15 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import LabeledComponent from '../../components/LabeledComponent';
 import Input from '../../components/Input';
 import PhoneInput from '../PhoneInput';
 import TextArea from '../../components/TextArea';
+
+const StyledTextArea = styled(TextArea)`
+  min-height: 8em;
+  max-height: 20em;
+  overflow: hidden;
+`;
 
 const StyledLabeledComponent = styled(LabeledComponent)`
   margin-bottom: 1.8em;
@@ -48,7 +54,18 @@ export const renderPhoneField = (props) => {
   return renderLabeledComponent(props, cmp);
 };
 
+const AutoGrowTextArea = (props) => {
+  const handleInput = useCallback((e: React.FormEvent<HTMLTextAreaElement>) => {
+    const el = e.currentTarget;
+    el.style.height = 'auto';
+    el.style.height = el.scrollHeight + 'px';
+    el.style.overflow = el.scrollHeight > el.offsetHeight ? 'auto' : 'hidden';
+  }, []);
+
+  return <StyledTextArea {...props} onInput={handleInput} />;
+};
+
 export const renderTextArea = (props) => {
-  const cmp = <TextArea {...props.input} readOnly={props.readOnly} data-cy={props.input.name}/>;
+  const cmp = <AutoGrowTextArea {...props.input} readOnly={props.readOnly} data-cy={props.input.name}/>;
   return renderLabeledComponent(props, cmp);
 };


### PR DESCRIPTION
## Summary
- Replace the fixed-height message textarea with an auto-growing variant
- Starts at `min-height: 8em` (~5-6 lines), grows with content up to `max-height: 20em`, then scrolls
- Keeps the existing bottom-border-only styling consistent with other form fields

## Test plan
- [x] `npm run typecheck` — no TypeScript errors
- [x] `npx jest "MessageForm"` — all tests pass
- [ ] Manual: type a short message — textarea stays at min height
- [ ] Manual: type a long message — textarea grows line by line
- [ ] Manual: exceed ~12-13 lines — scrollbar appears, textarea stops growing
- [ ] Manual: delete text — textarea shrinks back down