### PR TITLE
Lower jet icon MTOW threshold to 2250 kg

### DIFF
--- a/src/components/AircraftTypeIcon/index.spec.tsx
+++ b/src/components/AircraftTypeIcon/index.spec.tsx
@@ -1,0 +1,39 @@
+import {getIconName} from './index';
+
+describe('components', () => {
+  describe('AircraftTypeIcon', () => {
+    describe('getIconName', () => {
+      it('returns plane for unknown category with no mtow', () => {
+        expect(getIconName(null, undefined)).toBe('plane');
+      });
+
+      it('returns helicopter for helicopter category regardless of mtow', () => {
+        expect(getIconName('Hubschrauber', 5000)).toBe('helicopter');
+      });
+
+      it('returns plane for mtow below jet threshold', () => {
+        expect(getIconName(null, 2249)).toBe('plane');
+      });
+
+      it('returns jet for mtow exactly at jet threshold (2250)', () => {
+        expect(getIconName(null, 2250)).toBe('jet');
+      });
+
+      it('returns jet for mtow above jet threshold', () => {
+        expect(getIconName(null, 5700)).toBe('jet');
+      });
+
+      it('overrides plane category with jet when mtow >= threshold', () => {
+        expect(getIconName('Flugzeug', 3000)).toBe('jet');
+      });
+
+      it('keeps plane category below threshold', () => {
+        expect(getIconName('Flugzeug', 1500)).toBe('plane');
+      });
+
+      it('keeps glider category regardless of mtow', () => {
+        expect(getIconName('Segelflugzeug', 3000)).toBe('glider');
+      });
+    });
+  });
+});

--- a/src/components/AircraftTypeIcon/index.tsx
+++ b/src/components/AircraftTypeIcon/index.tsx
@@ -24,12 +24,12 @@ const ICON_MAP = {
   glider,
 }
 
-const JET_MTOW = 2550
+const JET_MTOW = 2250
 
-const getIconName = (aircraftCategory, mtow) => {
+export const getIconName = (aircraftCategory, mtow) => {
   let iconName = aircraftCategoryIcon(aircraftCategory)
 
-  if ((!iconName || iconName === 'plane') && mtow > JET_MTOW) {
+  if ((!iconName || iconName === 'plane') && mtow >= JET_MTOW) {
     iconName = 'jet'
   }
 


### PR DESCRIPTION
## Summary
- Aircraft with MTOW >= 2250 kg are now classified as jets and shown with the jet icon (was > 2550 kg).
- Exported `getIconName` as a named export to enable direct unit testing of the threshold logic.
- Added 8 unit tests covering threshold boundary (2249/2250/5700), helicopter/glider passthrough, and plane→jet override.

## Test plan
- [x] `npm test` — all 1746 tests pass
- [x] `npm run typecheck` — no TypeScript errors
- [ ] Visually verify in movement list that an aircraft with MTOW between 2250 and 2550 now shows the jet icon