### PR TITLE
Convert 7 UI primitive class components to functional

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,77 +1,64 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import MaterialIcon from '../MaterialIcon';
 import StyledButton from './StyledButton';
 import Overlay from './Overlay';
 import Label from './Label';
 
-class Button extends React.Component<any, any> {
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      hovered: false
-    }
-  }
-
-  handleMouseEnter() {
-    this.setState({
-      hovered: true
-    })
-  }
-
-  handleMouseLeave() {
-    this.setState({
-      hovered: false
-    })
-  }
-
-  render() {
-    const { type, className, disabled, onClick, icon, label, primary, flat, danger, neutral, loading, dataCy } = this.props;
-    return (
-      <StyledButton
-        type={type}
-        className={className}
-        onClick={onClick}
-        disabled={disabled}
-        $primary={primary}
-        $flat={flat}
-        $danger={danger}
-        $neutral={neutral}
-        onMouseEnter={this.handleMouseEnter.bind(this)}
-        onMouseLeave={this.handleMouseLeave.bind(this)}
-        data-cy={dataCy}
-      >
-        <Overlay
-          disabled={disabled}
-          $hovered={this.state.hovered}
-          $danger={danger}
-          $flat={flat}
-        >
-          {loading ? <MaterialIcon icon="sync" rotate="left"/> : icon ? <MaterialIcon icon={icon}/> : undefined}<Label>{label}</Label>
-        </Overlay>
-      </StyledButton>
-    );
-  }
+interface ButtonProps {
+  type?: 'submit' | 'button' | 'reset';
+  label: string;
+  icon?: string;
+  className?: string;
+  disabled?: boolean;
+  onClick?: () => void;
+  primary?: boolean;
+  flat?: boolean;
+  danger?: boolean;
+  neutral?: boolean;
+  loading?: boolean;
+  dataCy?: string;
 }
 
-(Button as any).propTypes = {
-  type: PropTypes.oneOf(['submit', 'button', 'reset']),
-  label: PropTypes.string.isRequired,
-  icon: PropTypes.string,
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
-  onClick: PropTypes.func,
-  primary: PropTypes.bool,
-  flat: PropTypes.bool,
-  danger: PropTypes.bool,
-  neutral: PropTypes.bool,
-  loading: PropTypes.bool,
-  dataCy: PropTypes.string
-};
+const Button: React.FC<ButtonProps> = ({
+  type = 'button',
+  label,
+  icon,
+  className,
+  disabled,
+  onClick,
+  primary,
+  flat,
+  danger,
+  neutral,
+  loading,
+  dataCy,
+}) => {
+  const [hovered, setHovered] = useState(false);
 
-(Button as any).defaultProps = {
-  type: 'button'
+  return (
+    <StyledButton
+      type={type}
+      className={className}
+      onClick={onClick}
+      disabled={disabled}
+      $primary={primary}
+      $flat={flat}
+      $danger={danger}
+      $neutral={neutral}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      data-cy={dataCy}
+    >
+      <Overlay
+        disabled={disabled}
+        $hovered={hovered}
+        $danger={danger}
+        $flat={flat}
+      >
+        {loading ? <MaterialIcon icon="sync" rotate="left"/> : icon ? <MaterialIcon icon={icon}/> : undefined}<Label>{label}</Label>
+      </Overlay>
+    </StyledButton>
+  );
 };
 
 export default Button;

--- a/src/components/ClipboardCopier/index.tsx
+++ b/src/components/ClipboardCopier/index.tsx
@@ -1,84 +1,75 @@
-import React from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import MaterialIcon from '../MaterialIcon'
-import PropTypes from 'prop-types'
 
-class ClipboardCopier extends React.Component<any, any> {
-  timeoutId: any;
+interface ClipboardCopierProps {
+  text: string;
+}
 
-  constructor(props) {
-    super(props);
+const ClipboardCopier: React.FC<ClipboardCopierProps> = ({ text }) => {
+  const [showCopied, setShowCopied] = useState(false);
+  const timeoutId = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    this.state = {
-      showCopied: false
+  useEffect(() => {
+    return () => {
+      if (timeoutId.current !== null) {
+        clearTimeout(timeoutId.current);
+      }
     };
+  }, []);
 
-    this.timeoutId = null;
+  const hideCopiedMessage = useCallback(() => {
+    if (timeoutId.current !== null) {
+      clearTimeout(timeoutId.current);
+    }
+    timeoutId.current = setTimeout(() => {
+      setShowCopied(false);
+    }, 5000);
+  }, []);
 
-    this.handleCopy = this.handleCopy.bind(this)
-    this.hideCopiedMessage = this.hideCopiedMessage.bind(this)
-  }
-
-  handleCopy()  {
-    const text = this.props.text || '';
+  const handleCopy = useCallback(() => {
+    const copyText = text || '';
 
     if (navigator.clipboard) {
-      navigator.clipboard.writeText(text).then(() => {
-        this.setState({ showCopied: true });
-        this.hideCopiedMessage();
+      navigator.clipboard.writeText(copyText).then(() => {
+        setShowCopied(true);
+        hideCopiedMessage();
       }).catch(err => {
         console.error('Failed to copy: ', err);
       });
     } else {
       const textarea = document.createElement('textarea');
-      textarea.value = text;
+      textarea.value = copyText;
       textarea.style.position = 'fixed';
       document.body.appendChild(textarea);
       textarea.focus();
       textarea.select();
       try {
         document.execCommand('copy');
-        this.setState({ showCopied: true });
-        this.hideCopiedMessage();
+        setShowCopied(true);
+        hideCopiedMessage();
       } catch (err) {
         console.error('Fallback: Failed to copy', err);
       }
       document.body.removeChild(textarea);
     }
-  };
+  }, [text, hideCopiedMessage]);
 
-  hideCopiedMessage() {
-    clearTimeout(this.timeoutId);
-    this.timeoutId = setTimeout(() => {
-      this.setState({ showCopied: false });
-    }, 5000);
-  };
-
-  componentWillUnmount() {
-    clearTimeout(this.timeoutId);
-  }
-
-  render() {
-    return (
-      <Container>
-        {this.state.showCopied ? (
-          <CopiedMessage>
-            <MaterialIcon icon="check"/>
-            Copied
-          </CopiedMessage>
-        ) : (
-          <CopyButton onClick={this.handleCopy} title="Copy to Clipboard">
-            <MaterialIcon icon="content_copy"/>
-          </CopyButton>
-        )}
-      </Container>
-    );
-  }
-}
-
-(ClipboardCopier as any).propTypes = {
-  text: PropTypes.string.isRequired
-}
+  return (
+    <Container>
+      {showCopied ? (
+        <CopiedMessage>
+          <MaterialIcon icon="check"/>
+          Copied
+        </CopiedMessage>
+      ) : (
+        <CopyButton onClick={handleCopy} title="Copy to Clipboard">
+          <MaterialIcon icon="content_copy"/>
+        </CopyButton>
+      )}
+    </Container>
+  );
+};
 
 const Container = styled.div`
   display: flex;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,12 +1,10 @@
-import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import scrollIntoView from 'scroll-into-view';
 import MaterialIcon from '../MaterialIcon';
 import Wrapper from './Wrapper';
 import Input from './Input';
 import OptionsContainer from './OptionsContainer';
 import Option from './Option';
-import NoOptions from './NoOptions';
 import MoreOptions from './MoreOptions';
 import ClearButton from './ClearButton';
 
@@ -17,220 +15,217 @@ const KEY_CODE_ESCAPE = 27;
 
 const OPTIONS_RENDER_LIMIT = 10;
 
-class Dropdown extends Component<any, any> {
-  options: any;
-  container: any;
-  input: any;
+interface DropdownOption {
+  key: string;
+  [k: string]: any;
+}
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      value: props.value || '',
-      filter: '',
-      focusedOption: null,
-      inputFocused: false,
-    };
-    this.options = [];
-    this.handleContainerKeyDown = this.handleContainerKeyDown.bind(this);
-    this.handleContainerBlur = this.handleContainerBlur.bind(this);
-    this.handleInputChange = this.handleInputChange.bind(this);
-    this.handleInputFocus = this.handleInputFocus.bind(this);
-    this.handleInputBlur = this.handleInputBlur.bind(this);
-    this.handleClear = this.handleClear.bind(this);
-    this.refContainerDom = this.refContainerDom.bind(this);
-    this.refInputDom = this.refInputDom.bind(this);
+interface DropdownProps {
+  className?: string;
+  options: DropdownOption[];
+  value?: string;
+  optionRenderer: (option: DropdownOption, focussed: boolean) => React.ReactNode;
+  valueRenderer?: (option: DropdownOption) => string;
+  optionFilter?: (options: DropdownOption[], filter: string) => DropdownOption[];
+  showOptionsOnFocus?: boolean;
+  noOptionsText?: string;
+  moreOptionsText?: string;
+  mustSelect?: boolean;
+  clearable?: boolean;
+  onChange?: (value: string) => void;
+  onBeforeInputChange?: (value: string) => string;
+  onFocus?: () => void;
+  onBlur?: (value: string) => void;
+  readOnly?: boolean;
+  optionsRenderLimit?: number;
+  dataCy?: string;
+}
+
+const Dropdown: React.FC<DropdownProps> = ({
+  className,
+  options,
+  value: valueProp,
+  optionRenderer,
+  valueRenderer,
+  optionFilter,
+  showOptionsOnFocus = true,
+  noOptionsText = 'No options found',
+  moreOptionsText = 'Too many options available. Type to filter...',
+  mustSelect = false,
+  clearable = false,
+  onChange,
+  onBeforeInputChange,
+  onFocus,
+  onBlur,
+  readOnly,
+  optionsRenderLimit = OPTIONS_RENDER_LIMIT,
+  dataCy,
+}) => {
+  const [value, setValue] = useState(valueProp || '');
+  const [filter, setFilter] = useState('');
+  const [focusedOption, setFocusedOption] = useState<string | null>(null);
+  const [inputFocused, setInputFocused] = useState(false);
+
+  const optionRefs = useRef<Record<string, any>>({});
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  // Sync value from prop during render (equivalent to componentWillReceiveProps).
+  // Using useEffect would cause a visible flash of the old value.
+  const [prevValueProp, setPrevValueProp] = useState(valueProp);
+  if (valueProp !== prevValueProp) {
+    setPrevValueProp(valueProp);
+    setValue(valueProp || '');
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      value: nextProps.value || '',
-    });
-  }
+  const getFilteredOptions = useCallback((filterValue: string) => {
+    return (typeof optionFilter === 'function')
+      ? optionFilter(options, filterValue)
+      : options.filter(option => option.key.indexOf(filterValue) > -1);
+  }, [options, optionFilter]);
 
-  render() {
-    return (
-      <Wrapper
-        className={this.props.className}
-        onKeyDown={this.handleContainerKeyDown}
-        onBlur={this.handleContainerBlur}
-        tabIndex={1}
-        ref={this.refContainerDom}
-      >
-        {this.renderInput()}
-        {this.renderOptions()}
-      </Wrapper>
-    );
-  }
+  const setFocusedOptionWithScroll = useCallback((key: string | null) => {
+    setFocusedOption(key);
+    if (key !== null) {
+      scrollIntoView(optionRefs.current[key], {
+        validTarget: target => target.classList && target.classList.contains('flightbox-dropdown-options-container')
+      });
+    }
+  }, []);
 
-  renderInput() {
-    const value = this.renderValue();
-    return (
-      <div>
-        <Input
-          type="text"
-          value={this.state.inputFocused === true ? this.state.filter : value}
-          placeholder={value}
-          onChange={this.handleInputChange}
-          onFocus={this.handleInputFocus}
-          onBlur={this.handleInputBlur}
-          ref={this.refInputDom}
-          readOnly={this.props.readOnly}
-          data-cy={this.props.dataCy}
-        />
-        {this.props.clearable && !this.props.readOnly && this.state.value && (
-          <ClearButton onClick={this.handleClear} type="button">
-            <MaterialIcon icon="clear"/>
-          </ClearButton>
-        )}
-      </div>
-    );
-  }
+  const setValueAndNotify = useCallback((newValue: string, focusContainer?: boolean) => {
+    setFilter('');
+    setValue(newValue);
+    onChange?.(newValue);
+    if (focusContainer === true) {
+      window.requestAnimationFrame(() => containerRef.current?.focus());
+    }
+  }, [onChange]);
 
-  renderValue() {
-    const value = this.state.value;
+  const isComponentElement = useCallback((element: Element | null) => {
+    let node = element;
+    while (node !== null) {
+      if (node === containerRef.current) {
+        return true;
+      }
+      node = node.parentNode as Element | null;
+    }
+    return false;
+  }, []);
+
+  const renderValue = () => {
     if (value) {
-      if (typeof this.props.valueRenderer === 'function') {
-        const option = this.props.options.find(option => option.key === value);
-        return this.props.valueRenderer(option);
+      if (typeof valueRenderer === 'function') {
+        const option = options.find(option => option.key === value);
+        return valueRenderer(option!);
       }
       return value;
     }
     return '';
-  }
+  };
 
-  renderOptions() {
-    if (this.state.filter.length === 0 && (!this.state.inputFocused || !this.props.showOptionsOnFocus)) {
-      return null;
-    }
-
-    const filteredOptions = this.getFilteredOptions(this.state.filter);
-
-    if (filteredOptions.length === 0) {
-      return null
-    }
-
-    const options = filteredOptions.slice(0, this.props.optionsRenderLimit).map(option => this.renderOption(option));
-
-    if (filteredOptions.length > this.props.optionsRenderLimit) {
-      options.push(this.renderMoreOptionsLabel());
-    }
-
-    return (
-      <OptionsContainer
-        className="flightbox-dropdown-options-container" // only for identification in scroll-into-view
-        onMouseLeave={this.handleOptionsMouseLeave.bind(this)}
-      >
-        {options}
-      </OptionsContainer>
-    );
-  }
-
-  renderOption(option) {
-    const focussed = this.state.focusedOption === option.key;
-    return (
-      <Option
-        key={option.key}
-        $focussed={focussed}
-        onMouseDown={this.handleOptionClick.bind(this, option)}
-        onMouseEnter={this.handleOptionMouseEnter.bind(this, option)}
-        ref={comp => this.options[option.key] = comp}
-        data-cy={this.props.dataCy && `${this.props.dataCy}-option-${option.key}` }
-      >
-        {this.props.optionRenderer(option, focussed)}
-      </Option>
-    );
-  }
-
-  renderNoOptionsLabel() {
-    return <NoOptions>{this.props.noOptionsText}</NoOptions>;
-  }
-
-  renderMoreOptionsLabel() {
-    return <MoreOptions key="more-options">{this.props.moreOptionsText}</MoreOptions>;
-  }
-
-  refContainerDom(comp) {
-    this.container = comp;
-  }
-
-  refInputDom(comp) {
-    this.input = comp;
-  }
-
-  handleInputChange(e) {
-    if (this.state.inputFocused !== true) {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (inputFocused !== true) {
       return;
     }
 
-    let filter = e.target.value;
+    let newFilter = e.target.value;
 
-    if (typeof this.props.onBeforeInputChange === 'function') {
-      filter = this.props.onBeforeInputChange(filter);
+    if (typeof onBeforeInputChange === 'function') {
+      newFilter = onBeforeInputChange(newFilter);
     }
 
-    let focusedOption = null;
+    let newFocusedOption: string | null = null;
 
-    const filteredOptions = this.getFilteredOptions(filter);
+    const filteredOptions = getFilteredOptions(newFilter);
     if (filteredOptions.length > 0) {
-      const focused = filteredOptions.find(option => option.key === this.state.focusedOption);
+      const focused = filteredOptions.find(option => option.key === focusedOption);
       if (focused) {
-        focusedOption = focused.key;
+        newFocusedOption = focused.key;
       } else {
-        focusedOption = filteredOptions[0].key;
+        newFocusedOption = filteredOptions[0].key;
       }
     }
 
-    this.setState({
-      filter,
-      focusedOption,
-    });
-  }
+    setFilter(newFilter);
+    setFocusedOption(newFocusedOption);
+  };
 
-  handleInputFocus() {
-    if (this.props.readOnly === true) {
+  const getInitiallyFocusedOption = () => {
+    if (value) {
+      return value;
+    }
+    if (options.length > 0) {
+      return options[0].key;
+    }
+    return null;
+  };
+
+  const handleInputFocus = () => {
+    if (readOnly === true) {
       return;
     }
-    this.setState({
-      inputFocused: true,
-      filter: '',
-    });
-    this.setFocusedOption(this.getInitiallyFocusedOption());
-    if (typeof this.props.onFocus === 'function') {
-      this.props.onFocus();
+    setInputFocused(true);
+    setFilter('');
+    setFocusedOptionWithScroll(getInitiallyFocusedOption());
+    if (typeof onFocus === 'function') {
+      onFocus();
     }
-  }
+  };
 
-  handleInputBlur() {
-    this.setState({
-      inputFocused: false,
-    });
-    if (this.state.filter && this.props.mustSelect !== true) {
-      this.setValue(this.state.filter);
+  const handleInputBlur = () => {
+    setInputFocused(false);
+    if (filter && mustSelect !== true) {
+      setValueAndNotify(filter);
     }
-  }
+  };
 
-  handleClear() {
-    this.setValue('');
-  }
+  const handleClear = () => {
+    setValueAndNotify('');
+  };
 
-  handleContainerBlur() {
+  const handleContainerBlur = () => {
     window.requestAnimationFrame(() => {
-      if (this.isComponentElement(document.activeElement) === false
-        && typeof this.props.onBlur === 'function') {
-        this.props.onBlur(this.state.value);
+      if (isComponentElement(document.activeElement) === false
+        && typeof onBlur === 'function') {
+        onBlur(valueRef.current);
       }
     });
-  }
+  };
 
-  handleContainerKeyDown(e) {
-    if (e.which === KEY_CODE_ENTER && this.state.focusedOption) {
+  const getCurrentlyFocusedIndex = (filteredOptions: DropdownOption[]) => {
+    return focusedOption !== null
+      ? filteredOptions.findIndex(option => option.key === focusedOption)
+      : -1;
+  };
+
+  const focusNextOption = (filteredOptions: DropdownOption[], currentlyFocused: number) => {
+    if (currentlyFocused === -1 || currentlyFocused === filteredOptions.length - 1) {
+      setFocusedOptionWithScroll(filteredOptions[0].key);
+    } else {
+      setFocusedOptionWithScroll(filteredOptions[currentlyFocused + 1].key);
+    }
+  };
+
+  const focusPreviousOption = (filteredOptions: DropdownOption[], currentlyFocused: number) => {
+    if (currentlyFocused === -1 || currentlyFocused === 0) {
+      setFocusedOptionWithScroll(filteredOptions[filteredOptions.length - 1].key);
+    } else {
+      setFocusedOptionWithScroll(filteredOptions[currentlyFocused - 1].key);
+    }
+  };
+
+  const handleContainerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.which === KEY_CODE_ENTER && focusedOption) {
       e.preventDefault();
-      this.setValue(this.state.focusedOption, true);
+      setValueAndNotify(focusedOption, true);
       return;
     }
 
     if (e.which === KEY_CODE_ESCAPE) {
-      window.requestAnimationFrame(() => this.container.focus());
+      window.requestAnimationFrame(() => containerRef.current?.focus());
       return;
     }
 
@@ -238,135 +233,104 @@ class Dropdown extends Component<any, any> {
       return;
     }
 
-    const filteredOptions = this.getFilteredOptions(this.state.filter);
+    const filteredOptions = getFilteredOptions(filter);
     if (filteredOptions.length === 0) {
       return;
     }
 
-    const currentlyFocused = this.getCurrentlyFocusedIndex(filteredOptions);
+    const currentlyFocused = getCurrentlyFocusedIndex(filteredOptions);
 
     if (e.which === KEY_CODE_ARROW_DOWN) {
-      this.focusNextOption(filteredOptions, currentlyFocused);
+      focusNextOption(filteredOptions, currentlyFocused);
     } else if (e.which === KEY_CODE_ARROW_UP) {
-      this.focusPreviousOption(filteredOptions, currentlyFocused);
+      focusPreviousOption(filteredOptions, currentlyFocused);
     }
-  }
+  };
 
-  focusNextOption(filteredOptions, currentlyFocused) {
-    if (currentlyFocused === -1 || currentlyFocused === filteredOptions.length - 1) {
-      this.setFocusedOption(filteredOptions[0].key);
-    } else {
-      this.setFocusedOption(filteredOptions[currentlyFocused + 1].key);
-    }
-  }
+  const handleOptionClick = (option: DropdownOption) => {
+    setValueAndNotify(option.key, true);
+  };
 
-  focusPreviousOption(filteredOptions, currentlyFocused) {
-    if (currentlyFocused === -1 || currentlyFocused === 0) {
-      this.setFocusedOption(filteredOptions[filteredOptions.length - 1].key);
-    } else {
-      this.setFocusedOption(filteredOptions[currentlyFocused - 1].key);
-    }
-  }
+  const handleOptionMouseEnter = (option: DropdownOption) => {
+    setFocusedOption(option.key);
+  };
 
-  getInitiallyFocusedOption() {
-    if (this.state.value) {
-      return this.state.value;
-    }
-    if (this.props.options.length > 0) {
-      return this.props.options[0].key;
-    }
-    return null;
-  }
+  const handleOptionsMouseLeave = () => {
+    setFocusedOption(null);
+  };
 
-  setFocusedOption(focusedOption) {
-    this.setState({
-      focusedOption,
+  const renderedValue = renderValue();
+
+  const renderOptions = () => {
+    if (filter.length === 0 && (!inputFocused || !showOptionsOnFocus)) {
+      return null;
+    }
+
+    const filteredOptions = getFilteredOptions(filter);
+
+    if (filteredOptions.length === 0) {
+      return null;
+    }
+
+    const renderedOptions = filteredOptions.slice(0, optionsRenderLimit).map(option => {
+      const focussed = focusedOption === option.key;
+      return (
+        <Option
+          key={option.key}
+          $focussed={focussed}
+          onMouseDown={() => handleOptionClick(option)}
+          onMouseEnter={() => handleOptionMouseEnter(option)}
+          ref={comp => optionRefs.current[option.key] = comp}
+          data-cy={dataCy && `${dataCy}-option-${option.key}`}
+        >
+          {optionRenderer(option, focussed)}
+        </Option>
+      );
     });
-    scrollIntoView(this.options[focusedOption], {
-      validTarget: target => target.classList && target.classList.contains('flightbox-dropdown-options-container')
-    });
-  }
 
-  handleOptionClick(option) {
-    this.setValue(option.key, true);
-  }
-
-  handleOptionMouseEnter(option) {
-    this.setState({
-      focusedOption: option.key,
-    });
-  }
-
-  handleOptionsMouseLeave() {
-    this.setState({
-      focusedOption: null,
-    });
-  }
-
-  setValue(value, focusContainer?) {
-    this.setState({
-      filter: '',
-      value,
-    });
-    this.props.onChange(value);
-    if (focusContainer === true) {
-      window.requestAnimationFrame(() => this.container.focus());
-    }
-  }
-
-  getFilteredOptions(filter) {
-    return (typeof this.props.optionFilter === 'function')
-      ? this.props.optionFilter(this.props.options, filter)
-      : this.props.options.filter(option => option.key.indexOf(filter) > -1);
-  }
-
-  getCurrentlyFocusedIndex(filteredOptions) {
-    return this.state.focusedOption !== null
-      ? filteredOptions.findIndex(option => option.key === this.state.focusedOption)
-      : -1;
-  }
-
-  isComponentElement(element) {
-    let node = element;
-    while (node !== null) {
-      if (node === this.container) {
-        return true;
-      }
-      node = node.parentNode;
+    if (filteredOptions.length > optionsRenderLimit) {
+      renderedOptions.push(<MoreOptions key="more-options">{moreOptionsText}</MoreOptions>);
     }
 
-    return false;
-  }
-}
+    return (
+      <OptionsContainer
+        className="flightbox-dropdown-options-container"
+        onMouseLeave={handleOptionsMouseLeave}
+      >
+        {renderedOptions}
+      </OptionsContainer>
+    );
+  };
 
-(Dropdown as any).propTypes = {
-  className: PropTypes.string,
-  options: PropTypes.array.isRequired,
-  value: PropTypes.string,
-  optionRenderer: PropTypes.func.isRequired,
-  valueRenderer: PropTypes.func,
-  optionFilter: PropTypes.func,
-  showOptionsOnFocus: PropTypes.bool,
-  noOptionsText: PropTypes.string,
-  moreOptionsText: PropTypes.string,
-  mustSelect: PropTypes.bool,
-  clearable: PropTypes.bool,
-  onChange: PropTypes.func,
-  onBeforeInputChange: PropTypes.func,
-  onFocus: PropTypes.func,
-  onBlur: PropTypes.func,
-  readOnly: PropTypes.bool,
-  optionsRenderLimit: PropTypes.number,
-  dataCy: PropTypes.string
-};
-
-(Dropdown as any).defaultProps = {
-  showOptionsOnFocus: true,
-  noOptionsText: 'No options found',
-  moreOptionsText: 'Too many options available. Type to filter...',
-  mustSelect: false,
-  clearable: false,
-  optionsRenderLimit: OPTIONS_RENDER_LIMIT,
+  return (
+    <Wrapper
+      className={className}
+      onKeyDown={handleContainerKeyDown}
+      onBlur={handleContainerBlur}
+      tabIndex={1}
+      ref={containerRef}
+    >
+      <div>
+        <Input
+          type="text"
+          value={inputFocused === true ? filter : renderedValue}
+          placeholder={renderedValue}
+          onChange={handleInputChange}
+          onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
+          ref={inputRef}
+          readOnly={readOnly}
+          data-cy={dataCy}
+        />
+        {clearable && !readOnly && value && (
+          <ClearButton onClick={handleClear} type="button">
+            <MaterialIcon icon="clear"/>
+          </ClearButton>
+        )}
+      </div>
+      {renderOptions()}
+    </Wrapper>
+  );
 };
 
 export default Dropdown;

--- a/src/components/ImageButton/__snapshots__/ImageButton.spec.tsx.snap
+++ b/src/components/ImageButton/__snapshots__/ImageButton.spec.tsx.snap
@@ -3,14 +3,14 @@
 exports[`components ImageButton propagates href to OptionalLink 1`] = `
 <div>
   <div
-    class="sc-elDHXC gPeVyn"
+    class="sc-dlnkDq iIJZep"
   >
     <a
-      class="sc-brayMQ hPonWa"
+      class="sc-bdnAzI cAHJWl"
       href="/some/path"
     >
       <div
-        class="sc-fQpSrZ hGnagO"
+        class="sc-hKFxUR rTqsk"
       >
         <img
           src=""
@@ -24,13 +24,13 @@ exports[`components ImageButton propagates href to OptionalLink 1`] = `
 exports[`components ImageButton propagates onClick to OptionalLink 1`] = `
 <div>
   <div
-    class="sc-elDHXC gPeVyn"
+    class="sc-dlnkDq iIJZep"
   >
     <div
-      class="sc-gJhJfT fdCJqJ"
+      class="sc-gtstET eMrqxt"
     >
       <div
-        class="sc-fQpSrZ hGnagO"
+        class="sc-hKFxUR rTqsk"
       >
         <img
           src=""
@@ -44,13 +44,13 @@ exports[`components ImageButton propagates onClick to OptionalLink 1`] = `
 exports[`components ImageButton renders label and image 1`] = `
 <div>
   <div
-    class="sc-elDHXC gPeVyn"
+    class="sc-dlnkDq iIJZep"
   >
     <div
-      class="sc-gJhJfT fdCJqJ"
+      class="sc-gtstET eMrqxt"
     >
       <div
-        class="sc-fQpSrZ hGnagO"
+        class="sc-hKFxUR rTqsk"
       >
         <img
           src="imgsource.jpg"

--- a/src/components/ImageButton/__snapshots__/OptionalLink.spec.tsx.snap
+++ b/src/components/ImageButton/__snapshots__/OptionalLink.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components ImageButton OptionalLink renders Link component if \`href\` prop is set 1`] = `
 <div>
   <a
-    class="sc-brayMQ hPonWa"
+    class="sc-bdnAzI cAHJWl"
     href="/some/path"
   />
 </div>
@@ -12,7 +12,7 @@ exports[`components ImageButton OptionalLink renders Link component if \`href\` 
 exports[`components ImageButton OptionalLink renders no Link component if \`href\` prop is not set 1`] = `
 <div>
   <div
-    class="sc-gJhJfT fdCJqJ"
+    class="sc-gtstET eMrqxt"
   />
 </div>
 `;

--- a/src/components/IncrementationField/IncrementationField.tsx
+++ b/src/components/IncrementationField/IncrementationField.tsx
@@ -1,48 +1,46 @@
-import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React from 'react';
 import Button from './Button';
 import Value from './Value';
 
-class IncrementationField extends Component<any, any> {
+interface IncrementationFieldProps {
+  value?: number;
+  minValue?: number;
+  onChange?: (event: { target: { value: number } }) => void;
+  readOnly?: boolean;
+  dataCy?: string;
+}
 
-  render() {
-    const value = typeof this.props.value === 'undefined' ? this.props.minValue : this.props.value;
+const IncrementationField: React.FC<IncrementationFieldProps> = ({
+  value: valueProp,
+  minValue = 0,
+  onChange,
+  readOnly,
+  dataCy,
+}) => {
+  const value = typeof valueProp === 'undefined' ? minValue : valueProp;
 
-    if (this.props.readOnly === true) {
-      return (
-        <div>
-          <Value>{value}</Value>
-        </div>
-      );
+  const change = (newValue: number) => {
+    if (newValue < minValue) newValue = minValue;
+    if (typeof onChange === 'function') {
+      onChange({ target: { value: newValue } });
     }
+  };
 
+  if (readOnly === true) {
     return (
       <div>
-        <Button type="button" onClick={() => this.change(value - 1)} data-cy={`${this.props.dataCy}-decrement`}>-</Button>
         <Value>{value}</Value>
-        <Button type="button" onClick={() => this.change(value + 1)} data-cy={`${this.props.dataCy}-increment`}>+</Button>
       </div>
     );
   }
 
-  change(newValue) {
-    if (newValue < this.props.minValue) newValue = this.props.minValue;
-    if (typeof this.props.onChange === 'function') {
-      this.props.onChange({ target: { value: newValue } });
-    }
-  }
-}
-
-(IncrementationField as any).propTypes = {
-  value: PropTypes.number,
-  minValue: PropTypes.number,
-  onChange: PropTypes.func,
-  readOnly: PropTypes.bool,
-  dataCy: PropTypes.string
-};
-
-(IncrementationField as any).defaultProps = {
-  minValue: 0,
+  return (
+    <div>
+      <Button type="button" onClick={() => change(value - 1)} data-cy={`${dataCy}-decrement`}>-</Button>
+      <Value>{value}</Value>
+      <Button type="button" onClick={() => change(value + 1)} data-cy={`${dataCy}-increment`}>+</Button>
+    </div>
+  );
 };
 
 export default IncrementationField;

--- a/src/components/LabeledBox/__snapshots__/LabeledBox.spec.tsx.snap
+++ b/src/components/LabeledBox/__snapshots__/LabeledBox.spec.tsx.snap
@@ -3,15 +3,15 @@
 exports[`components LabeledBox is built correctly 1`] = `
 <div>
   <div
-    class="sc-brayMQ fFFFma my-class"
+    class="sc-bdnAzI fXmjto my-class"
   >
     <div
-      class="sc-gJhJfT khwLik"
+      class="sc-gtstET fXfcxk"
     >
       My label
     </div>
     <div
-      class="sc-elDHXC kXVFFx"
+      class="sc-dlnkDq hKzrqG"
     >
       <div>
         child1

--- a/src/components/LabeledComponent/LabeledComponent.tsx
+++ b/src/components/LabeledComponent/LabeledComponent.tsx
@@ -1,52 +1,35 @@
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import Label from './Label';
 import ComponentContainer from './ComponentContainer';
 import Tooltip from './Tooltip';
 import ValidationMessage from './ValidationMessage';
 import Wrapper from './Wrapper';
 
-class LabeledComponent extends Component<any, any> {
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      tooltipVisible: false,
-    };
-    this.handleFocus = this.handleFocus.bind(this);
-    this.handleBlur = this.handleBlur.bind(this);
-  }
-
-  render() {
-    return (
-      <Wrapper className={this.props.className} onFocus={this.handleFocus} onBlur={this.handleBlur}>
-        <Label>{this.props.label}</Label>
-        {this.props.validationError && <ValidationMessage error={this.props.validationError}/>}
-        <ComponentContainer>{this.props.component}</ComponentContainer>
-        {this.state.tooltipVisible && this.props.tooltip && <Tooltip>{this.props.tooltip}</Tooltip>}
-      </Wrapper>
-    );
-  }
-
-  handleFocus() {
-    this.setState({
-      tooltipVisible: true,
-    });
-  }
-
-  handleBlur() {
-    this.setState({
-      tooltipVisible: false,
-    });
-  }
+interface LabeledComponentProps {
+  label: string;
+  component: React.ReactElement;
+  className?: string;
+  validationError?: string | null;
+  tooltip?: string;
 }
 
-(LabeledComponent as any).propTypes = {
-  label: PropTypes.string.isRequired,
-  component: PropTypes.element.isRequired,
-  className: PropTypes.string,
-  validationError: PropTypes.string,
-  tooltip: PropTypes.string,
+const LabeledComponent: React.FC<LabeledComponentProps> = ({
+  label,
+  component,
+  className,
+  validationError,
+  tooltip,
+}) => {
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+
+  return (
+    <Wrapper className={className} onFocus={() => setTooltipVisible(true)} onBlur={() => setTooltipVisible(false)}>
+      <Label>{label}</Label>
+      {validationError && <ValidationMessage error={validationError}/>}
+      <ComponentContainer>{component}</ComponentContainer>
+      {tooltipVisible && tooltip && <Tooltip>{tooltip}</Tooltip>}
+    </Wrapper>
+  );
 };
 
 export default LabeledComponent;

--- a/src/components/LabeledComponent/__snapshots__/LabeledComponent.spec.tsx.snap
+++ b/src/components/LabeledComponent/__snapshots__/LabeledComponent.spec.tsx.snap
@@ -3,15 +3,15 @@
 exports[`components LabeledComponent is built correctly 1`] = `
 <div>
   <div
-    class="sc-la-DyAJ ZVehy"
+    class="sc-iCoKjR edoGqq"
   >
     <label
-      class="sc-brayMQ gOAALP"
+      class="sc-bdnAzI bovLLd"
     >
       My label
     </label>
     <div
-      class="sc-gJhJfT ifiXPT"
+      class="sc-gtstET ka-DbvP"
     >
       <input
         id="my-input"

--- a/src/components/ModalDialog/__snapshots__/ModalDialog.spec.tsx.snap
+++ b/src/components/ModalDialog/__snapshots__/ModalDialog.spec.tsx.snap
@@ -4,11 +4,11 @@ exports[`components ModalDialog renders given content 1`] = `
 <div>
   <div>
     <div
-      class="sc-brayMQ cRdfxi"
+      class="sc-bdnAzI jyGYNs"
       data-testid="modal-mask"
     />
     <div
-      class="sc-gJhJfT sc-elDHXC gBmdDr gOMMpF"
+      class="sc-gtstET sc-dlnkDq hxiEGP bxSAwW"
     >
       <div>
         My test content

--- a/src/components/QrCodeGenerator/index.tsx
+++ b/src/components/QrCodeGenerator/index.tsx
@@ -1,8 +1,8 @@
-import React, {Component} from "react";
+import React, { useMemo, useCallback } from "react";
 import QRCode from "qrcode-svg";
 import Button from '../Button'
 import styled from 'styled-components'
-import { withTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 
 const Wrapper = styled.div`
   display: flex;
@@ -10,38 +10,39 @@ const Wrapper = styled.div`
   align-items: center;
   gap: 1em;
 `
-class QRCodeGenerator extends Component<any, any> {
 
-  constructor(props) {
-    super(props);
-    const qr = new QRCode({ content: props.url, width: 200, height: 200 });
-    this.state = { qrSvg: qr.svg() };
-    this.downloadQRCode = this.downloadQRCode.bind(this);
-  }
+interface QRCodeGeneratorProps {
+  url: string;
+}
 
-  downloadQRCode() {
-    const blob = new Blob([this.state.qrSvg], { type: "image/svg+xml" });
+const QRCodeGenerator: React.FC<QRCodeGeneratorProps> = ({ url }) => {
+  const { t } = useTranslation();
+
+  const qrSvg = useMemo(() => {
+    const qr = new QRCode({ content: url, width: 200, height: 200 });
+    return qr.svg();
+  }, [url]);
+
+  const downloadQRCode = useCallback(() => {
+    const blob = new Blob([qrSvg], { type: "image/svg+xml" });
     const link = document.createElement("a");
     link.href = URL.createObjectURL(blob);
     link.download = "qrcode.svg";
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-  }
+  }, [qrSvg]);
 
-  render() {
-    const { t } = this.props;
-    return (
-      <Wrapper>
-        <div dangerouslySetInnerHTML={{ __html: this.state.qrSvg }} />
-        <Button
-          onClick={this.downloadQRCode}
-          label={t('common.download')}
-          icon="file_download"
-          />
-      </Wrapper>
-    );
-  }
-}
+  return (
+    <Wrapper>
+      <div dangerouslySetInnerHTML={{ __html: qrSvg }} />
+      <Button
+        onClick={downloadQRCode}
+        label={t('common.download')}
+        icon="file_download"
+      />
+    </Wrapper>
+  );
+};
 
-export default withTranslation()(QRCodeGenerator);
+export default QRCodeGenerator;

--- a/src/components/SingleSelect/SingleSelect.tsx
+++ b/src/components/SingleSelect/SingleSelect.tsx
@@ -1,118 +1,93 @@
-import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import Wrapper from './Wrapper';
 import Item from './Item';
 
-class SingleSelect extends Component<any, any> {
+interface SingleSelectItem {
+  value: string;
+  label: string;
+  description?: string;
+}
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      value: this.props.value || null,
+interface SingleSelectProps {
+  items: SingleSelectItem[];
+  value?: string;
+  onChange?: (event: { target: { value: string } }) => void;
+  orientation?: 'horizontal' | 'vertical';
+  readOnly?: boolean;
+  dataCy?: string;
+}
+
+const SingleSelect: React.FC<SingleSelectProps> = ({
+  items,
+  value: valueProp,
+  onChange,
+  orientation = 'horizontal',
+  readOnly,
+  dataCy,
+}) => {
+  const [value, setValue] = useState<string | null>(valueProp || null);
+
+  // Sync value from prop during render (equivalent to componentDidUpdate).
+  // Using useEffect would cause a visible flash of the old value.
+  const [prevValueProp, setPrevValueProp] = useState(valueProp);
+  if (valueProp !== prevValueProp) {
+    setPrevValueProp(valueProp);
+    setValue(valueProp || null);
+  }
+
+  useEffect(() => {
+    if (items.length === 1 && !valueProp && onChange) {
+      onChange({ target: { value: items[0].value } });
+    }
+  }, [items, valueProp, onChange]);
+
+  const handleClick = useCallback((newValue: string) => {
+    if (readOnly !== true) {
+      setValue(newValue);
+      if (typeof onChange === 'function') {
+        onChange({ target: { value: newValue } });
+      }
+    }
+  }, [readOnly, onChange]);
+
+  if (readOnly === true) {
+    const getReadOnlyValue = () => {
+      if (!value) {
+        return '-';
+      }
+      const selectedItem = items.find(item => item.value === value);
+      if (selectedItem) {
+        return selectedItem.label;
+      }
+      return value;
     };
-  }
-
-  componentDidMount() {
-    this.selectSingleItem()
-  }
-
-  componentDidUpdate(prevProps) {
-    this.selectSingleItem()
-    if (prevProps.value !== this.props.value) {
-      this.setState({
-        value: this.props.value
-      })
-    }
-  }
-
-  render() {
-    if (this.props.readOnly === true) {
-      return (
-        <div>{this.getReadOnlyValue()}</div>
-      )
-    }
-
-    const orientation = this.props.orientation;
-
-    const widthPercentage = orientation === 'horizontal'
-      ? 100 / this.props.items.length
-      : null;
 
     return (
-      <Wrapper $orientation={orientation}>
-        {this.props.items.map((item, index) => (
-          <Item
-            key={index}
-            value={item.value}
-            label={item.label}
-            description={item.description}
-            selected={this.state.value === item.value}
-            widthPercentage={widthPercentage}
-            orientation={orientation}
-            onClick={this.clickHandler.bind(this)}
-            dataCy={`${this.props.dataCy}-${item.value}`}
-          />
-        ))}
-      </Wrapper>
+      <div>{getReadOnlyValue()}</div>
     );
   }
 
-  clickHandler(value) {
-    if (this.props.readOnly !== true) {
-      this.setState({
-        value,
-      }, this.fireChangeEvent);
-    }
-  }
+  const widthPercentage = orientation === 'horizontal'
+    ? 100 / items.length
+    : null;
 
-  fireChangeEvent() {
-    if (typeof this.props.onChange === 'function') {
-      this.props.onChange({
-        target: {
-          value: this.state.value,
-        },
-      });
-    }
-  }
-
-  getReadOnlyValue() {
-    if (!this.state.value) {
-      return '-';
-    }
-
-    const selectedItem = this.props.items.find(item => item.value === this.state.value);
-    if (selectedItem) {
-      return selectedItem.label;
-    }
-
-    return this.state.value;
-  }
-
-  selectSingleItem() {
-    if (this.props.items.length === 1 && !this.props.value && this.props.onChange) {
-      this.props.onChange({
-        target: {
-          value: this.props.items[0].value
-        }
-      })
-    }
-  }
-}
-
-(SingleSelect as any).propTypes = {
-  items: PropTypes.arrayOf(PropTypes.shape({
-    value: PropTypes.string.isRequired,
-    label: PropTypes.string.isRequired
-  })).isRequired,
-  value: PropTypes.string,
-  onChange: PropTypes.func,
-  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
-  readOnly: PropTypes.bool,
-  dataCy: PropTypes.string
-};
-
-(SingleSelect as any).defaultProps = {
-  orientation: 'horizontal'
+  return (
+    <Wrapper $orientation={orientation}>
+      {items.map((item, index) => (
+        <Item
+          key={index}
+          value={item.value}
+          label={item.label}
+          description={item.description}
+          selected={value === item.value}
+          widthPercentage={widthPercentage}
+          orientation={orientation}
+          onClick={handleClick}
+          dataCy={`${dataCy}-${item.value}`}
+        />
+      ))}
+    </Wrapper>
+  );
 };
 
 export default SingleSelect;


### PR DESCRIPTION
## Summary
- Convert **Button**, **Dropdown**, **SingleSelect**, **IncrementationField**, **LabeledComponent**, **ClipboardCopier**, and **QrCodeGenerator** from class components to functional components with hooks
- Replace PropTypes with TypeScript interfaces and default parameters
- Use render-time sync pattern (not `useEffect`) for prop-to-state synchronization in Dropdown and SingleSelect, preserving the original `componentWillReceiveProps`/`componentDidUpdate` timing to avoid visual flash
- Use `useRef` for Dropdown's async `onBlur` callback to prevent stale closure in `requestAnimationFrame`
- Replace `withTranslation()` HOC with `useTranslation()` hook in QrCodeGenerator

## Test plan
- [x] `npm test` — 1746 tests pass
- [x] `npm run typecheck` — clean
- [x] Reviewed for stale closure issues in async handlers (rAF, timeouts)
- [x] Reviewed prop-to-state sync timing matches original lifecycle methods
- [ ] Cypress E2E — Button, Dropdown, SingleSelect, IncrementationField are exercised by departure/arrival wizard specs