### PR TITLE
Fix wizard crash on double-submit with async predicate

### DIFF
--- a/src/components/wizards/MovementWizard.tsx
+++ b/src/components/wizards/MovementWizard.tsx
@@ -135,7 +135,7 @@ class MovementWizard extends Component<any, any> {
       return;
     }
 
-    dialogConf.predicate(data).then(show => {
+    return dialogConf.predicate(data).then(show => {
       if (show === true) {
         this.props.showDialog(dialogConf.name);
       } else {


### PR DESCRIPTION
## Summary
- `submitPage` in `MovementWizard` did not return the dialog predicate promise, so react-final-form considered the submission instantly complete and accepted re-submissions
- Two rapid submits on page 4 (DepartureArrivalPage) launched two async `aerodromeExists` lookups that both resolved and dispatched `nextPage`, pushing `wizard.page` past the pages array bounds → `TypeError: Cannot read properties of undefined (reading 'component')`
- Fix: return the promise so react-final-form blocks re-submission while the predicate is in flight

Fixes JAVASCRIPT-REACT-5C, JAVASCRIPT-REACT-50, JAVASCRIPT-REACT-5A, JAVASCRIPT-REACT-58, JAVASCRIPT-REACT-55, JAVASCRIPT-REACT-52

## Test plan
- [x] Reproduced crash locally by adding 500ms delay to `aerodromeExists` and double-clicking Next on page 4
- [x] Verified fix: same double-click with delay no longer crashes
- [x] `npm run typecheck` passes
- [x] All 39 wizard tests pass