### PR TITLE
Prefill message form with user profile data

### DIFF
--- a/src/components/MessageForm/MessageForm.tsx
+++ b/src/components/MessageForm/MessageForm.tsx
@@ -18,7 +18,7 @@ class MessageForm extends React.Component<any, any> {
   render() {
     const { t } = this.props;
     return (
-      <Form validate={validate} onSubmit={this.props.onSubmit}>
+      <Form validate={validate} onSubmit={this.props.onSubmit} initialValues={this.props.initialValues}>
         {({handleSubmit}) => (
           <form className="MessageForm" onSubmit={handleSubmit}>
             <H1>{t('message.heading')}</H1>
@@ -77,6 +77,7 @@ class MessageForm extends React.Component<any, any> {
   onSubmit: PropTypes.func.isRequired,
   resetMessageForm: PropTypes.func.isRequired,
   confirmSaveMessageSuccess: PropTypes.func.isRequired,
+  initialValues: PropTypes.object,
 };
 
 export default withTranslation()(MessageForm);

--- a/src/components/MessagePage/MessagePage.spec.ts
+++ b/src/components/MessagePage/MessagePage.spec.ts
@@ -1,0 +1,82 @@
+import {getInitialValues} from './MessagePage';
+
+describe('MessagePage', () => {
+  describe('getInitialValues', () => {
+    it('returns empty object when profile and auth are undefined', () => {
+      expect(getInitialValues(undefined, undefined)).toEqual({});
+    });
+
+    it('returns empty object when profile and auth are null', () => {
+      expect(getInitialValues(null, null)).toEqual({});
+    });
+
+    it('returns name from profile firstname and lastname', () => {
+      const profile = {firstname: 'Hans', lastname: 'Muster'};
+      expect(getInitialValues(profile, null)).toEqual({
+        name: 'Hans Muster',
+      });
+    });
+
+    it('returns trimmed name when only firstname is set', () => {
+      const profile = {firstname: 'Hans'};
+      expect(getInitialValues(profile, null)).toEqual({
+        name: 'Hans',
+      });
+    });
+
+    it('returns trimmed name when only lastname is set', () => {
+      const profile = {lastname: 'Muster'};
+      expect(getInitialValues(profile, null)).toEqual({
+        name: 'Muster',
+      });
+    });
+
+    it('returns email from profile', () => {
+      const profile = {email: 'hans@example.com'};
+      expect(getInitialValues(profile, null)).toEqual({
+        email: 'hans@example.com',
+      });
+    });
+
+    it('falls back to auth email when profile email is missing', () => {
+      const auth = {email: 'auth@example.com'};
+      expect(getInitialValues({}, auth)).toEqual({
+        email: 'auth@example.com',
+      });
+    });
+
+    it('prefers profile email over auth email', () => {
+      const profile = {email: 'profile@example.com'};
+      const auth = {email: 'auth@example.com'};
+      expect(getInitialValues(profile, auth)).toEqual({
+        email: 'profile@example.com',
+      });
+    });
+
+    it('returns phone from profile', () => {
+      const profile = {phone: '0791234567'};
+      expect(getInitialValues(profile, null)).toEqual({
+        phone: '0791234567',
+      });
+    });
+
+    it('does not include empty fields', () => {
+      const result = getInitialValues({}, {});
+      expect(Object.keys(result)).toHaveLength(0);
+    });
+
+    it('returns all fields when profile is complete', () => {
+      const profile = {
+        firstname: 'Hans',
+        lastname: 'Muster',
+        email: 'hans@example.com',
+        phone: '0791234567',
+      };
+      expect(getInitialValues(profile, null)).toEqual({
+        name: 'Hans Muster',
+        email: 'hans@example.com',
+        phone: '0791234567',
+      });
+    });
+  });
+});

--- a/src/components/MessagePage/MessagePage.tsx
+++ b/src/components/MessagePage/MessagePage.tsx
@@ -1,9 +1,26 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import Content from './Content';
 import VerticalHeaderLayout from '../VerticalHeaderLayout';
 import MessageForm from '../MessageForm';
 import JumpNavigation from '../JumpNavigation';
+
+export const getInitialValues = (profile: any, auth: any) => {
+  const p = profile || {};
+  const values: Record<string, string> = {};
+
+  const firstname = p.firstname || '';
+  const lastname = p.lastname || '';
+  const name = `${firstname} ${lastname}`.trim();
+  if (name) values.name = name;
+
+  const email = p.email || (auth && auth.email);
+  if (email) values.email = email;
+
+  if (p.phone) values.phone = p.phone;
+
+  return values;
+};
 
 const MessagePage = props => (
   <VerticalHeaderLayout>
@@ -15,6 +32,7 @@ const MessagePage = props => (
         onSubmit={props.saveMessage}
         resetMessageForm={props.resetMessageForm}
         confirmSaveMessageSuccess={props.confirmSaveMessageSuccess}
+        initialValues={getInitialValues(props.profile, props.auth)}
       />
     </Content>
   </VerticalHeaderLayout>
@@ -26,6 +44,8 @@ MessagePage.propTypes = {
   saveMessage: PropTypes.func.isRequired,
   resetMessageForm: PropTypes.func.isRequired,
   confirmSaveMessageSuccess: PropTypes.func.isRequired,
+  profile: PropTypes.object,
+  auth: PropTypes.object,
 };
 
 export default MessagePage;

--- a/src/containers/MessagePageContainer.tsx
+++ b/src/containers/MessagePageContainer.tsx
@@ -6,6 +6,8 @@ import {RootState} from '../modules';
 const mapStateToProps = (state: RootState) => ({
   sent: state.messages.form.sent,
   commitFailed: state.messages.form.commitFailed,
+  profile: state.profile.profile,
+  auth: state.auth.data,
 });
 
 const mapActionCreators = {


### PR DESCRIPTION
## Summary
- Prefill the message form (name, email, phone) from the logged-in user's profile data
- Fall back to Firebase auth email when profile email is not set
- Form stays empty for guest, kiosk, ipauth, and static logins without profile data
- Users can still edit all prefilled fields

## Test plan
- [x] `npm run typecheck` — no TypeScript errors
- [x] All tests pass (11 tests for `getInitialValues`, 100% branch coverage)
- [ ] Manual: log in with a user that has profile data → message form fields are prefilled
- [ ] Manual: log in with a user without profile email → auth email is used
- [ ] Manual: guest/kiosk user → message form fields are empty
- [ ] Manual: prefilled fields are editable