### PR TITLE
Convert 20 trivial class components to functional

### DIFF
--- a/src/components/ImageButton/ImageButton.tsx
+++ b/src/components/ImageButton/ImageButton.tsx
@@ -15,24 +15,18 @@ const LinkContent = styled.div`
   align-items: center;
 `
 
-class ImageButton extends React.PureComponent<any, any> {
+const ImageButton = ({ className, label, img, href, onClick, dataCy }: any) => (
+  <Wrapper className={className}>
+    <OptionalLink href={href} onClick={onClick} dataCy={dataCy}>
+      <LinkContent>
+        <img src={img}/>
+        {label}
+      </LinkContent>
+    </OptionalLink>
+  </Wrapper>
+);
 
-  render() {
-    const props = this.props;
-    return (
-      <Wrapper className={props.className}>
-        <OptionalLink href={props.href} onClick={props.onClick} dataCy={props.dataCy}>
-          <LinkContent>
-            <img src={props.img}/>
-            {props.label}
-          </LinkContent>
-        </OptionalLink>
-      </Wrapper>
-    )
-  }
-}
-
-(ImageButton as any).propTypes = {
+ImageButton.propTypes = {
   className: PropTypes.string,
   label: PropTypes.string.isRequired,
   img: PropTypes.string.isRequired,

--- a/src/components/JumpNavigation/JumpNavigation.tsx
+++ b/src/components/JumpNavigation/JumpNavigation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import Item from './Item';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 const Wrapper = styled.div`
   font-size: 1.2em;
@@ -12,17 +12,15 @@ const Wrapper = styled.div`
   }
 `;
 
-class JumpNavigation extends React.PureComponent<any, any> {
-  render() {
-    const { t } = this.props;
-    return (
-      <Wrapper>
-        <Item href="/" icon="home" label={t('nav.home')}/>
-        <Item href="/departure/new" icon="flight_takeoff" label={t('hints.recordDeparture')}/>
-        <Item href="/arrival/new" icon="flight_land" label={t('hints.recordArrival')}/>
-      </Wrapper>
-    );
-  }
-}
+const JumpNavigation = () => {
+  const { t } = useTranslation();
+  return (
+    <Wrapper>
+      <Item href="/" icon="home" label={t('nav.home')}/>
+      <Item href="/departure/new" icon="flight_takeoff" label={t('hints.recordDeparture')}/>
+      <Item href="/arrival/new" icon="flight_land" label={t('hints.recordArrival')}/>
+    </Wrapper>
+  );
+};
 
-export default withTranslation()(JumpNavigation);
+export default JumpNavigation;

--- a/src/components/LabeledComponent/ValidationMessage.tsx
+++ b/src/components/LabeledComponent/ValidationMessage.tsx
@@ -18,19 +18,14 @@ const Text = styled.div`
   margin-left: 2em;
 `;
 
-class ValidationMessage extends React.PureComponent<any, any> {
+const ValidationMessage = ({ error }: any) => (
+  <Wrapper>
+    <Icon icon="error"/>
+    <Text>{error}</Text>
+  </Wrapper>
+);
 
-  render() {
-    return (
-      <Wrapper>
-        <Icon icon="error"/>
-        <Text>{this.props.error}</Text>
-      </Wrapper>
-    );
-  }
-}
-
-(ValidationMessage as any).propTypes = {
+ValidationMessage.propTypes = {
   error: PropTypes.string.isRequired,
 };
 

--- a/src/components/MaterialIcon/MaterialIcon.tsx
+++ b/src/components/MaterialIcon/MaterialIcon.tsx
@@ -45,31 +45,23 @@ const I = styled.i<{ $size?: number; $rotate?: string }>`
   ${props => props.$rotate && css`animation: ${animations[props.$rotate]} 2s linear infinite;`}
 `;
 
-class MaterialIcon extends React.PureComponent<any, any> {
-  render() {
-    return (
-      <I
-        className={this.props.className}
-        $size={this.props.size}
-        title={this.props.title}
-        $rotate={this.props.rotate}
-      >
-        {this.props.icon}
-      </I>
-    );
-  }
-}
+const MaterialIcon = ({ icon, className, size = 24, title, rotate }: any) => (
+  <I
+    className={className}
+    $size={size}
+    title={title}
+    $rotate={rotate}
+  >
+    {icon}
+  </I>
+);
 
-(MaterialIcon as any).propTypes = {
+MaterialIcon.propTypes = {
   icon: PropTypes.string.isRequired,
   className: PropTypes.string,
   size: PropTypes.number,
   title: PropTypes.string,
   rotate: PropTypes.oneOf(['left', 'right'])
-};
-
-(MaterialIcon as any).defaultProps = {
-  size: 24
 };
 
 export default MaterialIcon;

--- a/src/components/MovementList/Action.tsx
+++ b/src/components/MovementList/Action.tsx
@@ -26,31 +26,23 @@ const ActionLabel = styled.span<{ $responsive?: boolean }>`
   }
 `;
 
-class Action extends React.PureComponent<any, any> {
-
-  constructor(props) {
-    super(props);
-    this.handleClick = this.handleClick.bind(this);
-  }
-
-  handleClick(e) {
+const Action = ({ className, onClick, icon, label, disabled, responsive, rotateIcon, dataCy }: any) => {
+  const handleClick = (e) => {
     e.stopPropagation();
-    if (!this.props.disabled) {
-      this.props.onClick();
+    if (!disabled) {
+      onClick();
     }
-  }
+  };
 
-  render() {
-    return (
-      <StyledAction onClick={this.handleClick} className={this.props.className} $disabled={this.props.disabled} data-cy={this.props.dataCy}>
-        <MaterialIcon icon={this.props.icon} rotate={this.props.rotateIcon}/>
-        <ActionLabel $responsive={this.props.responsive}>&nbsp;{this.props.label}</ActionLabel>
-      </StyledAction>
-    );
-  }
-}
+  return (
+    <StyledAction onClick={handleClick} className={className} $disabled={disabled} data-cy={dataCy}>
+      <MaterialIcon icon={icon} rotate={rotateIcon}/>
+      <ActionLabel $responsive={responsive}>&nbsp;{label}</ActionLabel>
+    </StyledAction>
+  );
+};
 
-(Action as any).propTypes = {
+Action.propTypes = {
   className: PropTypes.string,
   onClick: PropTypes.func.isRequired,
   icon: PropTypes.string.isRequired,

--- a/src/components/MovementList/DetailsBox.tsx
+++ b/src/components/MovementList/DetailsBox.tsx
@@ -22,21 +22,16 @@ const Label = styled.div`
   color: ${props => props.theme.colors.main}
 `;
 
-class DetailsBox extends React.PureComponent<any, any> {
+const DetailsBox = ({ label, children }: any) => (
+  <Wrapper>
+    {label && <Label>{label}</Label>}
+    {children}
+  </Wrapper>
+);
 
-  render() {
-    const {label, children} = this.props;
-    return (
-      <Wrapper>
-        {label && <Label>{label}</Label>}
-        {children}
-      </Wrapper>
-    )
-  }
-}
-
-(DetailsBox as any).propTypes = {
-  label: PropTypes.string
+DetailsBox.propTypes = {
+  label: PropTypes.string,
+  children: PropTypes.node
 };
 
 export default DetailsBox;

--- a/src/components/MovementList/HomeBaseIcon.spec.tsx
+++ b/src/components/MovementList/HomeBaseIcon.spec.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import {renderWithTheme} from '../../../test/renderWithTheme';
 
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key, opts) => opts?.name ? `${key} ${opts.name}` : key }),
+}));
+
 jest.mock('../MaterialIcon', () => {
   const React = require('react');
   return function MockMaterialIcon({icon, title}) {
@@ -8,7 +12,6 @@ jest.mock('../MaterialIcon', () => {
   };
 });
 
-// HomeBaseIcon is a class component wrapped with withTranslation()
 import HomeBaseIcon from './HomeBaseIcon';
 
 describe('components', () => {

--- a/src/components/MovementList/HomeBaseIcon.tsx
+++ b/src/components/MovementList/HomeBaseIcon.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import MaterialIcon from '../MaterialIcon';
 
 const Wrapper = styled.div`
@@ -37,34 +37,31 @@ const Text = styled.div`
   line-height: 24px;
 `;
 
-class HomeBaseIcon extends React.PureComponent<any, any> {
+const HomeBaseIcon = ({ className, isHomeBase, showText }: any) => {
+  const { t } = useTranslation();
+  const text = t(
+    isHomeBase ? 'movement.homeBase.yes' : 'movement.homeBase.no',
+    { name: __CONF__.aerodrome.name }
+  );
 
-  render() {
-    const { t } = this.props;
-    const text = t(
-      this.props.isHomeBase ? 'movement.homeBase.yes' : 'movement.homeBase.no',
-      { name: __CONF__.aerodrome.name }
-    );
+  return (
+    <Wrapper className={className}>
+      <IconWrapper $withText={showText}>
+        <StyledIcon
+          icon="home"
+          title={text}
+          $isHomeBase={isHomeBase}
+        />
+      </IconWrapper>
+      {showText && <Text>{text}</Text>}
+    </Wrapper>
+  );
+};
 
-    return (
-      <Wrapper className={this.props.className}>
-        <IconWrapper $withText={this.props.showText}>
-          <StyledIcon
-            icon="home"
-            title={text}
-            $isHomeBase={this.props.isHomeBase}
-          />
-        </IconWrapper>
-        {this.props.showText && <Text>{text}</Text>}
-      </Wrapper>
-    );
-  }
-}
-
-(HomeBaseIcon as any).propTypes = {
+HomeBaseIcon.propTypes = {
   className: PropTypes.string,
   isHomeBase: PropTypes.bool.isRequired,
   showText: PropTypes.bool
 };
 
-export default withTranslation()(HomeBaseIcon);
+export default HomeBaseIcon;

--- a/src/components/MovementList/MovementDetails.tsx
+++ b/src/components/MovementList/MovementDetails.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import dates from '../../util/dates';
 import {getLabel as getFlightTypeLabel} from '../../util/flightTypes';
@@ -41,112 +41,104 @@ const getLandingFee = data => {
   return null
 }
 
-class MovementDetails extends React.PureComponent<any, any> {
+const MovementDetails = ({ className, data, locked, isHomeBase, isAdmin }: any) => {
+  const { t } = useTranslation();
 
-  constructor(props) {
-    super(props);
-  }
+  const date = dates.formatDate(data.date);
+  const time = dates.formatTime(data.date, data.time);
 
-  render() {
-    const props = this.props;
-    const { t } = this.props;
+  const showPaymentMethod = (isAdmin || !data.paymentMethod || data.paymentMethod.status === 'pending')
+    && (isHomeBase === false || __CONF__.homebasePayment)
 
-    const date = dates.formatDate(props.data.date);
-    const time = dates.formatTime(props.data.date, props.data.time);
-
-    const showPaymentMethod = (props.isAdmin || !props.data.paymentMethod || props.data.paymentMethod.status === 'pending')
-      && (props.isHomeBase === false || __CONF__.homebasePayment)
-
-    return (
-        <Content className={props.className}>
-          <DetailsBox label={t('movement.details.aircraftData')}>
-            <MovementField label={t('movement.details.immatriculation')} value={props.data.immatriculation}/>
-            <MovementField label={t('movement.details.aircraftType')} value={props.data.aircraftType}/>
-            <MovementField label={t('movement.details.mtow')} value={props.data.mtow}/>
-            {props.data.aircraftCategory && <MovementField label={t('movement.details.category')} value={props.data.aircraftCategory}/>}
-            <StyledHomeBaseIcon isHomeBase={props.isHomeBase} showText/>
-          </DetailsBox>
-          <DetailsBox label={t('movement.details.pilot')}>
-            {__CONF__.memberManagement === true && <MovementField label={t('movement.details.memberNr')} value={props.data.memberNr}/>}
-            <MovementField label={t('movement.details.lastname')} value={props.data.lastname}/>
-            <MovementField label={t('movement.details.firstname')} value={props.data.firstname}/>
-            <MovementField label={t('movement.details.email')}
-                           value={__CONF__.maskContactInformation === true && !props.isAdmin
-                             ? maskEmail(props.data.email)
-                             : props.data.email}/>
-            <MovementField label={t('movement.details.phone')}
-                           value={__CONF__.maskContactInformation === true && !props.isAdmin
-                             ? maskPhone(props.data.phone)
-                             : props.data.phone}/>
-          </DetailsBox>
-          {props.data.type === 'departure'
-            ? (
-              <DetailsBox label={t('movement.details.passengers')}>
-                <MovementField label={t('movement.details.passengerCount')} value={props.data.passengerCount} defaultValue={0}/>
-                <MovementField label={t('movement.details.carriageVoucher')} value={props.data.carriageVoucher ? t(`carriageVoucher.${props.data.carriageVoucher}`) : null}/>
-              </DetailsBox>
-            ) : (
-              <DetailsBox label={t('movement.details.passengers')}>
-                <MovementField label={t('movement.details.passengerCount')} value={props.data.passengerCount} defaultValue={0}/>
-              </DetailsBox>
-            )
-          }
-          {props.data.type === 'departure'
-            ? (
-              <DetailsBox label={t('movement.details.flightInfo')}>
-                <MovementField label={t('movement.details.date')} value={date}/>
-                <MovementField label={t('movement.details.departureTime')} value={time}/>
-                <MovementField label={t('movement.details.destination')} value={formatLocationDisplay(props.data, { lineHeight: 1.2, nameMarginTop: '2px' })}/>
-                <MovementField label={t('movement.details.duration')} value={props.data.duration}/>
-              </DetailsBox>
-            ) : (
-              <DetailsBox label={t('movement.details.flightInfo')}>
-                <MovementField label={t('movement.details.date')} value={date}/>
-                <MovementField label={t('movement.details.landingTime')} value={time}/>
-                <MovementField label={t('movement.details.origin')} value={formatLocationDisplay(props.data, { lineHeight: 1.2, nameMarginTop: '2px' })}/>
-                <MovementField label={t('movement.details.landingCount')} value={props.data.landingCount}/>
-                <MovementField label={t('movement.details.goAroundCount')} value={props.data.goAroundCount} defaultValue={0}/>
-              </DetailsBox>
-            )
-          }
-          {props.data.type === 'departure'
-            ? (
-              <DetailsBox label={t('movement.details.flight')}>
-                <MovementField label={t('movement.details.flightType')} value={getFlightTypeLabel(props.data.flightType)}/>
-                <MovementField label={t('movement.details.runway')} value={props.data.runway}/>
-                <MovementField label={t('movement.details.departureRoute')} value={getDepartureRouteLabel(props.data.departureRoute)}/>
-                <MovementField label={t('movement.details.routing')} value={newLineToBr(props.data.route)}/>
-                <MovementField label={t('movement.details.remarks')} value={newLineToBr(props.data.remarks)}/>
-              </DetailsBox>
-            ) : (
-              <DetailsBox label={t('movement.details.flight')}>
-                <MovementField label={t('movement.details.flightType')} value={getFlightTypeLabel(props.data.flightType)}/>
-                <MovementField label={t('movement.details.runway')} value={props.data.runway}/>
-                <MovementField label={t('movement.details.arrivalRoute')} value={getArrivalRouteLabel(props.data.arrivalRoute)}/>
-                <MovementField label={t('movement.details.remarks')} value={newLineToBr(props.data.remarks)}/>
-              </DetailsBox>
-            )
-          }
-          {props.data.type === 'arrival' && props.data.landingFeeTotal !== undefined && (
-            <DetailsBox label={t('movement.details.fees')}>
-              <MovementField label={t('movement.details.referenceNumber')} value={getFromItemKey(props.data.key)}/>
-              <MovementField label={t('movement.details.landingFee')} value={getLandingFee(props.data)}/>
-              {showPaymentMethod && (
-                <MovementField
-                  label={t('movement.details.paymentMethod')}
-                  value={props.data.paymentMethod && props.data.paymentMethod.status !== 'pending'
-                    ? getPaymentMethodLabel(props.data.paymentMethod, t)
-                    : <NoPaymentFieldValue arrivalId={props.data.key}/>}
-                />
-              )}
+  return (
+      <Content className={className}>
+        <DetailsBox label={t('movement.details.aircraftData')}>
+          <MovementField label={t('movement.details.immatriculation')} value={data.immatriculation}/>
+          <MovementField label={t('movement.details.aircraftType')} value={data.aircraftType}/>
+          <MovementField label={t('movement.details.mtow')} value={data.mtow}/>
+          {data.aircraftCategory && <MovementField label={t('movement.details.category')} value={data.aircraftCategory}/>}
+          <StyledHomeBaseIcon isHomeBase={isHomeBase} showText/>
+        </DetailsBox>
+        <DetailsBox label={t('movement.details.pilot')}>
+          {__CONF__.memberManagement === true && <MovementField label={t('movement.details.memberNr')} value={data.memberNr}/>}
+          <MovementField label={t('movement.details.lastname')} value={data.lastname}/>
+          <MovementField label={t('movement.details.firstname')} value={data.firstname}/>
+          <MovementField label={t('movement.details.email')}
+                         value={__CONF__.maskContactInformation === true && !isAdmin
+                           ? maskEmail(data.email)
+                           : data.email}/>
+          <MovementField label={t('movement.details.phone')}
+                         value={__CONF__.maskContactInformation === true && !isAdmin
+                           ? maskPhone(data.phone)
+                           : data.phone}/>
+        </DetailsBox>
+        {data.type === 'departure'
+          ? (
+            <DetailsBox label={t('movement.details.passengers')}>
+              <MovementField label={t('movement.details.passengerCount')} value={data.passengerCount} defaultValue={0}/>
+              <MovementField label={t('movement.details.carriageVoucher')} value={data.carriageVoucher ? t(`carriageVoucher.${data.carriageVoucher}`) : null}/>
             </DetailsBox>
-          )}
-        </Content>
-    );
-  }
-}
+          ) : (
+            <DetailsBox label={t('movement.details.passengers')}>
+              <MovementField label={t('movement.details.passengerCount')} value={data.passengerCount} defaultValue={0}/>
+            </DetailsBox>
+          )
+        }
+        {data.type === 'departure'
+          ? (
+            <DetailsBox label={t('movement.details.flightInfo')}>
+              <MovementField label={t('movement.details.date')} value={date}/>
+              <MovementField label={t('movement.details.departureTime')} value={time}/>
+              <MovementField label={t('movement.details.destination')} value={formatLocationDisplay(data, { lineHeight: 1.2, nameMarginTop: '2px' })}/>
+              <MovementField label={t('movement.details.duration')} value={data.duration}/>
+            </DetailsBox>
+          ) : (
+            <DetailsBox label={t('movement.details.flightInfo')}>
+              <MovementField label={t('movement.details.date')} value={date}/>
+              <MovementField label={t('movement.details.landingTime')} value={time}/>
+              <MovementField label={t('movement.details.origin')} value={formatLocationDisplay(data, { lineHeight: 1.2, nameMarginTop: '2px' })}/>
+              <MovementField label={t('movement.details.landingCount')} value={data.landingCount}/>
+              <MovementField label={t('movement.details.goAroundCount')} value={data.goAroundCount} defaultValue={0}/>
+            </DetailsBox>
+          )
+        }
+        {data.type === 'departure'
+          ? (
+            <DetailsBox label={t('movement.details.flight')}>
+              <MovementField label={t('movement.details.flightType')} value={getFlightTypeLabel(data.flightType)}/>
+              <MovementField label={t('movement.details.runway')} value={data.runway}/>
+              <MovementField label={t('movement.details.departureRoute')} value={getDepartureRouteLabel(data.departureRoute)}/>
+              <MovementField label={t('movement.details.routing')} value={newLineToBr(data.route)}/>
+              <MovementField label={t('movement.details.remarks')} value={newLineToBr(data.remarks)}/>
+            </DetailsBox>
+          ) : (
+            <DetailsBox label={t('movement.details.flight')}>
+              <MovementField label={t('movement.details.flightType')} value={getFlightTypeLabel(data.flightType)}/>
+              <MovementField label={t('movement.details.runway')} value={data.runway}/>
+              <MovementField label={t('movement.details.arrivalRoute')} value={getArrivalRouteLabel(data.arrivalRoute)}/>
+              <MovementField label={t('movement.details.remarks')} value={newLineToBr(data.remarks)}/>
+            </DetailsBox>
+          )
+        }
+        {data.type === 'arrival' && data.landingFeeTotal !== undefined && (
+          <DetailsBox label={t('movement.details.fees')}>
+            <MovementField label={t('movement.details.referenceNumber')} value={getFromItemKey(data.key)}/>
+            <MovementField label={t('movement.details.landingFee')} value={getLandingFee(data)}/>
+            {showPaymentMethod && (
+              <MovementField
+                label={t('movement.details.paymentMethod')}
+                value={data.paymentMethod && data.paymentMethod.status !== 'pending'
+                  ? getPaymentMethodLabel(data.paymentMethod, t)
+                  : <NoPaymentFieldValue arrivalId={data.key}/>}
+              />
+            )}
+          </DetailsBox>
+        )}
+      </Content>
+  );
+};
 
-(MovementDetails as any).propTypes = {
+MovementDetails.propTypes = {
   className: PropTypes.string,
   data: PropTypes.object.isRequired,
   locked: PropTypes.bool,
@@ -154,4 +146,4 @@ class MovementDetails extends React.PureComponent<any, any> {
   isAdmin: PropTypes.bool.isRequired
 };
 
-export default withTranslation()(MovementDetails);
+export default MovementDetails;

--- a/src/components/MovementList/MovementField.tsx
+++ b/src/components/MovementList/MovementField.tsx
@@ -20,28 +20,17 @@ const Value = styled.div<{ $hasValue?: boolean }>`
   ${props => !props.$hasValue && 'opacity: 0.5;'}
 `;
 
-class MovementField extends React.PureComponent<any, any> {
+const MovementField = ({ label, value, defaultValue = 'k.A.' }: any) => (
+  <Wrapper>
+    <Label>{label}</Label>
+    <Value $hasValue={!!value}>{value == null ? defaultValue : value}</Value>
+  </Wrapper>
+);
 
-  render() {
-    const props = this.props;
-
-    return (
-      <Wrapper>
-        <Label>{props.label}</Label>
-        <Value $hasValue={!!props.value}>{props.value == null ? props.defaultValue : props.value}</Value>
-      </Wrapper>
-    )
-  }
-}
-
-(MovementField as any).propTypes = {
+MovementField.propTypes = {
   label: PropTypes.string.isRequired,
   value: PropTypes.any,
   defaultValue: PropTypes.any,
-};
-
-(MovementField as any).defaultProps = {
-  defaultValue: 'k.A.'
 };
 
 export default MovementField;

--- a/src/components/MovementList/MovementGroup.tsx
+++ b/src/components/MovementList/MovementGroup.tsx
@@ -16,43 +16,43 @@ const GroupLabel = styled.div`
 const ItemsContainer = styled.div`
 `;
 
-class MovementGroup extends React.PureComponent<any, any> {
+const MovementGroup = ({
+  label, items, selected, onSelect, onEdit, timeWithDate,
+  createMovementFromMovement, onDelete, lockDate, aircraftSettings,
+  loading, isAdmin, predicate
+}: any) => {
+  const filteredItems = items.array.filter(predicate);
 
-  render() {
-    const props = this.props;
-    const filteredItems = props.items.array.filter(props.predicate);
-
-    if (filteredItems.length === 0) {
-      return null;
-    }
-
-    return (
-      <GroupWrapper>
-        <GroupLabel>{props.label}</GroupLabel>
-        <ItemsContainer>
-          {filteredItems.map(item =>
-            <Movement
-              key={item.key}
-              data={item}
-              selected={item.key === props.selected}
-              onSelect={props.onSelect}
-              onEdit={props.onEdit}
-              timeWithDate={props.timeWithDate}
-              createMovementFromMovement={props.createMovementFromMovement}
-              onDelete={props.onDelete}
-              locked={isLocked(item, props.lockDate) || item.anonymized === true}
-              aircraftSettings={props.aircraftSettings}
-              loading={props.loading}
-              isAdmin={props.isAdmin}
-            />
-          )}
-        </ItemsContainer>
-      </GroupWrapper>
-    );
+  if (filteredItems.length === 0) {
+    return null;
   }
-}
 
-(MovementGroup as any).propTypes = {
+  return (
+    <GroupWrapper>
+      <GroupLabel>{label}</GroupLabel>
+      <ItemsContainer>
+        {filteredItems.map(item =>
+          <Movement
+            key={item.key}
+            data={item}
+            selected={item.key === selected}
+            onSelect={onSelect}
+            onEdit={onEdit}
+            timeWithDate={timeWithDate}
+            createMovementFromMovement={createMovementFromMovement}
+            onDelete={onDelete}
+            locked={isLocked(item, lockDate) || item.anonymized === true}
+            aircraftSettings={aircraftSettings}
+            loading={loading}
+            isAdmin={isAdmin}
+          />
+        )}
+      </ItemsContainer>
+    </GroupWrapper>
+  );
+};
+
+MovementGroup.propTypes = {
   label: PropTypes.string,
   items: PropTypes.object.isRequired,
   selected: PropTypes.string,

--- a/src/components/MovementList/MovementHeader.tsx
+++ b/src/components/MovementList/MovementHeader.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import dates from '../../util/dates';
 import Action from './Action';
@@ -135,114 +135,109 @@ const StyledLockIcon = styled(MaterialIcon)`
   color: #666;
 `
 
-class MovementHeader extends React.PureComponent<any, any> {
+const MovementHeader = ({
+  data, selected, createMovementFromMovement, locked,
+  onClick, isHomeBase, isAdmin, timeWithDate
+}: any) => {
+  const { t } = useTranslation();
 
-  constructor(props) {
-    super(props);
-    this.handleActionClick = this.handleActionClick.bind(this);
-  }
+  const handleActionClick = () => {
+    createMovementFromMovement(data.type, data.key);
+  };
 
-  render() {
-    const props = this.props;
-    const { t } = this.props;
+  const date = timeWithDate === true
+    ? dates.formatDate(data.date)
+    : null;
+  const time = dates.formatTime(data.date, data.time);
 
-    const date = props.timeWithDate === true
-      ? dates.formatDate(props.data.date)
-      : null;
-    const time = dates.formatTime(props.data.date, props.data.time);
+  const showPayment = (isHomeBase === false || __CONF__.homebasePayment)
+  const paymentMissing = showPayment
+    && data.type === 'arrival'
+    && data.landingFeeTotal !== undefined
+    && (!data.paymentMethod || data.paymentMethod.status === 'pending')
+  const hasTags = paymentMissing
 
-    const showPayment = (props.isHomeBase === false || __CONF__.homebasePayment)
-    const paymentMissing = showPayment
-      && props.data.type === 'arrival'
-      && props.data.landingFeeTotal !== undefined
-      && (!props.data.paymentMethod || props.data.paymentMethod.status === 'pending')
-    const hasTags = paymentMissing
-
-    return (
-      <Wrapper
-        onClick={props.onClick}
-        selected={props.selected}
-        $locked={props.locked}>
-        <ColumnsWrapper
-          $hasAssociatedMovement={
-            props.data.associatedMovement
-            && ['departure', 'arrival'].includes(props.data.associatedMovement.type)
-          }
-        >
-          <Column className="type">
-            <div style={{ position: 'relative', display: 'inline-block' }}>
-              <StyledMovementTypeIcon
-                icon={TYPE_LABELS[props.data.type].icon}
-                size={ICON_HEIGHT}
-                title={TYPE_LABELS[props.data.type].label}
-                $locked={props.locked}
+  return (
+    <Wrapper
+      onClick={onClick}
+      selected={selected}
+      $locked={locked}>
+      <ColumnsWrapper
+        $hasAssociatedMovement={
+          data.associatedMovement
+          && ['departure', 'arrival'].includes(data.associatedMovement.type)
+        }
+      >
+        <Column className="type">
+          <div style={{ position: 'relative', display: 'inline-block' }}>
+            <StyledMovementTypeIcon
+              icon={TYPE_LABELS[data.type].icon}
+              size={ICON_HEIGHT}
+              title={TYPE_LABELS[data.type].label}
+              $locked={locked}
+            />
+            {locked && (
+              <StyledLockIcon
+                icon="lock"
+                size={14}
+                title={t('movement.locked')}
               />
-              {props.locked && (
-                <StyledLockIcon
-                  icon="lock"
-                  size={14}
-                  title={t('movement.locked')}
-                />
-              )}
-            </div>
-          </Column>
-          <Column className="immatriculation" $alignMiddle>{props.data.immatriculation}</Column>
-          <Column className="homebase" $alignMiddle>
-            <HomeBaseIcon isHomeBase={props.isHomeBase}/>
-          </Column>
-          <Column className="aircraftType" $alignMiddle>
-            <AircraftTypeIcon aircraftCategory={props.data.aircraftCategory} mtow={props.data.mtow}/>
-          </Column>
-          <Column className="pilot" $alignMiddle>{props.data.lastname}</Column>
-          <Column className="datetime" $alignMiddle>
-            {date ? (<div style={{lineHeight: '1.1'}}>
-              <div style={{fontSize: '0.90em', color: '#666'}}>{date}</div>
+            )}
+          </div>
+        </Column>
+        <Column className="immatriculation" $alignMiddle>{data.immatriculation}</Column>
+        <Column className="homebase" $alignMiddle>
+          <HomeBaseIcon isHomeBase={isHomeBase}/>
+        </Column>
+        <Column className="aircraftType" $alignMiddle>
+          <AircraftTypeIcon aircraftCategory={data.aircraftCategory} mtow={data.mtow}/>
+        </Column>
+        <Column className="pilot" $alignMiddle>{data.lastname}</Column>
+        <Column className="datetime" $alignMiddle>
+          {date ? (<div style={{lineHeight: '1.1'}}>
+            <div style={{fontSize: '0.90em', color: '#666'}}>{date}</div>
+            <div>{time}</div>
+          </div>) : (
+            <div>
               <div>{time}</div>
-            </div>) : (
-              <div>
-                <div>{time}</div>
-              </div>
-            )}
-          </Column>
-          <Column className="location" $alignMiddle>{formatLocationDisplay(props.data)}</Column>
-          <ActionColumn className="action" $alignMiddle $highlight>
-            {props.data.associatedMovement && props.data.associatedMovement.type === 'none' ? (
-              <Action
-                label={ACTION_LABELS[props.data.type].label}
-                icon={ACTION_LABELS[props.data.type].icon}
-                onClick={this.handleActionClick}
-                responsive
-              />
-            ) : props.data.associatedMovement === null
-              ? <MaterialIcon icon="sync" rotate="left"/> // show rotating icon if `associatedMovement` is null (= state where the associated movement is being monitored, but not set yet)
-              : null // if `associatedMovement` is undefined, we don't want to show anything (= state before the associated movement is even being monitored)
-            }
-          </ActionColumn>
-        </ColumnsWrapper>
-        {hasTags && (
-          <TagsWrapper>
-            {props.isAdmin && paymentMissing && (
-              <NoPaymentTag/>
-            )}
-          </TagsWrapper>
-        )}
-      </Wrapper>
-    );
-  }
+            </div>
+          )}
+        </Column>
+        <Column className="location" $alignMiddle>{formatLocationDisplay(data)}</Column>
+        <ActionColumn className="action" $alignMiddle $highlight>
+          {data.associatedMovement && data.associatedMovement.type === 'none' ? (
+            <Action
+              label={ACTION_LABELS[data.type].label}
+              icon={ACTION_LABELS[data.type].icon}
+              onClick={handleActionClick}
+              responsive
+            />
+          ) : data.associatedMovement === null
+            ? <MaterialIcon icon="sync" rotate="left"/> // show rotating icon if `associatedMovement` is null (= state where the associated movement is being monitored, but not set yet)
+            : null // if `associatedMovement` is undefined, we don't want to show anything (= state before the associated movement is even being monitored)
+          }
+        </ActionColumn>
+      </ColumnsWrapper>
+      {hasTags && (
+        <TagsWrapper>
+          {isAdmin && paymentMissing && (
+            <NoPaymentTag/>
+          )}
+        </TagsWrapper>
+      )}
+    </Wrapper>
+  );
+};
 
-  handleActionClick() {
-    this.props.createMovementFromMovement(this.props.data.type, this.props.data.key);
-  }
-}
-
-(MovementHeader as any).propTypes = {
+MovementHeader.propTypes = {
   data: PropTypes.object.isRequired,
   selected: PropTypes.bool,
   createMovementFromMovement: PropTypes.func.isRequired,
   locked: PropTypes.bool,
   onClick: PropTypes.func,
   isHomeBase: PropTypes.bool.isRequired,
-  isAdmin: PropTypes.bool.isRequired
+  isAdmin: PropTypes.bool.isRequired,
+  timeWithDate: PropTypes.bool
 };
 
-export default withTranslation()(MovementHeader);
+export default MovementHeader;

--- a/src/components/StartPage/EntryPoints.tsx
+++ b/src/components/StartPage/EntryPoints.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import ImageButton from '../ImageButton';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 const departureImagePath = require('./ic_flight_takeoff_black_48dp_2x.png');
 const arrivalImagePath = require('./ic_flight_land_black_48dp_2x.png');
@@ -27,37 +27,34 @@ const EntryPoint = styled(ImageButton)`
   }
 `;
 
-class EntryPoints extends React.PureComponent<any, any> {
-
-  render() {
-    const { t } = this.props;
-    if (this.props.guest === true || this.props.kiosk === true) {
-      return (
-        <Wrapper>
-          <EntryPoint img={departureImagePath} label={t('nav.departure')} href="/departure/new" dataCy="new-departure"/>
-          <EntryPoint img={arrivalImagePath} label={t('nav.arrival')} href="/arrival/new" dataCy="new-arrival"/>
-          <EntryPoint img={helpImagePath} label={t('nav.help')} href="/help" dataCy="help"/>
-        </Wrapper>
-      );
-    }
-
+const EntryPoints = ({ admin, guest, kiosk }: any) => {
+  const { t } = useTranslation();
+  if (guest === true || kiosk === true) {
     return (
       <Wrapper>
         <EntryPoint img={departureImagePath} label={t('nav.departure')} href="/departure/new" dataCy="new-departure"/>
         <EntryPoint img={arrivalImagePath} label={t('nav.arrival')} href="/arrival/new" dataCy="new-arrival"/>
-        <EntryPoint img={movementsImagePath} label={t('nav.movements')} href="/movements" dataCy="movements"/>
-        <EntryPoint img={messageImagePath} label={t('nav.message')} href="/message" dataCy="message"/>
         <EntryPoint img={helpImagePath} label={t('nav.help')} href="/help" dataCy="help"/>
-        {this.props.admin === true && <EntryPoint img={adminImagePath} label={t('nav.admin')} href="/admin" dataCy="admin"/>}
       </Wrapper>
     );
   }
-}
 
-(EntryPoints as any).propTypes = {
+  return (
+    <Wrapper>
+      <EntryPoint img={departureImagePath} label={t('nav.departure')} href="/departure/new" dataCy="new-departure"/>
+      <EntryPoint img={arrivalImagePath} label={t('nav.arrival')} href="/arrival/new" dataCy="new-arrival"/>
+      <EntryPoint img={movementsImagePath} label={t('nav.movements')} href="/movements" dataCy="movements"/>
+      <EntryPoint img={messageImagePath} label={t('nav.message')} href="/message" dataCy="message"/>
+      <EntryPoint img={helpImagePath} label={t('nav.help')} href="/help" dataCy="help"/>
+      {admin === true && <EntryPoint img={adminImagePath} label={t('nav.admin')} href="/admin" dataCy="admin"/>}
+    </Wrapper>
+  );
+};
+
+EntryPoints.propTypes = {
   admin: PropTypes.bool,
   guest: PropTypes.bool,
   kiosk: PropTypes.bool,
 };
 
-export default withTranslation()(EntryPoints);
+export default EntryPoints;

--- a/src/components/StartPage/Header.tsx
+++ b/src/components/StartPage/Header.tsx
@@ -47,29 +47,23 @@ const StyledAerodromeName = styled.div`
   color: #666;
 `
 
-class Header extends React.PureComponent<any, any> {
+const Header = ({ auth, logout, showLogin }: any) => (
+  <StyledHeader>
+    <StyledTopRight>
+      <LanguageSwitch/>
+      <LoginInfo logout={logout} auth={auth} showLogin={showLogin}/>
+    </StyledTopRight>
+    <StyledLogoWrapper>
+      <StyledLogo/>
+      <StyledTitle>
+        <StyledFlightboxLabel>Flightbox</StyledFlightboxLabel>
+        <StyledAerodromeName>{__CONF__.aerodrome.name}</StyledAerodromeName>
+      </StyledTitle>
+    </StyledLogoWrapper>
+  </StyledHeader>
+);
 
-  render() {
-    const props = this.props;
-    return (
-      <StyledHeader>
-        <StyledTopRight>
-          <LanguageSwitch/>
-          <LoginInfo logout={props.logout} auth={props.auth} showLogin={props.showLogin}/>
-        </StyledTopRight>
-        <StyledLogoWrapper>
-          <StyledLogo/>
-          <StyledTitle>
-            <StyledFlightboxLabel>Flightbox</StyledFlightboxLabel>
-            <StyledAerodromeName>{__CONF__.aerodrome.name}</StyledAerodromeName>
-          </StyledTitle>
-        </StyledLogoWrapper>
-      </StyledHeader>
-    );
-  }
-}
-
-(Header as any).propTypes = {
+Header.propTypes = {
   auth: PropTypes.object.isRequired,
   logout: PropTypes.func.isRequired,
   showLogin: PropTypes.func.isRequired,

--- a/src/components/StartPage/Hints.tsx
+++ b/src/components/StartPage/Hints.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import {Link} from 'react-router-dom';
 import PropTypes from 'prop-types'
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 const Wrapper = styled.div`
   border-radius: 10px;
@@ -39,26 +39,23 @@ const StyledLink = styled(Link)`
   text-decoration: underline;
 `;
 
-class Hints extends React.PureComponent<any, any> {
+const Hints = ({ guest, kiosk }: any) => {
+  const { t } = useTranslation();
+  return (
+    <Wrapper>
+      <ul>
+        <Hint>{t('hints.departureBeforeStart_pre')} <Strong>{t('hints.departureBeforeStart_text')}</Strong>.</Hint>
+        <Hint>{t('hints.arrivalAfterLanding_pre')} <Strong>{t('hints.arrivalAfterLanding_text')}</Strong>.</Hint>
+        {guest !== true && kiosk !== true && (<Hint>{t('hints.associatedMovement_pre')} <I>{t('hints.recordArrival')}</I> {t('hints.associatedMovement_mid')} <I>{t('hints.recordDeparture')}</I>{t('hints.associatedMovement_post')} <StyledLink to="/movements">{t('hints.recordedMovement')}</StyledLink>.
+        </Hint>)}
+      </ul>
+    </Wrapper>
+  );
+};
 
-  render() {
-    const { t } = this.props;
-    return (
-      <Wrapper>
-        <ul>
-          <Hint>{t('hints.departureBeforeStart_pre')} <Strong>{t('hints.departureBeforeStart_text')}</Strong>.</Hint>
-          <Hint>{t('hints.arrivalAfterLanding_pre')} <Strong>{t('hints.arrivalAfterLanding_text')}</Strong>.</Hint>
-          {this.props.guest !== true && this.props.kiosk !== true && (<Hint>{t('hints.associatedMovement_pre')} <I>{t('hints.recordArrival')}</I> {t('hints.associatedMovement_mid')} <I>{t('hints.recordDeparture')}</I>{t('hints.associatedMovement_post')} <StyledLink to="/movements">{t('hints.recordedMovement')}</StyledLink>.
-          </Hint>)}
-        </ul>
-      </Wrapper>
-    );
-  }
-}
-
-(Hints as any).propTypes = {
+Hints.propTypes = {
   guest: PropTypes.bool,
   kiosk: PropTypes.bool
 }
 
-export default withTranslation()(Hints);
+export default Hints;

--- a/src/components/StartPage/Main.tsx
+++ b/src/components/StartPage/Main.tsx
@@ -9,20 +9,15 @@ const Wrapper = styled.div`
   padding-top: 100px;
 `;
 
-class Main extends React.PureComponent<any, any> {
+const Main = ({ auth }: any) => (
+  <Wrapper>
+    <Hints guest={auth.data.guest} kiosk={auth.data.kiosk}/>
+    <EntryPoints admin={auth.data.admin} guest={auth.data.guest} kiosk={auth.data.kiosk}/>
+    <InstallCard authData={auth.data} />
+  </Wrapper>
+);
 
-  render() {
-    return (
-      <Wrapper>
-        <Hints guest={this.props.auth.data.guest} kiosk={this.props.auth.data.kiosk}/>
-        <EntryPoints admin={this.props.auth.data.admin} guest={this.props.auth.data.guest} kiosk={this.props.auth.data.kiosk}/>
-        <InstallCard authData={this.props.auth.data} />
-      </Wrapper>
-    );
-  }
-}
-
-(Main as any).propTypes = {
+Main.propTypes = {
   auth: PropTypes.shape({
     data: PropTypes.shape({
       admin: PropTypes.bool,

--- a/src/components/WizardBreadcrumbs/WizardBreadcrumbs.tsx
+++ b/src/components/WizardBreadcrumbs/WizardBreadcrumbs.tsx
@@ -86,30 +86,24 @@ const Text = styled.div<{ $active?: boolean }>`
   }
 `;
 
-class WizardBreadcrumbs extends React.PureComponent<any, any> {
+const WizardBreadcrumbs = ({ title, items, activeItem }: any) => (
+  <Wrapper>
+    {title && <Title>{title}</Title>}
+    <List>
+      {items.map((item, index) => {
+        const active = index === activeItem;
+        return (
+          <Item key={index}>
+            <Number $active={active} $first={index === 0}>{index + 1}</Number>
+            <Text $active={active}>{item.label.replace(/ /g, '\u00a0')}</Text>
+          </Item>
+        );
+      })}
+    </List>
+  </Wrapper>
+);
 
-  render() {
-    const props = this.props;
-    return (
-      <Wrapper>
-        {props.title && <Title>{props.title}</Title>}
-        <List>
-          {props.items.map((item, index) => {
-            const active = index === props.activeItem;
-            return (
-              <Item key={index}>
-                <Number $active={active} $first={index === 0}>{index + 1}</Number>
-                <Text $active={active}>{item.label.replace(/ /g, '\u00a0')}</Text>
-              </Item>
-            );
-          })}
-        </List>
-      </Wrapper>
-    );
-  }
-}
-
-(WizardBreadcrumbs as any).propTypes = {
+WizardBreadcrumbs.propTypes = {
   title: PropTypes.string,
   items: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/WizardNavigation/WizardNavigation.tsx
+++ b/src/components/WizardNavigation/WizardNavigation.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import Button from '../Button';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 const Wrapper = styled.div`
   padding: 10px 20px 10px 20px;
@@ -31,42 +31,46 @@ export const CancelButton = styled(WizardButton)`
   }
 `;
 
-class WizardNavigation extends React.PureComponent<any, any> {
+const WizardNavigation = ({
+  previousStep,
+  nextStep,
+  nextLabel,
+  nextVisible = true,
+  previousVisible = true,
+  cancel
+}: any) => {
+  const { t } = useTranslation();
+  return (
+    <Wrapper>
+      {nextVisible && (
+        <NextButton
+          type="submit"
+          label={nextLabel || t('wizard.next')}
+          icon="navigate_next"
+          onClick={nextStep}
+          dataCy="next-button"
+          primary
+        />
+      )}
+      {previousVisible && (
+        <BackButton
+          type="button"
+          label={t('wizard.back')}
+          onClick={previousStep}
+        />
+      )}
+      {cancel && (
+        <CancelButton
+          type="button"
+          label={t('wizard.cancel')}
+          onClick={cancel}
+        />
+      )}
+    </Wrapper>
+  );
+};
 
-  render() {
-    const props = this.props;
-    const { t } = this.props;
-    return (
-      <Wrapper>
-        {props.nextVisible && (
-          <NextButton
-            type="submit"
-            label={props.nextLabel || t('wizard.next')}
-            icon="navigate_next"
-            onClick={props.nextStep}
-            dataCy="next-button"
-            primary
-          />
-        )}
-        {props.previousVisible && (
-          <BackButton
-            type="button"
-            label={t('wizard.back')}
-            onClick={props.previousStep}
-          />
-        )}
-        {props.cancel && (
-          <CancelButton
-            type="button"
-            label={t('wizard.cancel')}
-            onClick={props.cancel}
-          />
-        )}
-      </Wrapper>)
-  }
-}
-
-(WizardNavigation as any).propTypes = {
+WizardNavigation.propTypes = {
   previousStep: PropTypes.func,
   nextStep: PropTypes.func,
   nextLabel: PropTypes.string,
@@ -75,9 +79,4 @@ class WizardNavigation extends React.PureComponent<any, any> {
   cancel: PropTypes.func
 };
 
-(WizardNavigation as any).defaultProps = {
-  nextVisible: true,
-  previousVisible: true
-};
-
-export default withTranslation()(WizardNavigation);
+export default WizardNavigation;

--- a/src/components/wizards/FieldSet.tsx
+++ b/src/components/wizards/FieldSet.tsx
@@ -12,25 +12,14 @@ const Legend = styled.legend`
   margin-bottom: 1em;
 `;
 
-class FieldSet extends React.PureComponent<any, any> {
+const FieldSet = ({ legend, gutter = true, children }: any) => (
+  <Wrapper $gutter={gutter}>
+    {legend && <Legend>{legend}</Legend>}
+    {children}
+  </Wrapper>
+);
 
-  render() {
-    const props = this.props;
-    return (
-      <Wrapper $gutter={props.gutter}>
-        {props.legend && <Legend>{props.legend}</Legend>}
-        {props.children}
-      </Wrapper>
-    );
-  }
-}
-
-const FieldSetAny = FieldSet as any;
-FieldSetAny.defaultProps = {
-  gutter: true
-};
-
-FieldSetAny.propTypes = {
+FieldSet.propTypes = {
   legend: PropTypes.string,
   gutter: PropTypes.bool,
   children: PropTypes.oneOfType([


### PR DESCRIPTION
## Summary
- Convert 20 PureComponent classes to functional arrow components
- Replace `withTranslation()` HOC with `useTranslation()` hook (8 components)
- Replace `defaultProps` with default parameter values (5 components)
- Add missing `children` propType to DetailsBox and `timeWithDate` propType to MovementHeader (previously hidden by `<any, any>` generic)
- Add `jest.mock('react-i18next')` to HomeBaseIcon test

**Converted components:** ValidationMessage, DetailsBox, Main, MaterialIcon, MovementField, FieldSet, ImageButton, WizardNavigation, WizardBreadcrumbs, JumpNavigation, HomeBaseIcon, Header, EntryPoints, Hints, MovementGroup, MovementDetails, Action, MovementHeader

No `React.memo` added — these are simple presentational components where shallow comparison overhead outweighs render cost.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — all 1738 tests pass, snapshots unchanged
- [ ] Cypress E2E