### PR TITLE
Update cypress, i18next and webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "final-form": "^5.0.0",
-        "i18next": "^26.0.3",
+        "i18next": "^26.0.4",
         "process": "^0.11.10",
         "react-final-form": "^7.0.0",
         "react-i18next": "^17.0.2"
@@ -40,7 +40,7 @@
         "css-loader": "^7.1.4",
         "csv-parse": "^6.1.0",
         "csv-stringify": "^6.6.0",
-        "cypress": "^15.11.0",
+        "cypress": "^15.13.1",
         "del": "^8.0.1",
         "firebase": "^12.10.0",
         "gulp": "^5.0.1",
@@ -73,7 +73,7 @@
         "styled-components": "^6.3.11",
         "typescript": "^6.0.2",
         "util": "^0.12.5",
-        "webpack": "^5.105.3",
+        "webpack": "^5.106.0",
         "webpack-cli": "^7.0.2",
         "webpack-dev-server": "^5.2.2",
         "webpack-stream": "^7.0.0",
@@ -8479,9 +8479,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.13.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.0.tgz",
-      "integrity": "sha512-hJ9sY++TUC/HlUzHVJpIrDyqKMjlhx5PTXl/A7eA91JNEtUWkJAqefQR5mo9AtLra/9+m+JJaMg2U5Qd0a74Fw==",
+      "version": "15.13.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.1.tgz",
+      "integrity": "sha512-jLkgo75zlwo7PhXp0XJot+zIfFSDzN1SvTml6Xf3ETM1XHRWnH3Q4LAR3orCo/BsnxPnhjG3m5HYSvn9DAtwBg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -11557,9 +11557,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.0.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.3.tgz",
-      "integrity": "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg==",
+      "version": "26.0.4",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.4.tgz",
+      "integrity": "sha512-gXF7U9bfioXPLv7mw8Qt2nfO7vij5MyINvPgVv99pX3fL1Y01pw2mKBFrlYpRxRCl2wz3ISenj6VsMJT2isfuA==",
       "funding": [
         {
           "type": "individual",
@@ -19505,9 +19505,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.105.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
-      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
+      "version": "5.106.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.0.tgz",
+      "integrity": "sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "css-loader": "^7.1.4",
     "csv-parse": "^6.1.0",
     "csv-stringify": "^6.6.0",
-    "cypress": "^15.11.0",
+    "cypress": "^15.13.1",
     "del": "^8.0.1",
     "firebase": "^12.10.0",
     "gulp": "^5.0.1",
@@ -77,7 +77,7 @@
     "styled-components": "^6.3.11",
     "typescript": "^6.0.2",
     "util": "^0.12.5",
-    "webpack": "^5.105.3",
+    "webpack": "^5.106.0",
     "webpack-cli": "^7.0.2",
     "webpack-dev-server": "^5.2.2",
     "webpack-stream": "^7.0.0",
@@ -89,7 +89,7 @@
   },
   "dependencies": {
     "final-form": "^5.0.0",
-    "i18next": "^26.0.3",
+    "i18next": "^26.0.4",
     "process": "^0.11.10",
     "react-final-form": "^7.0.0",
     "react-i18next": "^17.0.2"


### PR DESCRIPTION
## Summary
- cypress 15.13.0 -> 15.13.1 (patch)
- i18next 26.0.3 -> 26.0.4 (patch)
- webpack 5.105.4 -> 5.106.0 (minor)

## Test plan
- [ ] CI passes