### PR TITLE
Localize sign-in email for English users

### DIFF
--- a/functions/auth/emailTemplates.js
+++ b/functions/auth/emailTemplates.js
@@ -14,18 +14,21 @@ const readTemplate = (templateName, format) => {
   return fs.readFileSync(templatePath, 'utf8');
 };
 
-const getSignInEmailContent = ({ signInCode, airportName, themeColor }) => {
+const getSignInEmailContent = ({ signInCode, airportName, themeColor, language }) => {
   const replacements = {
     signInCode,
     airportName,
     themeColor
   };
 
-  const htmlTemplate = readTemplate('signin', 'html');
-  const textTemplate = readTemplate('signin', 'txt');
+  const templateName = language === 'en' ? 'signin_en' : 'signin';
+  const subject = language === 'en' ? 'Sign in to Flightbox' : 'Bei Flightbox anmelden';
+
+  const htmlTemplate = readTemplate(templateName, 'html');
+  const textTemplate = readTemplate(templateName, 'txt');
 
   return {
-    subject: 'Bei Flightbox anmelden',
+    subject,
     html: replacePlaceholders(htmlTemplate, replacements),
     text: replacePlaceholders(textTemplate, replacements)
   };

--- a/functions/auth/emailTemplates.spec.js
+++ b/functions/auth/emailTemplates.spec.js
@@ -21,7 +21,7 @@ describe('functions', () => {
       jest.clearAllMocks();
     });
 
-    it('returns subject, html, and text', () => {
+    it('returns German subject by default', () => {
       const result = getSignInEmailContent({
         signInCode: '123456',
         airportName: 'Thun Airport',
@@ -30,6 +30,16 @@ describe('functions', () => {
       expect(result.subject).toBe('Bei Flightbox anmelden');
       expect(result.html).toBeDefined();
       expect(result.text).toBeDefined();
+    });
+
+    it('returns English subject when language is en', () => {
+      const result = getSignInEmailContent({
+        signInCode: '123456',
+        airportName: 'Thun Airport',
+        themeColor: '#003863',
+        language: 'en'
+      });
+      expect(result.subject).toBe('Sign in to Flightbox');
     });
 
     it('replaces signInCode placeholder in html', () => {
@@ -83,7 +93,7 @@ describe('functions', () => {
       expect(result.html).toContain('654321');
     });
 
-    it('reads html template from correct path', () => {
+    it('reads German template by default', () => {
       getSignInEmailContent({
         signInCode: '123456',
         airportName: 'Thun',
@@ -93,16 +103,25 @@ describe('functions', () => {
         expect.stringContaining('signin.html'),
         'utf8'
       );
+      expect(fs.readFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('signin.txt'),
+        'utf8'
+      );
     });
 
-    it('reads text template from correct path', () => {
+    it('reads English template when language is en', () => {
       getSignInEmailContent({
         signInCode: '123456',
         airportName: 'Thun',
-        themeColor: '#003863'
+        themeColor: '#003863',
+        language: 'en'
       });
       expect(fs.readFileSync).toHaveBeenCalledWith(
-        expect.stringContaining('signin.txt'),
+        expect.stringContaining('signin_en.html'),
+        'utf8'
+      );
+      expect(fs.readFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('signin_en.txt'),
         'utf8'
       );
     });

--- a/functions/auth/generateSignInCode.js
+++ b/functions/auth/generateSignInCode.js
@@ -39,7 +39,7 @@ exports.generateSignInCode = functions.region('europe-west1').https.onRequest((r
         return res.status(validationError.status).json({ error: validationError.error });
       }
 
-      const { email, airportName, themeColor } = req.body;
+      const { email, airportName, themeColor, language } = req.body;
       const normalizedEmail = email.toLowerCase();
 
       const code = String(crypto.randomInt(0, 1000000)).padStart(6, '0');
@@ -53,7 +53,7 @@ exports.generateSignInCode = functions.region('europe-west1').https.onRequest((r
         attempts: 0,
       });
 
-      await sendSignInEmail({ email: normalizedEmail, signInCode: code, airportName, themeColor });
+      await sendSignInEmail({ email: normalizedEmail, signInCode: code, airportName, themeColor, language });
 
       res.status(200).json({ success: true });
     } catch (error) {

--- a/functions/auth/sendSignInEmail.js
+++ b/functions/auth/sendSignInEmail.js
@@ -34,9 +34,9 @@ const createTransporter = (settings) => {
   });
 };
 
-const sendSignInEmail = async ({ email, signInCode, airportName, themeColor }) => {
+const sendSignInEmail = async ({ email, signInCode, airportName, themeColor, language }) => {
   const smtpSettings = await loadSmtpSettings();
-  const emailContent = getSignInEmailContent({ signInCode, airportName, themeColor });
+  const emailContent = getSignInEmailContent({ signInCode, airportName, themeColor, language });
   const transporter = createTransporter(smtpSettings);
 
   const info = await transporter.sendMail({

--- a/functions/auth/templates/signin_en.html
+++ b/functions/auth/templates/signin_en.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sign in to Flightbox</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; margin: 0; padding: 0; background-color: #f4f4f4;">
+  <div style="max-width: 600px; margin: 40px auto; background-color: #ffffff; box-shadow: 0 2px 10px rgba(0,0,0,0.1); overflow: hidden;">
+
+    <!-- Header -->
+    <div style="background: {{themeColor}}; color: white; padding: 20px 30px; text-align: center;">
+      <h1 style="margin: 0; font-size: 28px; font-weight: 300;">Flightbox</h1>
+      <p style="margin: 10px 0 0 0; font-size: 16px; opacity: 0.9;">{{airportName}}</p>
+    </div>
+
+    <!-- Content -->
+    <div style="padding: 20px 30px;">
+      <p style="font-size: 16px; margin-bottom: 20px;">Hello!</p>
+
+      <p style="font-size: 16px; margin-bottom: 30px;">Enter the following code in the Flightbox app to sign in:</p>
+
+      <!-- OTP Code Display -->
+      <div style="text-align: center; margin: 40px 0;">
+        <div style="display: inline-block; background-color: #f8f9fa; border: 2px solid {{themeColor}}; border-radius: 12px; padding: 20px 40px;">
+          <p style="margin: 0 0 8px 0; font-size: 13px; color: #666; text-transform: uppercase; letter-spacing: 1px;">Your sign-in code</p>
+          <p style="margin: 0; font-size: 42px; font-weight: 700; letter-spacing: 12px; color: #222; font-family: 'Courier New', Courier, monospace;">{{signInCode}}</p>
+        </div>
+      </div>
+
+      <!-- Security Notice -->
+      <div style="margin-top: 40px; padding: 20px; background-color: #fff3cd; border: 1px solid #ffeaa7; border-radius: 4px;">
+        <h3 style="margin: 0 0 10px 0; font-size: 16px; color: #856404;">Security notice</h3>
+        <p style="margin: 0; font-size: 14px; color: #856404;">
+          &#x2022; This code is valid for <strong>10 minutes</strong><br>
+          &#x2022; If you did not request this code, you can ignore this email<br>
+          &#x2022; Never share this code with anyone
+        </p>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div style="background-color: #f8f9fa; padding: 30px; text-align: center; border-top: 1px solid #e9ecef;">
+      <p style="margin: 0; font-size: 14px; color: #6c757d;">
+        This email was sent by open digital Flightbox<br>
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/functions/auth/templates/signin_en.txt
+++ b/functions/auth/templates/signin_en.txt
@@ -1,0 +1,13 @@
+Hello!
+
+Enter the following code in the Flightbox app to sign in:
+
+  {{signInCode}}
+
+SECURITY NOTICE:
+- This code is valid for 10 minutes
+- If you did not request this code, you can ignore this email
+- Never share this code with anyone
+
+---
+This email was sent by open digital Flightbox

--- a/src/modules/auth/sagas.spec.ts
+++ b/src/modules/auth/sagas.spec.ts
@@ -7,6 +7,9 @@ import firebase, {authenticate as fbAuth, requestSignInCode as fbRequestSignInCo
 import {get} from 'firebase/database';
 
 jest.mock('../../util/firebase');
+jest.mock('../../i18n', () => ({
+  language: 'de',
+}));
 jest.mock('firebase/database', () => ({
   get: jest.fn(),
   query: jest.fn(r => r),
@@ -425,7 +428,7 @@ describe('modules', () => {
           expect(generator.next().value).toEqual(put(actions.setSubmitting()));
           // next: sets isLocalSignIn in localStorage (synchronous)
           expect(generator.next().value).toEqual(
-            call(fbRequestSignInCode, 'user@example.com', 'Test Airport', '#003863')
+            call(fbRequestSignInCode, 'user@example.com', 'Test Airport', '#003863', 'de')
           );
 
           expect(generator.next().value).toEqual(
@@ -442,7 +445,7 @@ describe('modules', () => {
           expect(generator.next().value).toEqual(put(actions.setSubmitting()));
           // next: sets isLocalSignIn in localStorage (synchronous), then calls requestSignInCode
           expect(generator.next().value).toEqual(
-            call(fbRequestSignInCode, 'user@example.com', 'Test Airport', '#003863')
+            call(fbRequestSignInCode, 'user@example.com', 'Test Airport', '#003863', 'de')
           );
 
           const error = new Error('Network error');

--- a/src/modules/auth/sagas.ts
+++ b/src/modules/auth/sagas.ts
@@ -12,6 +12,7 @@ import firebase, {
 } from '../../util/firebase';
 import {error as logError} from '../../util/log';
 import {getKioskAuthQueryToken} from '../../util/getAuthQueryToken'
+import i18n from '../../i18n'
 
 export function getLoginData(uid: string) {
   return get(firebase('/logins/' + uid))
@@ -93,7 +94,7 @@ export function* sendAuthenticationEmail(action: any) {
       const airportName = __CONF__.aerodrome.name;
       const theme = require(`../../../theme/${__CONF__.theme}`);
 
-      yield call(fbRequestSignInCode, email, airportName, theme.colors.main);
+      yield call(fbRequestSignInCode, email, airportName, theme.colors.main, i18n.language);
 
       yield put(actions.sendAuthenticationEmailSuccess());
     }

--- a/src/util/firebase.spec.ts
+++ b/src/util/firebase.spec.ts
@@ -140,7 +140,7 @@ describe('util/firebase', () => {
       };
       global.fetch = jest.fn().mockResolvedValue(mockResponse);
 
-      const result = await requestSignInCode('user@example.com', 'Thun', '#003863');
+      const result = await requestSignInCode('user@example.com', 'Thun', '#003863', 'de');
       expect(result).toBeUndefined();
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining('generateSignInCode'),
@@ -152,7 +152,7 @@ describe('util/firebase', () => {
       const mockResponse = { ok: true };
       global.fetch = jest.fn().mockResolvedValue(mockResponse);
 
-      await requestSignInCode('user@example.com', 'Thun', '#003863');
+      await requestSignInCode('user@example.com', 'Thun', '#003863', 'de');
 
       const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
       const body = JSON.parse(fetchCall[1].body);
@@ -160,6 +160,7 @@ describe('util/firebase', () => {
         email: 'user@example.com',
         airportName: 'Thun',
         themeColor: '#003863',
+        language: 'de',
       });
     });
 
@@ -170,7 +171,7 @@ describe('util/firebase', () => {
       };
       global.fetch = jest.fn().mockResolvedValue(mockResponse);
 
-      const result = await requestSignInCode('user@example.com', 'Thun', '#003863');
+      const result = await requestSignInCode('user@example.com', 'Thun', '#003863', 'de');
       // Result should be undefined (not an object with code)
       expect(result).toBeUndefined();
     });
@@ -182,7 +183,7 @@ describe('util/firebase', () => {
       };
       global.fetch = jest.fn().mockResolvedValue(mockResponse);
 
-      await expect(requestSignInCode('bad@example.com', 'Thun', '#003863'))
+      await expect(requestSignInCode('bad@example.com', 'Thun', '#003863', 'de'))
         .rejects.toThrow('Invalid email');
     });
 
@@ -193,14 +194,14 @@ describe('util/firebase', () => {
       };
       global.fetch = jest.fn().mockResolvedValue(mockResponse);
 
-      await expect(requestSignInCode('user@example.com', 'Thun', '#003863'))
+      await expect(requestSignInCode('user@example.com', 'Thun', '#003863', 'de'))
         .rejects.toThrow('Failed to send sign-in code');
     });
 
     it('rejects when fetch throws', async () => {
       global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
 
-      await expect(requestSignInCode('user@example.com', 'Thun', '#003863'))
+      await expect(requestSignInCode('user@example.com', 'Thun', '#003863', 'de'))
         .rejects.toThrow('Network error');
     });
   });

--- a/src/util/firebase.ts
+++ b/src/util/firebase.ts
@@ -43,7 +43,7 @@ export function authenticate(token) {
   return signInWithCustomToken(getAuth(), token);
 }
 
-export function requestSignInCode(email: string, airportName: string, themeColor: string) {
+export function requestSignInCode(email: string, airportName: string, themeColor: string, language: string) {
   initialize();
 
   const functionUrl = `https://europe-west1-${__FIREBASE_PROJECT_ID__}.cloudfunctions.net/generateSignInCode`;
@@ -51,7 +51,7 @@ export function requestSignInCode(email: string, airportName: string, themeColor
   return fetch(functionUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, airportName, themeColor }),
+    body: JSON.stringify({ email, airportName, themeColor, language }),
   })
     .then(response => {
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- English email templates (HTML + plain text) for sign-in OTP code
- Language passed from frontend (`i18n.language`) through Cloud Function to select template
- Defaults to German when language not provided (backward compatible with older clients)

## Test plan
- [ ] Switch to English, request sign-in code — email arrives in English
- [ ] Switch to German, request sign-in code — email arrives in German
- [ ] Verify email subject, body text, and security notice in both languages
- [ ] `npm test` passes
- [ ] `npm run test:functions` passes
- [ ] Deploy Cloud Functions before deploying frontend