### PR TITLE
Update minor/patch dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "dependencies": {
         "date-fns": "^4.1.0",
         "final-form": "^5.0.0",
-        "i18next": "^26.0.4",
+        "i18next": "^26.0.5",
         "process": "^0.11.10",
         "react-final-form": "^7.0.0",
-        "react-i18next": "^17.0.2"
+        "react-i18next": "^17.0.3"
       },
       "devDependencies": {
         "@babel/cli": "^7.2.3",
@@ -22,7 +22,7 @@
         "@babel/preset-react": "^7.0.0",
         "@babel/preset-typescript": "^7.0.0",
         "@babel/runtime": "^7.3.1",
-        "@sentry/react": "^10.41.0",
+        "@sentry/react": "^10.48.0",
         "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -43,7 +43,7 @@
         "csv-stringify": "^6.6.0",
         "cypress": "^15.13.1",
         "del": "^8.0.1",
-        "firebase": "^12.10.0",
+        "firebase": "^12.12.0",
         "gulp": "^5.0.1",
         "gulp-env": "~0.4.0",
         "gulp-rename": "^2.1.0",
@@ -68,13 +68,13 @@
         "redux": "^5.0.1",
         "redux-saga": "^1.4.2",
         "scroll-into-view": "^1.16.2",
-        "start-server-and-test": "^3.0.0",
+        "start-server-and-test": "^3.0.2",
         "stream-browserify": "^3.0.0",
         "style-loader": "^4.0.0",
-        "styled-components": "^6.3.11",
+        "styled-components": "^6.4.0",
         "typescript": "^6.0.2",
         "util": "^0.12.5",
-        "webpack": "^5.106.0",
+        "webpack": "^5.106.2",
         "webpack-cli": "^7.0.2",
         "webpack-dev-server": "^5.2.2",
         "webpack-stream": "^7.0.0",
@@ -2344,17 +2344,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@firebase/ai": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.10.0.tgz",
-      "integrity": "sha512-1lI6HomyoO/8RSJb6ItyHLpHnB2z27m5F4aX/Vpi1nhwWoxdNjkq+6UQOykHyCE0KairojOE5qQ20i1tnF0nNA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.11.0.tgz",
+      "integrity": "sha512-+oqOne/h5J51LezazR+VyzKe3AK455W29JXnb4jOeVvQhC7FymledN5+XE+w5vEcMhRQ6n1f62fdGs4A44X32A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2435,9 +2428,9 @@
       "license": "0BSD"
     },
     "node_modules/@firebase/app": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.10.tgz",
-      "integrity": "sha512-PlPhdtjgWUra+LImQTnXOUqUa/jcufZhizdR93ZjlQSS3ahCtDTG6pJw7j0OwFal18DQjICXfeVNsUUrcNisfA==",
+      "version": "0.14.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.11.tgz",
+      "integrity": "sha512-yxADFW35LYkP8oSGobGsYIrI42I+GPCvKTNHx4meT9Yq3C950IVz1eANoBk822I9tbKv1wyv9P4Bv1G5TpucFw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2520,13 +2513,13 @@
       "license": "0BSD"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.10.tgz",
-      "integrity": "sha512-tFmBuZL0/v1h6eyKRgWI58ucft6dEJmAi9nhPUXoAW4ZbPSTlnsh31AuEwUoRTz+wwRk9gmgss9GZV05ZM9Kug==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.11.tgz",
+      "integrity": "sha512-KaACDjXkK5VLpI01vEs592R7/8s5DjFdIXfKoR385ly1SmK3Tu+jMHCIB4MsiY5jsez6v7VlEX/3rJ90dVkHyA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app": "0.14.10",
+        "@firebase/app": "0.14.11",
         "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
         "@firebase/util": "1.15.0",
@@ -2544,11 +2537,14 @@
       "license": "0BSD"
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
-      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.4.tgz",
+      "integrity": "sha512-crX9TA5SVYZwLPG7/R16IsH8FLlgkPXjJUVhsVpHVDSqJiq3D/NuFTM5ctxGTExXAOeIn//69tQw47CPerM8MQ==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.0"
+      }
     },
     "node_modules/@firebase/app/node_modules/tslib": {
       "version": "2.8.1",
@@ -2558,9 +2554,9 @@
       "license": "0BSD"
     },
     "node_modules/@firebase/auth": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.12.2.tgz",
-      "integrity": "sha512-CZJL8V10Vzibs+pDTXdQF+hot1IigIoqF4a4lA/qr5Deo1srcefiyIfgg28B67Lk7IxZhwfJMuI+1bu2xBmV0A==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.0.tgz",
+      "integrity": "sha512-mKkSLNym3UbnnZ06dAmtqzp5EpPGCANGCZDJbkoR135aoUdKG6Aizwcnp29RzsQpwH0nmy5nay17Sfbsh9oY8A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2574,7 +2570,7 @@
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
-        "@react-native-async-storage/async-storage": "^2.2.0"
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
       },
       "peerDependenciesMeta": {
         "@react-native-async-storage/async-storage": {
@@ -2583,13 +2579,13 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.4.tgz",
-      "integrity": "sha512-2pj8m/hnqXvMLfC0Mk+fORVTM5DQPkS6l8JpMgtoAWGVgCmYnoWdFMaNWtKbmCxBEyvMA3FlnCJyzrUSMWTfuA==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.5.tgz",
+      "integrity": "sha512-IfVsafZ3QiXbsydXTP/XMI0wVYbJLI1rkb8Qqf03/h5FnL+upbbPOb+6Yj3RpcX+Y1iP5Uh18lxTHlXfbiyAow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "1.12.2",
+        "@firebase/auth": "1.13.0",
         "@firebase/auth-types": "0.13.0",
         "@firebase/component": "0.7.2",
         "@firebase/util": "1.15.0",
@@ -2656,9 +2652,9 @@
       "license": "0BSD"
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.5.0.tgz",
-      "integrity": "sha512-G3GYHpWNJJ95502RQLApzw0jaG3pScHl+J/2MdxIuB51xtHnkRL6KvIAP3fFF1drUewWJHOnDA1U+q4Evf3KSw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.6.0.tgz",
+      "integrity": "sha512-OiugPRcdlhqXF97oR9CjVObILmsWU0dFUS0gXNYEe4bDfpW8pZmQ5GqhIPPtLWbT/0W2lMJJD7VILFMk+xuHPg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2699,15 +2695,15 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.2.tgz",
-      "integrity": "sha512-j4A6IhVZbgxAzT6gJJC2PfOxYCK9SrDrUO7nTM4EscTYtKkAkzsbKoCnDdjFapQfnsncvPWjqVTr/0PffUwg3g==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.3.tgz",
+      "integrity": "sha512-GMyfWjD8mehjg/QpNkY/tl9G/MoeugPeg91n9D0atggxbWuKF/2KhVPHZDH+XmoP0EKYqMWYTtKxBsaBaNKLYQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.7.2",
         "@firebase/database": "1.1.2",
-        "@firebase/database-types": "1.0.18",
+        "@firebase/database-types": "1.0.19",
         "@firebase/logger": "0.5.0",
         "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
@@ -2724,13 +2720,13 @@
       "license": "0BSD"
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.18.tgz",
-      "integrity": "sha512-yOY8IC2go9lfbVDMiy2ATun4EB2AFwocPaQADwMN/RHRUAZSM4rlAV7PGbWPSG/YhkJ2A9xQAiAENgSua9G5Fg==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.19.tgz",
+      "integrity": "sha512-FqewjUZmV9LqFfuEnmgdcUpiOUz7qwLXxnm/H8BcMFEzQXtd1yyUDm8ex5VRad2nuTE+ahOuCjUAM/cyDncO+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-types": "0.9.3",
+        "@firebase/app-types": "0.9.4",
         "@firebase/util": "1.15.0"
       }
     },
@@ -2742,9 +2738,9 @@
       "license": "0BSD"
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.13.0.tgz",
-      "integrity": "sha512-7i4cVNJXTMim7/P7UsNim0DwyLPk4QQ3y1oSNzv4l0ykJOKYCiFMOuEeUxUYvrReXDJxWHrT/4XMeVQm+13rRw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.0.tgz",
+      "integrity": "sha512-bZc6YOjRkMBVA16527tgzi6iN9n//xRB3Mmx/R+Gr6UAP/+xrIKOejQIcn1hh+tCzNT8jO0jI+kWox5J4tB/qQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2764,14 +2760,14 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.7.tgz",
-      "integrity": "sha512-Et4XxtGnjp0Q9tmaEMETnY5GHJ8gQ9+RN6sSTT4ETWKmym2d6gIjarw0rCQcx+7BrWVYLEIOAXSXysl0b3xnUA==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.8.tgz",
+      "integrity": "sha512-WK9NJRpnosGD2nuyjdr7K+Ht7AxRYJlTF62myI4rRA7ibJOosbecvjacR5oirJ7s1BgNS6qzcBw7n4fD3a5w1w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.7.2",
-        "@firebase/firestore": "4.13.0",
+        "@firebase/firestore": "4.14.0",
         "@firebase/firestore-types": "3.0.3",
         "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
@@ -5137,80 +5133,80 @@
       "license": "MIT"
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.47.0.tgz",
-      "integrity": "sha512-bVFRAeJWMBcBCvJKIFCMJ1/yQToL4vPGqfmlnDZeypcxkqUDKQ/Y3ziLHXoDL2sx0lagcgU2vH1QhCQ67Aujjw==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.48.0.tgz",
+      "integrity": "sha512-SCiTLBXzugFKxev6NoKYBIhQoDk0gUh0AVVVepCBqfCJiWBG01Zvv0R5tCVohr4cWRllkQ8mlBdNQd/I7s9tdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.47.0"
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.47.0.tgz",
-      "integrity": "sha512-pdvMmi4dQpX5S/vAAzrhHPIw3T3HjUgDNgUiCBrlp7N9/6zGO2gNPhUnNekP+CjgI/z0rvf49RLqlDenpNrMOg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.48.0.tgz",
+      "integrity": "sha512-tGkEyOM1HDS9qebDphUMEnyk3qq/50AnuTBiFmMJyjNzowylVGmRRk0sr3xkmbVHCDXQCiYnDmSVlJ2x4SDMrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.47.0"
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.47.0.tgz",
-      "integrity": "sha512-ScdovxP7hJxgMt70+7hFvwT02GIaIUAxdEM/YPsayZBeCoAukPW8WiwztJfoKtsfPyKJ5A6f0H3PIxTPcA9Row==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.48.0.tgz",
+      "integrity": "sha512-sevRTePfuk4PNuz9KAKpmTZEomAU0aLXyIhOwA0OnUDdxPhkY8kq5lwDbuxTHv6DQUjUX3YgFbY45VH1JEqHKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.47.0",
-        "@sentry/core": "10.47.0"
+        "@sentry-internal/browser-utils": "10.48.0",
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.47.0.tgz",
-      "integrity": "sha512-A5OY8friSe6g8WAK4L8IeOPiEd9D3Ps40DzRH5j2f6SUja0t90mKMvHRcRf8zq0d4BkdB+JM7tjOkwxpuv8heA==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.48.0.tgz",
+      "integrity": "sha512-9nWuN2z4O+iwbTfuYV5ZmngBgJU/ZxfOo47A5RJP3Nu/kl59aJ1lUhILYOKyeNOIC/JyeERmpIcTxnlPXQzZ3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.47.0",
-        "@sentry/core": "10.47.0"
+        "@sentry-internal/replay": "10.48.0",
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.47.0.tgz",
-      "integrity": "sha512-rC0agZdxKA5XWfL4VwPOr/rJMogXDqZgnVzr93YWpFn9DMZT/7LzxSJVPIJwRUjx3bFEby3PcTa3YaX7pxm1AA==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.48.0.tgz",
+      "integrity": "sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.47.0",
-        "@sentry-internal/feedback": "10.47.0",
-        "@sentry-internal/replay": "10.47.0",
-        "@sentry-internal/replay-canvas": "10.47.0",
-        "@sentry/core": "10.47.0"
+        "@sentry-internal/browser-utils": "10.48.0",
+        "@sentry-internal/feedback": "10.48.0",
+        "@sentry-internal/replay": "10.48.0",
+        "@sentry-internal/replay-canvas": "10.48.0",
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.47.0.tgz",
-      "integrity": "sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
+      "integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5218,14 +5214,14 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.47.0.tgz",
-      "integrity": "sha512-ZtJV6xxF8jUVE9e3YQUG3Do0XapG1GjniyLyqMPgN6cNvs/HaRJODf7m60By+VGqcl5XArEjEPTvx8CdPUXDfA==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.48.0.tgz",
+      "integrity": "sha512-uc93vKjmu6gNns+JAX4qquuxWpAMit0uGPA1TYlMjct9NG1uX3TkDPJAr9Pgd1lOXx8mKqCmj5fK33QeExMpPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.47.0",
-        "@sentry/core": "10.47.0"
+        "@sentry/browser": "10.48.0",
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
@@ -5925,13 +5921,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/stylis": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
-      "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7001,9 +6990,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10038,27 +10027,27 @@
       }
     },
     "node_modules/firebase": {
-      "version": "12.11.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.11.0.tgz",
-      "integrity": "sha512-W9f3Y+cgQYgF9gvCGxt0upec8zwAtiQVcHuU8MfzUIgVU/9fRQWtu48Geiv1lsigtBz9QHML++Km9xAKO5GB5Q==",
+      "version": "12.12.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.12.0.tgz",
+      "integrity": "sha512-5Ap+pN5iEJUvBlQEZEmLuUm7Gvu6I5xv1jZ5SiSNyw4jrwlHo+4tmZv3OPPoKfN9eo1kBwyyBvi+pWHIPXwfYw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "2.10.0",
+        "@firebase/ai": "2.11.0",
         "@firebase/analytics": "0.10.21",
         "@firebase/analytics-compat": "0.2.27",
-        "@firebase/app": "0.14.10",
+        "@firebase/app": "0.14.11",
         "@firebase/app-check": "0.11.2",
         "@firebase/app-check-compat": "0.4.2",
-        "@firebase/app-compat": "0.5.10",
-        "@firebase/app-types": "0.9.3",
-        "@firebase/auth": "1.12.2",
-        "@firebase/auth-compat": "0.6.4",
-        "@firebase/data-connect": "0.5.0",
+        "@firebase/app-compat": "0.5.11",
+        "@firebase/app-types": "0.9.4",
+        "@firebase/auth": "1.13.0",
+        "@firebase/auth-compat": "0.6.5",
+        "@firebase/data-connect": "0.6.0",
         "@firebase/database": "1.1.2",
-        "@firebase/database-compat": "2.1.2",
-        "@firebase/firestore": "4.13.0",
-        "@firebase/firestore-compat": "0.4.7",
+        "@firebase/database-compat": "2.1.3",
+        "@firebase/firestore": "4.14.0",
+        "@firebase/firestore-compat": "0.4.8",
         "@firebase/functions": "0.13.3",
         "@firebase/functions-compat": "0.4.3",
         "@firebase/installations": "0.6.21",
@@ -11592,9 +11581,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.0.4",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.4.tgz",
-      "integrity": "sha512-gXF7U9bfioXPLv7mw8Qt2nfO7vij5MyINvPgVv99pX3fL1Y01pw2mKBFrlYpRxRCl2wz3ISenj6VsMJT2isfuA==",
+      "version": "26.0.5",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.5.tgz",
+      "integrity": "sha512-9uHb4T27TdV36phJXcbpnRPt5yzAfqHXVrdASvmHZyPuZJtrLythd+GyXhiaHV5LlpuuskbAqhwPjmfTbKbi8w==",
       "funding": [
         {
           "type": "individual",
@@ -16057,9 +16046,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -16359,9 +16348,9 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.2.tgz",
-      "integrity": "sha512-shBftH2vaTWK2Bsp7FiL+cevx3xFJlvFxmsDFQSrJc+6twHkP0tv/bGa01VVWzpreUVVwU+3Hev5iFqRg65RwA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.3.tgz",
+      "integrity": "sha512-x4xjvUNZ56T+zfXWNedNnCET9Xq1IBYWX7IsWo5cCQ/RT+Rm7GWqt0h9PShFi4IhyMnsdiu1C6Jc4DE+/S3PFQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -17348,13 +17337,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -17691,20 +17673,20 @@
       }
     },
     "node_modules/start-server-and-test": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-3.0.0.tgz",
-      "integrity": "sha512-R//IdnWC+H+raB6zJIqw5QbIsMAjjYFwJC/OIJO6kgZljguYe4n4LlA7vkPTO7zoctFlVPfymsNShjcPOIH8nw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-3.0.2.tgz",
+      "integrity": "sha512-g6v4zPr1RRL5XxXJ+Wnk1GFLb+DGZLjFqse+5lNZ0X7m4SRMC6eOA+AXYboQDfNCEjpnTu0AGrvJb/JTUOg8dQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "arg": "^5.0.2",
+        "arg": "5.0.2",
         "bluebird": "3.7.2",
         "check-more-types": "2.24.0",
         "debug": "4.4.3",
         "execa": "5.1.1",
         "lazy-ass": "1.6.0",
         "tree-kill": "1.2.2",
-        "wait-on": "9.0.4"
+        "wait-on": "9.0.5"
       },
       "bin": {
         "server-test": "src/bin/start.js",
@@ -18106,21 +18088,16 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.12.tgz",
-      "integrity": "sha512-hFR6xsVkVYbsdcUlzPYFvFfoc6o2KlV0VvgRIQwSYMtdThM7SCxnjX9efh/cWce2kTq16I/Kl3xM98xiLptsXA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.0.tgz",
+      "integrity": "sha512-BL1EDFpt+q10eAeZB0q9ps6pSlPejaBQWBkiuM16pyoVTG4NhZrPrZK0cqNbrozxSsYwUsJ9SQYN6NyeKJYX9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
-        "@emotion/unitless": "0.10.0",
-        "@types/stylis": "4.2.7",
         "css-to-react-native": "3.2.0",
         "csstype": "3.2.3",
-        "postcss": "8.4.49",
-        "shallowequal": "1.1.0",
-        "stylis": "4.3.6",
-        "tslib": "2.8.1"
+        "stylis": "4.3.6"
       },
       "engines": {
         "node": ">= 16"
@@ -18130,50 +18107,22 @@
         "url": "https://opencollective.com/styled-components"
       },
       "peerDependencies": {
+        "css-to-react-native": ">= 3.2.0",
         "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
+        "react-dom": ">= 16.8.0",
+        "react-native": ">= 0.68.0"
       },
       "peerDependenciesMeta": {
+        "css-to-react-native": {
+          "optional": true
+        },
         "react-dom": {
+          "optional": true
+        },
+        "react-native": {
           "optional": true
         }
       }
-    },
-    "node_modules/styled-components/node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/styled-components/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/stylis": {
       "version": "4.3.6",
@@ -19479,15 +19428,15 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.4.tgz",
-      "integrity": "sha512-k8qrgfwrPVJXTeFY8tl6BxVHiclK11u72DVKhpybHfUL/K6KM4bdyK9EhIVYGytB5MJe/3lq4Tf0hrjM+pvJZQ==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.5.tgz",
+      "integrity": "sha512-qgnbHDfDTRIp73ANEJNRW/7kn8CrDUcvZz18xotJQku/P4saTGkbIzvnMZebPmVvVNUiRq1qWAPyqCH+W4H8KA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.13.5",
-        "joi": "^18.0.2",
-        "lodash": "^4.17.23",
+        "axios": "^1.15.0",
+        "joi": "^18.1.2",
+        "lodash": "^4.18.1",
         "minimist": "^1.2.8",
         "rxjs": "^7.8.2"
       },
@@ -19550,9 +19499,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.106.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.0.tgz",
-      "integrity": "sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA==",
+      "version": "5.106.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19572,9 +19521,8 @@
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
@@ -19861,6 +19809,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.0.0",
     "@babel/runtime": "^7.3.1",
-    "@sentry/react": "^10.41.0",
+    "@sentry/react": "^10.48.0",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -46,7 +46,7 @@
     "csv-stringify": "^6.6.0",
     "cypress": "^15.13.1",
     "del": "^8.0.1",
-    "firebase": "^12.10.0",
+    "firebase": "^12.12.0",
     "gulp": "^5.0.1",
     "gulp-env": "~0.4.0",
     "gulp-rename": "^2.1.0",
@@ -71,13 +71,13 @@
     "redux": "^5.0.1",
     "redux-saga": "^1.4.2",
     "scroll-into-view": "^1.16.2",
-    "start-server-and-test": "^3.0.0",
+    "start-server-and-test": "^3.0.2",
     "stream-browserify": "^3.0.0",
     "style-loader": "^4.0.0",
-    "styled-components": "^6.3.11",
+    "styled-components": "^6.4.0",
     "typescript": "^6.0.2",
     "util": "^0.12.5",
-    "webpack": "^5.106.0",
+    "webpack": "^5.106.2",
     "webpack-cli": "^7.0.2",
     "webpack-dev-server": "^5.2.2",
     "webpack-stream": "^7.0.0",
@@ -90,9 +90,9 @@
   "dependencies": {
     "date-fns": "^4.1.0",
     "final-form": "^5.0.0",
-    "i18next": "^26.0.4",
+    "i18next": "^26.0.5",
     "process": "^0.11.10",
     "react-final-form": "^7.0.0",
-    "react-i18next": "^17.0.2"
+    "react-i18next": "^17.0.3"
   }
 }

--- a/src/components/ImageButton/__snapshots__/ImageButton.spec.tsx.snap
+++ b/src/components/ImageButton/__snapshots__/ImageButton.spec.tsx.snap
@@ -3,14 +3,14 @@
 exports[`components ImageButton propagates href to OptionalLink 1`] = `
 <div>
   <div
-    class="sc-elDHXC gPeVyn"
+    class="sc-dlnkDq iIJZep"
   >
     <a
-      class="sc-brayMQ hPonWa"
+      class="sc-bdnAzI cAHJWl"
       href="/some/path"
     >
       <div
-        class="sc-fQpSrZ hGnagO"
+        class="sc-hKFxUR rTqsk"
       >
         <img
           src=""
@@ -24,13 +24,13 @@ exports[`components ImageButton propagates href to OptionalLink 1`] = `
 exports[`components ImageButton propagates onClick to OptionalLink 1`] = `
 <div>
   <div
-    class="sc-elDHXC gPeVyn"
+    class="sc-dlnkDq iIJZep"
   >
     <div
-      class="sc-gJhJfT fdCJqJ"
+      class="sc-gtstET eMrqxt"
     >
       <div
-        class="sc-fQpSrZ hGnagO"
+        class="sc-hKFxUR rTqsk"
       >
         <img
           src=""
@@ -44,13 +44,13 @@ exports[`components ImageButton propagates onClick to OptionalLink 1`] = `
 exports[`components ImageButton renders label and image 1`] = `
 <div>
   <div
-    class="sc-elDHXC gPeVyn"
+    class="sc-dlnkDq iIJZep"
   >
     <div
-      class="sc-gJhJfT fdCJqJ"
+      class="sc-gtstET eMrqxt"
     >
       <div
-        class="sc-fQpSrZ hGnagO"
+        class="sc-hKFxUR rTqsk"
       >
         <img
           src="imgsource.jpg"

--- a/src/components/ImageButton/__snapshots__/OptionalLink.spec.tsx.snap
+++ b/src/components/ImageButton/__snapshots__/OptionalLink.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components ImageButton OptionalLink renders Link component if \`href\` prop is set 1`] = `
 <div>
   <a
-    class="sc-brayMQ hPonWa"
+    class="sc-bdnAzI cAHJWl"
     href="/some/path"
   />
 </div>
@@ -12,7 +12,7 @@ exports[`components ImageButton OptionalLink renders Link component if \`href\` 
 exports[`components ImageButton OptionalLink renders no Link component if \`href\` prop is not set 1`] = `
 <div>
   <div
-    class="sc-gJhJfT fdCJqJ"
+    class="sc-gtstET eMrqxt"
   />
 </div>
 `;

--- a/src/components/LabeledBox/__snapshots__/LabeledBox.spec.tsx.snap
+++ b/src/components/LabeledBox/__snapshots__/LabeledBox.spec.tsx.snap
@@ -3,15 +3,15 @@
 exports[`components LabeledBox is built correctly 1`] = `
 <div>
   <div
-    class="sc-brayMQ fFFFma my-class"
+    class="sc-bdnAzI fXmjto my-class"
   >
     <div
-      class="sc-gJhJfT khwLik"
+      class="sc-gtstET fXfcxk"
     >
       My label
     </div>
     <div
-      class="sc-elDHXC kXVFFx"
+      class="sc-dlnkDq hKzrqG"
     >
       <div>
         child1

--- a/src/components/LabeledComponent/__snapshots__/LabeledComponent.spec.tsx.snap
+++ b/src/components/LabeledComponent/__snapshots__/LabeledComponent.spec.tsx.snap
@@ -3,15 +3,15 @@
 exports[`components LabeledComponent is built correctly 1`] = `
 <div>
   <div
-    class="sc-la-DyAJ ZVehy"
+    class="sc-iCoKjR edoGqq"
   >
     <label
-      class="sc-brayMQ gOAALP"
+      class="sc-bdnAzI bovLLd"
     >
       My label
     </label>
     <div
-      class="sc-gJhJfT ifiXPT"
+      class="sc-gtstET ka-DbvP"
     >
       <input
         id="my-input"

--- a/src/components/ModalDialog/__snapshots__/ModalDialog.spec.tsx.snap
+++ b/src/components/ModalDialog/__snapshots__/ModalDialog.spec.tsx.snap
@@ -4,11 +4,11 @@ exports[`components ModalDialog renders given content 1`] = `
 <div>
   <div>
     <div
-      class="sc-brayMQ cRdfxi"
+      class="sc-bdnAzI jyGYNs"
       data-testid="modal-mask"
     />
     <div
-      class="sc-gJhJfT sc-elDHXC gBmdDr gOMMpF"
+      class="sc-gtstET sc-dlnkDq hxiEGP bxSAwW"
     >
       <div>
         My test content


### PR DESCRIPTION
## Summary
- Update 8 dependencies to latest compatible (minor/patch) versions:
  - `@sentry/react` 10.47.0 → 10.48.0
  - `cypress` 15.13.0 → 15.13.1
  - `firebase` 12.11.0 → 12.12.0
  - `i18next` 26.0.3 → 26.0.5
  - `react-i18next` 17.0.2 → 17.0.3
  - `start-server-and-test` 3.0.0 → 3.0.2
  - `styled-components` 6.3.12 → 6.4.0
  - `webpack` 5.105.4 → 5.106.2
- Update snapshots for styled-components class name changes

## Test plan
- [x] `npm test` — 1746 tests pass, 8 snapshots updated
- [x] `npm run typecheck` — clean