### PR TITLE
Upgrade react-day-picker from v7 to v9

### DIFF
--- a/cypress/integration/movements/arrival/create_arrival_spec.js
+++ b/cypress/integration/movements/arrival/create_arrival_spec.js
@@ -49,7 +49,7 @@ describe('movements', () => {
         cy.get(`[data-cy=next-button]`).click();
 
         cy.get(`[data-cy=date]`).click();
-        cy.get(`.DayPicker-Day[aria-disabled=false]`).last().click();
+        cy.get(`.rdp-day:not(.rdp-disabled) .rdp-day_button`).last().click();
         cy.get(`[data-cy=time-minutes-increment]`).click();
         cy.get(`[data-cy=location]`).type('LSZR');
         cy.get(`[data-cy=landingCount-increment]`).click();

--- a/cypress/integration/movements/departure/create_departure_spec.js
+++ b/cypress/integration/movements/departure/create_departure_spec.js
@@ -50,7 +50,7 @@ describe('movements', () => {
         cy.get(`[data-cy=next-button]`).click();
 
         cy.get(`[data-cy=date]`).click();
-        cy.get(`.DayPicker-Day[aria-disabled=false]`).last().click(); // select last day of month
+        cy.get(`.rdp-day:not(.rdp-disabled) .rdp-day_button`).last().click(); // select last day of month
         cy.get(`[data-cy=time-minutes-increment]`).click();
         cy.get(`[data-cy=location]`).type('LSZR');
         cy.get(`[data-cy=duration-hours-increment]`).click();

--- a/cypress/integration/movements/email_user_movement_list_spec.js
+++ b/cypress/integration/movements/email_user_movement_list_spec.js
@@ -49,7 +49,7 @@ describe('movements', () => {
       cy.get(`[data-cy=next-button]`).click();
 
       cy.get(`[data-cy=date]`).click();
-      cy.get(`.DayPicker-Day[aria-disabled=false]`).last().click();
+      cy.get(`.rdp-day:not(.rdp-disabled) .rdp-day_button`).last().click();
       cy.get(`[data-cy=time-minutes-increment]`).click();
       cy.get(`[data-cy=location]`).type('LSZR');
       cy.get(`[data-cy=duration-hours-increment]`).click();

--- a/cypress/integration/settings/lock_date_spec.js
+++ b/cypress/integration/settings/lock_date_spec.js
@@ -18,7 +18,7 @@ describe('settings', () => {
       cy.get(`[data-cy=lock-movements]`).click();
 
       cy.get(`[data-cy=lock-date]`).click();
-      cy.get(`.DayPicker-Day[aria-disabled=false]`).first().click();
+      cy.get(`.rdp-day:not(.rdp-disabled) .rdp-day_button`).first().click();
 
       cy.window().then(win =>
         win.firebase.getRef('/settings/lockDate').once('value').then(snapshot => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "license": "UNLICENSED",
       "dependencies": {
+        "date-fns": "^4.1.0",
         "final-form": "^5.0.0",
         "i18next": "^26.0.4",
         "process": "^0.11.10",
@@ -60,7 +61,7 @@
         "qrcode-svg": "^1.1.0",
         "ramda": "^0.32.0",
         "react": "^18.3.1",
-        "react-day-picker": "^7.1.9",
+        "react-day-picker": "^9.14.0",
         "react-dom": "^18.3.1",
         "react-redux": "^9.2.0",
         "react-router-dom": "^5.3.4",
@@ -2250,6 +2251,13 @@
       "dependencies": {
         "ms": "^2.1.1"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "1.0.0",
@@ -5302,6 +5310,16 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/@tabby_ai/hijri-converter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -8633,6 +8651,23 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dateformat": {
       "version": "2.2.0",
@@ -16270,16 +16305,26 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "7.4.10",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.4.10.tgz",
-      "integrity": "sha512-/QkK75qLKdyLmv0kcVzhL7HoJPazoZXS8a6HixbVoK6vWey1Od1WRLcxfyEiUsRfccAlIlf6oKHShqY2SM82rA==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "prop-types": "^15.6.2"
+        "@date-fns/tz": "^1.4.1",
+        "@tabby_ai/hijri-converter": "1.0.5",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
-        "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "qrcode-svg": "^1.1.0",
     "ramda": "^0.32.0",
     "react": "^18.3.1",
-    "react-day-picker": "^7.1.9",
+    "react-day-picker": "^9.14.0",
     "react-dom": "^18.3.1",
     "react-redux": "^9.2.0",
     "react-router-dom": "^5.3.4",
@@ -88,6 +88,7 @@
     "url": "https://github.com/odch/flightbox.git"
   },
   "dependencies": {
+    "date-fns": "^4.1.0",
     "final-form": "^5.0.0",
     "i18next": "^26.0.4",
     "process": "^0.11.10",

--- a/src/components/DatePicker/DatePicker.spec.tsx
+++ b/src/components/DatePicker/DatePicker.spec.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { renderWithTheme, screen, fireEvent } from '../../../test/renderWithTheme';
 import DatePicker from './DatePicker';
 
-// Mock the styled DayPicker wrapper (imported as ./DayPicker in DatePicker.js)
+// Mock the styled DayPicker wrapper (imported as ./DayPicker in DatePicker.tsx)
 jest.mock('./DayPicker', () => {
   const React = require('react');
-  const MockDayPicker = ({ onDayClick }) => (
+  const MockDayPicker = ({ onSelect }) => (
     <div data-testid="day-picker">
       <button
         data-testid="day-picker-day"
         type="button"
-        onClick={() => onDayClick && onDayClick(new Date('2024-06-15'))}
+        onClick={() => onSelect && onSelect(new Date('2024-06-15'))}
       >
         15
       </button>
@@ -18,8 +18,6 @@ jest.mock('./DayPicker', () => {
   );
   return MockDayPicker;
 });
-
-jest.mock('react-day-picker/moment', () => ({}));
 
 // Mock ModalDialog to render content directly for testability
 jest.mock('../ModalDialog', () => {

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import { withTranslation } from 'react-i18next';
+import { de } from 'date-fns/locale/de';
+import { enGB } from 'date-fns/locale/en-GB';
 import ModalDialog from '../ModalDialog';
 import MaterialIcon from '../MaterialIcon';
-import MomentLocaleUtils from 'react-day-picker/moment';
 import dates from '../../util/dates';
 import Wrapper from './Wrapper';
 import DayPicker from './DayPicker';
@@ -70,15 +71,15 @@ class DatePicker extends Component<any, any> {
 
   renderPicker() {
     const date = this.state.value ? new Date(this.state.value) : undefined;
-    const locale = this.props.i18n?.language === 'en' ? 'en' : 'de-ch';
+    const locale = this.props.i18n?.language === 'en' ? enGB : de;
     return (
       <DayPicker
-        selectedDays={date}
-        initialMonth={date}
-        onDayClick={this.handleDayClick}
-        localeUtils={MomentLocaleUtils}
+        mode="single"
+        selected={date}
+        defaultMonth={date}
+        onSelect={this.handleDayClick}
         locale={locale}
-        firstDayOfWeek={1}
+        weekStartsOn={1}
       />
     );
   }

--- a/src/components/DatePicker/DayPicker.tsx
+++ b/src/components/DatePicker/DayPicker.tsx
@@ -1,23 +1,11 @@
 import styled from 'styled-components';
-import DayPicker from 'react-day-picker';
-import 'react-day-picker/lib/style.css';
+import { DayPicker } from 'react-day-picker';
+import 'react-day-picker/style.css';
 
 const StyledDayPicker = styled(DayPicker)`
-  & .DayPicker-Weekday {
-    color: ${props => props.theme.colors.main};
-  }
-  
-  & .DayPicker-Day--today {
-    color: ${props => props.theme.colors.danger};
-  }
-  
-  & .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-    background-color: ${props => props.theme.colors.main};
-    
-    &:hover {
-      background-color: ${props => props.theme.colors.main};
-    }
-  }
+  --rdp-accent-color: ${props => props.theme.colors.main};
+  --rdp-accent-background-color: ${props => props.theme.colors.main};
+  --rdp-today-color: ${props => props.theme.colors.danger};
 `;
 
 export default StyledDayPicker;


### PR DESCRIPTION
## Summary
- Upgrade react-day-picker 7.4.10 -> 9.14.0
- Add date-fns 4.1.0 for locale support (replaces MomentLocaleUtils)
- Use specific locale imports (de, en-GB) to avoid bundling all locales
- Use CSS variables for theming instead of class overrides
- Update to v9 API: mode, selected, defaultMonth, onSelect, weekStartsOn

## Test plan
- [ ] Open date picker in departure/arrival wizard
- [ ] Verify month/weekday names show in German
- [ ] Switch to English, verify month/weekday names in English
- [ ] Select a date, verify it populates correctly
- [ ] Clear a date (where clearable)
- [ ] Verify selected day highlighting uses theme color
- [ ] Verify today is highlighted in red
- [ ] CI passes