### PR TITLE
Use PhoneInput in profile form

### DIFF
--- a/src/components/ProfilePage/ProfileForm.tsx
+++ b/src/components/ProfilePage/ProfileForm.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import FieldSet from '../wizards/FieldSet'
 import { useTranslation } from 'react-i18next';
 import {Field, Form} from 'react-final-form'
-import {renderAircraftCategoryDropdown, renderAircraftDropdown, renderInputField} from '../wizards/renderField'
+import {renderAircraftCategoryDropdown, renderAircraftDropdown, renderInputField, renderPhoneField} from '../wizards/renderField'
 import React from 'react'
 import Button from '../Button'
 import styled from 'styled-components'
@@ -74,9 +74,8 @@ function ProfileForm(props) {
               />
               <Field
                 name="phone"
-                type="tel"
                 label={t('profile.phone')}
-                component={renderInputField}
+                component={renderPhoneField}
               />
             </FieldSet>
           </StyledSection>


### PR DESCRIPTION
## Summary
- Replace plain text input with the reusable `PhoneInput` component for the phone field in the profile form
- Filters non-phone characters (letters, special symbols) during typing, consistent with the movement wizard and message form

## Test plan
- [x] `npm run typecheck` — no TypeScript errors
- [ ] Manual: type letters in phone field on profile page — should be filtered out
- [ ] Manual: valid phone numbers still work as before