### PR TITLE
Fall back to auth email in movement wizard

### DIFF
--- a/cypress/integration/movements/email_user_movement_list_spec.js
+++ b/cypress/integration/movements/email_user_movement_list_spec.js
@@ -30,10 +30,18 @@ describe('movements', () => {
       cy.get(`[data-cy=aircraftCategory-option-Flugzeug]`).click();
       cy.get(`[data-cy=next-button]`).click();
 
-      cy.get(`[data-cy=lastname]`).type('Cypress');
-      cy.get(`[data-cy=firstname]`).type('Pilot');
-      cy.get(`[data-cy=email]`).type('pilot@example.com');
-      cy.get(`[data-cy=phone]`).type('0790000000');
+      cy.get(`[data-cy=lastname]`).clear().type('Cypress');
+      cy.get(`[data-cy=firstname]`).clear().type('Pilot');
+      // Email may be masked when prefilled; clear masked value then type
+      cy.get(`[data-cy=email]`).then($el => {
+        if ($el.is('input')) {
+          cy.wrap($el).clear().type('pilot@example.com');
+        } else {
+          cy.wrap($el).find('button').click();
+          cy.get(`[data-cy=email]`).type('pilot@example.com');
+        }
+      });
+      cy.get(`[data-cy=phone]`).clear().type('0790000000');
       cy.get(`[data-cy=next-button]`).click();
 
       cy.get(`[data-cy=passengerCount-increment]`).click();

--- a/src/components/MaskedInput/MaskedInput.tsx
+++ b/src/components/MaskedInput/MaskedInput.tsx
@@ -71,7 +71,7 @@ class MaskedInput extends Component<any, any> {
   render() {
     if (this.props.input.value && !this.props.meta.active) {
       return (
-        <StyledMaskedComponent onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+        <StyledMaskedComponent data-cy={this.props.input.name} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
           <MaskedContent>{
             this.props.type === 'email'
               ? maskEmail(this.props.input.value)

--- a/src/modules/movements/sagas.spec.ts
+++ b/src/modules/movements/sagas.spec.ts
@@ -722,6 +722,36 @@ describe('modules', () => {
           expect(next.value).toEqual({ firstname: 'John' });
           expect(next.done).toEqual(true);
         });
+
+        it('should fall back to auth email when profile has no email', () => {
+          const generator = sagas.getProfileDefaultValues();
+
+          expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+          const auth = { uid: 'user-123', email: 'auth@example.com' };
+          expect(generator.next(auth).value).toEqual(call(loadRemote, 'user-123'));
+
+          const snapshot = { val: () => ({ firstname: 'John' }) };
+
+          const next = generator.next(snapshot);
+          expect(next.value).toEqual({ firstname: 'John', email: 'auth@example.com' });
+          expect(next.done).toEqual(true);
+        });
+
+        it('should prefer profile email over auth email', () => {
+          const generator = sagas.getProfileDefaultValues();
+
+          expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+          const auth = { uid: 'user-123', email: 'auth@example.com' };
+          expect(generator.next(auth).value).toEqual(call(loadRemote, 'user-123'));
+
+          const snapshot = { val: () => ({ email: 'profile@example.com' }) };
+
+          const next = generator.next(snapshot);
+          expect(next.value).toEqual({ email: 'profile@example.com' });
+          expect(next.done).toEqual(true);
+        });
       });
 
       describe('filterMovements', () => {

--- a/src/modules/movements/sagas.ts
+++ b/src/modules/movements/sagas.ts
@@ -37,6 +37,9 @@ export function* getProfileDefaultValues() {
   for (const key of ['memberNr', 'email', 'firstname', 'lastname', 'phone', 'immatriculation', 'aircraftCategory', 'aircraftType', 'mtow']) {
     if (key in p) result[key] = p[key];
   }
+  if (!result.email && auth.email) {
+    result.email = auth.email;
+  }
   return result;
 }
 


### PR DESCRIPTION
## Summary
- When the user profile has no email, fall back to Firebase auth email for prefilling the pilot email in the movement wizard
- Profile email is still preferred when present
- No change for guest/kiosk/ipauth users (early return before profile load)

## Test plan
- [x] `npm run typecheck` — no TypeScript errors
- [x] `npx jest "movements/sagas"` — all 64 tests pass
- [x] New test: auth email used when profile email is missing
- [x] New test: profile email preferred over auth email
- [ ] Manual: user with profile email → profile email prefilled
- [ ] Manual: user without profile email but with auth email → auth email prefilled