### PR TITLE
Add multi-aircraft profile with wizard quick-pick

### DIFF
--- a/firebase-rules-template.json
+++ b/firebase-rules-template.json
@@ -485,6 +485,26 @@
         "privacyPolicyAcceptedAt": {
           ".validate": "newData.isString() && newData.val().matches(/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$/)"
         },
+        "aircrafts": {
+          "$index": {
+            ".validate": "newData.hasChildren(['immatriculation'])",
+            "immatriculation": {
+              ".validate": "newData.isString() && newData.val().length > 0"
+            },
+            "aircraftType": {
+              ".validate": "newData.isString()"
+            },
+            "aircraftCategory": {
+              ".validate": "{aircraftCategory}"
+            },
+            "mtow": {
+              ".validate": "newData.isNumber() && newData.val() > 0"
+            },
+            "$other": {
+              ".validate": false
+            }
+          }
+        },
         "language": {
           ".validate": "newData.isString() && newData.val().matches(/^(de|en)$/)"
         },

--- a/src/components/ProfilePage/AircraftList.tsx
+++ b/src/components/ProfilePage/AircraftList.tsx
@@ -1,0 +1,276 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+import { Field, Form } from 'react-final-form';
+import type { Aircraft } from '../../modules/profile/migration';
+import { renderAircraftDropdown, renderAircraftCategoryDropdown, renderInputField } from '../wizards/renderField';
+import FieldSet from '../wizards/FieldSet';
+import Button from '../Button';
+import MaterialIcon from '../MaterialIcon';
+
+const Section = styled.div`
+  padding: 1em;
+  border: 1px solid #ddd;
+  background-color: #fefefe;
+  box-shadow: 0 -1px 0 rgba(0,0,0,.03), 0 0 2px rgba(0,0,0,.03), 0 2px 4px rgba(0,0,0,.06);
+`;
+
+const SectionTitle = styled.h1`
+  font-weight: bold;
+  font-size: 1.5em;
+  margin-bottom: 1em;
+`;
+
+const AddForm = styled.div`
+  margin-bottom: 1.5em;
+  padding-bottom: 1.5em;
+  border-bottom: 1px solid #eee;
+`;
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+`;
+
+const Item = styled.div`
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background-color: #fff;
+`;
+
+const ItemHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75em 1em;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #fafafa;
+  }
+`;
+
+const ItemInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  flex-wrap: wrap;
+`;
+
+const Registration = styled.span`
+  font-weight: bold;
+`;
+
+const Detail = styled.span`
+  color: #666;
+  font-size: 0.9em;
+`;
+
+const ItemActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.25em;
+`;
+
+const IconButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #999;
+  padding: 4px;
+  font-family: inherit;
+
+  &:hover {
+    color: ${props => props.theme.colors.danger};
+  }
+`;
+
+const EditIcon = styled(IconButton)`
+  &:hover {
+    color: ${props => props.theme.colors.main};
+  }
+`;
+
+const ItemBody = styled.div`
+  padding: 1em;
+  border-top: 1px solid #eee;
+`;
+
+const ButtonRow = styled.div`
+  display: flex;
+  gap: 0.5em;
+  margin-top: 0.5em;
+`;
+
+const EmptyMessage = styled.div`
+  color: #999;
+  font-style: italic;
+  padding: 0.5em 0;
+`;
+
+function aircraftFormFields(t: any, form: any) {
+  return (
+    <>
+      <FieldSet gutter={false}>
+        <Field name="immatriculation">
+          {({ input, meta }) =>
+            renderAircraftDropdown({
+              input: {
+                ...input,
+                onChange: aircraft => {
+                  if (aircraft) {
+                    input.onChange(aircraft.key);
+                    form.change('aircraftType', aircraft.type);
+                    form.change('mtow', aircraft.mtow);
+                    form.change('aircraftCategory', aircraft.category);
+                  } else {
+                    input.onChange(null);
+                  }
+                }
+              },
+              meta,
+              label: t('profile.immatriculation'),
+              clearable: true,
+            })
+          }
+        </Field>
+        <Field
+          name="aircraftType"
+          type="text"
+          component={renderInputField}
+          label={t('profile.type')}
+        />
+      </FieldSet>
+      <FieldSet gutter={false}>
+        <Field
+          name="mtow"
+          type="number"
+          component={renderInputField}
+          label={t('profile.mtow')}
+          parse={input => {
+            if (typeof input === 'number') return input;
+            if (typeof input === 'string' && /^\d+$/.test(input)) return parseInt(input);
+            return null;
+          }}
+        />
+        <Field
+          name="aircraftCategory"
+          component={renderAircraftCategoryDropdown}
+          label={t('profile.category')}
+          clearable
+        />
+      </FieldSet>
+    </>
+  );
+}
+
+interface AircraftListProps {
+  aircrafts: Aircraft[];
+  addAircraft: (aircraft: Aircraft) => void;
+  updateAircraft: (index: number, aircraft: Aircraft) => void;
+  removeAircraft: (index: number) => void;
+}
+
+const AircraftList: React.FC<AircraftListProps> = ({ aircrafts, addAircraft, updateAircraft, removeAircraft }) => {
+  const { t } = useTranslation();
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
+  const handleAdd = (values: Record<string, any>, form: any) => {
+    if (values.immatriculation) {
+      addAircraft({
+        immatriculation: values.immatriculation || null,
+        aircraftType: values.aircraftType || null,
+        mtow: values.mtow ?? null,
+        aircraftCategory: values.aircraftCategory || null,
+      });
+      setTimeout(() => form.restart());
+    }
+  };
+
+  const handleUpdate = (index: number) => (values: Record<string, any>) => {
+    updateAircraft(index, {
+      immatriculation: values.immatriculation || null,
+      aircraftType: values.aircraftType || null,
+      mtow: values.mtow ?? null,
+      aircraftCategory: values.aircraftCategory || null,
+    });
+    setEditingIndex(null);
+  };
+
+  return (
+    <Section>
+      <SectionTitle>{t('profile.aircraft')}</SectionTitle>
+
+      <AddForm>
+        <Form onSubmit={handleAdd}>
+          {({ handleSubmit, form }) => (
+            <form onSubmit={handleSubmit}>
+              {aircraftFormFields(t, form)}
+              <Button
+                label={t('profile.addAircraft')}
+                icon="add"
+                type="submit"
+                primary
+              />
+            </form>
+          )}
+        </Form>
+      </AddForm>
+
+      <List>
+        {aircrafts.length === 0 && (
+          <EmptyMessage>{t('profile.noAircraft')}</EmptyMessage>
+        )}
+        {aircrafts.map((aircraft, index) => (
+          <Item key={`${aircraft.immatriculation}-${index}`}>
+            <ItemHeader onClick={() => setEditingIndex(editingIndex === index ? null : index)}>
+              <ItemInfo>
+                <Registration>{aircraft.immatriculation}</Registration>
+                {aircraft.aircraftType && <Detail>{aircraft.aircraftType}</Detail>}
+                {aircraft.mtow != null && <Detail>{aircraft.mtow} kg</Detail>}
+                {aircraft.aircraftCategory && <Detail>{aircraft.aircraftCategory}</Detail>}
+              </ItemInfo>
+              <ItemActions>
+                <EditIcon
+                  onClick={e => { e.stopPropagation(); setEditingIndex(editingIndex === index ? null : index); }}
+                  title={t('common.edit')}
+                >
+                  <MaterialIcon icon={editingIndex === index ? 'expand_less' : 'edit'}/>
+                </EditIcon>
+                <IconButton
+                  onClick={e => { e.stopPropagation(); removeAircraft(index); }}
+                  title={t('profile.removeAircraft')}
+                >
+                  <MaterialIcon icon="delete"/>
+                </IconButton>
+              </ItemActions>
+            </ItemHeader>
+            {editingIndex === index && (
+              <ItemBody>
+                <Form onSubmit={handleUpdate(index)} initialValues={aircraft}>
+                  {({ handleSubmit, dirty, form }) => (
+                    <form onSubmit={handleSubmit}>
+                      {aircraftFormFields(t, form)}
+                      <ButtonRow>
+                        <Button
+                          label={t('profile.save')}
+                          icon="save"
+                          type="submit"
+                          disabled={!dirty}
+                          primary
+                        />
+                      </ButtonRow>
+                    </form>
+                  )}
+                </Form>
+              </ItemBody>
+            )}
+          </Item>
+        ))}
+      </List>
+    </Section>
+  );
+};
+
+export default AircraftList;

--- a/src/components/ProfilePage/ProfileForm.tsx
+++ b/src/components/ProfilePage/ProfileForm.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import FieldSet from '../wizards/FieldSet'
 import { useTranslation } from 'react-i18next';
 import {Field, Form} from 'react-final-form'
-import {renderAircraftCategoryDropdown, renderAircraftDropdown, renderInputField, renderPhoneField} from '../wizards/renderField'
+import {renderInputField, renderPhoneField} from '../wizards/renderField'
 import React from 'react'
 import Button from '../Button'
 import styled from 'styled-components'
@@ -78,64 +78,6 @@ function ProfileForm(props) {
                 component={renderPhoneField}
               />
             </FieldSet>
-          </StyledSection>
-
-          <StyledSection>
-            <StyledSectionTitle>{t('profile.aircraft')}</StyledSectionTitle>
-            <FieldSet gutter={false}>
-              <Field name="immatriculation">
-                {({input, meta}) =>
-                  renderAircraftDropdown({
-                    input: {
-                      ...input,
-                      onChange: aircraft => {
-                        if (aircraft) {
-                          input.onChange(aircraft.key);
-                          form.change('aircraftType', aircraft.type);
-                          form.change('mtow', aircraft.mtow);
-                          form.change('aircraftCategory', aircraft.category);
-                        } else {
-                          input.onChange(null);
-                        }
-                      }
-                    },
-                    meta,
-                    label: t('profile.immatriculation'),
-                    clearable: true,
-                  })
-                }
-              </Field>
-              <Field
-                name="aircraftType"
-                type="text"
-                component={renderInputField}
-                label={t('profile.type')}
-              />
-              <Field
-                name="mtow"
-                type="number"
-                component={renderInputField}
-                label={t('profile.mtow')}
-                parse={input => {
-                  if (typeof input === 'number') {
-                    return input;
-                  }
-                  if (typeof input === 'string' && /^\d+$/.test(input)) {
-                    return parseInt(input);
-                  }
-                  return null;
-                }}
-              />
-              <Field
-                name="aircraftCategory"
-                component={renderAircraftCategoryDropdown}
-                label={t('profile.category')}
-                clearable
-              />
-            </FieldSet>
-          </StyledSection>
-
-          <div>
             <Button
               type="submit"
               label={t('profile.save')}
@@ -143,7 +85,7 @@ function ProfileForm(props) {
               disabled={!dirty || props.saving}
               loading={props.saving}
               primary/>
-          </div>
+          </StyledSection>
         </StyledForm>
       )}
     </Form>

--- a/src/components/ProfilePage/ProfilePage.tsx
+++ b/src/components/ProfilePage/ProfilePage.tsx
@@ -1,46 +1,69 @@
-import React, {Component} from 'react';
-import PropTypes from 'prop-types'
-import { withTranslation } from 'react-i18next';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components'
 import Centered from '../Centered'
 import MaterialIcon from '../MaterialIcon'
 import JumpNavigation from '../JumpNavigation'
 import VerticalHeaderLayout from '../VerticalHeaderLayout'
 import ProfileForm from './ProfileForm'
+import AircraftList from './AircraftList'
+import type { Aircraft } from '../../modules/profile/migration'
 
 const Content = styled.div`
   padding: 2em;
 `;
 
-class ProfilePage extends Component<any, any> {
+const FormLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+`;
 
-  componentDidMount() {
-    this.props.loadProfile()
-  }
-
-  render() {
-    const {profile, saving, saveProfile} = this.props;
-    const { t } = this.props;
-
-    if (!profile) {
-      return <Centered><MaterialIcon icon="sync" rotate="left"/> {t('profile.loading')}</Centered>;
-    }
-
-    return (
-      <VerticalHeaderLayout>
-        <Content>
-          <JumpNavigation/>
-          <ProfileForm profile={profile} saveProfile={saveProfile} saving={saving}/>
-        </Content>
-      </VerticalHeaderLayout>
-    )
-  }
+interface ProfilePageProps {
+  profile: Record<string, unknown> | undefined;
+  saving: boolean;
+  loadProfile: () => void;
+  saveProfile: (values: Record<string, unknown>) => void;
+  addAircraft: (aircraft: Aircraft) => void;
+  updateAircraft: (index: number, aircraft: Aircraft) => void;
+  removeAircraft: (index: number) => void;
 }
 
-(ProfilePage as any).propTypes = {
-  profile: PropTypes.object,
-  loadProfile: PropTypes.func.isRequired,
-  saveProfile: PropTypes.func.isRequired
+const ProfilePage: React.FC<ProfilePageProps> = ({
+  profile,
+  saving,
+  loadProfile,
+  saveProfile,
+  addAircraft,
+  updateAircraft,
+  removeAircraft,
+}) => {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    loadProfile();
+  }, []);
+
+  if (!profile) {
+    return <Centered><MaterialIcon icon="sync" rotate="left"/> {t('profile.loading')}</Centered>;
+  }
+
+  return (
+    <VerticalHeaderLayout>
+      <Content>
+        <JumpNavigation/>
+        <FormLayout>
+          <ProfileForm profile={profile} saveProfile={saveProfile} saving={saving}/>
+          <AircraftList
+            aircrafts={(profile.aircrafts as Aircraft[]) || []}
+            addAircraft={addAircraft}
+            updateAircraft={updateAircraft}
+            removeAircraft={removeAircraft}
+          />
+        </FormLayout>
+      </Content>
+    </VerticalHeaderLayout>
+  );
 };
 
-export default withTranslation()(ProfilePage);
+export default ProfilePage;

--- a/src/components/wizards/pages/AircraftPage.tsx
+++ b/src/components/wizards/pages/AircraftPage.tsx
@@ -1,17 +1,90 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 import {Field, Form} from 'react-final-form'
 import validate from '../validate';
 import {renderAircraftCategoryDropdown, renderAircraftDropdown, renderInputField} from '../renderField';
 import FieldSet from '../FieldSet';
 import WizardNavigation from '../../WizardNavigation';
+import MaterialIcon from '../../MaterialIcon';
 import {getAircraftOrigin, updateFeesTotal, updateGoAroundFees, updateLandingFees} from '../../../util/landingFees'
+import type { Aircraft } from '../../../modules/profile/migration';
 
-const AircraftPage = (props) => {
+const FavouritesBar = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6em;
+  padding: 0.4em 1em;
+  margin: 0 1em 1em;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  overflow: hidden;
+`;
+
+const StarIcon = styled.span`
+  color: #e8a735;
+  display: flex;
+  align-items: center;
+  font-size: 1.1em;
+`;
+
+const Chip = styled.button<{ $active?: boolean }>`
+  padding: 0.5em 0.9em;
+  min-height: 44px;
+  border: 1px solid ${props => props.$active ? props.theme.colors.main : '#ddd'};
+  border-radius: 3px;
+  background-color: ${props => props.$active ? props.theme.colors.main : '#fff'};
+  color: ${props => props.$active ? '#fff' : '#555'};
+  font-family: inherit;
+  font-size: 0.9em;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    border-color: ${props => props.theme.colors.main};
+    color: ${props => props.$active ? '#fff' : props.theme.colors.main};
+  }
+`;
+
+function applyAircraft(form: any, aircraft: { key: string; type?: string; mtow?: number; category?: string }, aircraftSettings: any) {
+  form.change('immatriculation', aircraft.key);
+  form.change('aircraftType', aircraft.type);
+  form.change('mtow', aircraft.mtow);
+  form.change('aircraftCategory', aircraft.category);
+
+  if (form.getState().values['type'] === 'arrival') {
+    const values = form.getState().values;
+    const flightType = values.flightType;
+    const landingCount = values.landingCount;
+    const goAroundCount = values.goAroundCount;
+    const aircraftOrigin = getAircraftOrigin(aircraft.key, aircraftSettings);
+
+    const landingFeeTotal = updateLandingFees(form.change, aircraft.mtow, flightType, aircraftOrigin, aircraft.category, landingCount);
+    const goAroundFeeTotal = updateGoAroundFees(form.change, aircraft.mtow, flightType, aircraftOrigin, aircraft.category, goAroundCount);
+
+    updateFeesTotal(form.change, landingFeeTotal, goAroundFeeTotal, flightType, aircraftOrigin, aircraft.category);
+  }
+}
+
+interface AircraftPageProps {
+  onSubmit: (values: any) => void;
+  cancel: () => void;
+  readOnly?: boolean;
+  formValues: Record<string, any>;
+  aircraftSettings: any;
+  hiddenFields?: string[];
+  profileAircrafts?: Aircraft[];
+}
+
+const AircraftPage: React.FC<AircraftPageProps> = (props) => {
   const { t } = useTranslation();
-  const {onSubmit, formValues, aircraftSettings} = props;
+  const {onSubmit, formValues, aircraftSettings, profileAircrafts} = props;
+
+  const showQuickPicks = !props.readOnly && profileAircrafts && profileAircrafts.length >= 2;
+
   return (
     <Form
       initialValues={formValues}
@@ -22,8 +95,28 @@ const AircraftPage = (props) => {
         props.hiddenFields
       )}
     >
-      {({handleSubmit, form}) => (
+      {({handleSubmit, form, values}) => (
         <form onSubmit={handleSubmit} className="AircraftPage">
+          {showQuickPicks && (
+            <FavouritesBar>
+              <StarIcon><MaterialIcon icon="star"/></StarIcon>
+              {profileAircrafts!.map((aircraft, index) => (
+                <Chip
+                  key={`${aircraft.immatriculation}-${index}`}
+                  type="button"
+                  $active={values.immatriculation === aircraft.immatriculation}
+                  onClick={() => applyAircraft(form, {
+                    key: aircraft.immatriculation!,
+                    type: aircraft.aircraftType ?? undefined,
+                    mtow: aircraft.mtow ?? undefined,
+                    category: aircraft.aircraftCategory ?? undefined,
+                  }, aircraftSettings)}
+                >
+                  {aircraft.immatriculation}
+                </Chip>
+              ))}
+            </FavouritesBar>
+          )}
           <FieldSet>
             <Field name="immatriculation">
               {({ input, meta }) =>
@@ -32,23 +125,7 @@ const AircraftPage = (props) => {
                     ...input,
                     onChange: (aircraft) => {
                       if (aircraft) {
-                        form.change('immatriculation', aircraft.key)
-                        form.change('aircraftType', aircraft.type);
-                        form.change('mtow', aircraft.mtow);
-                        form.change('aircraftCategory', aircraft.category)
-
-                        if (form.getState().values['type'] === 'arrival') {
-                          const values = form.getState().values;
-                          const flightType = values.flightType;
-                          const landingCount = values.landingCount;
-                          const goAroundCount = values.goAroundCount;
-                          const aircraftOrigin = getAircraftOrigin(aircraft.key, aircraftSettings);
-
-                          const landingFeeTotal = updateLandingFees(form.change, aircraft.mtow, flightType, aircraftOrigin, aircraft.category, landingCount);
-                          const goAroundFeeTotal = updateGoAroundFees(form.change, aircraft.mtow, flightType, aircraftOrigin, aircraft.category, goAroundCount);
-
-                          updateFeesTotal(form.change, landingFeeTotal, goAroundFeeTotal, flightType, aircraftOrigin, aircraft.category);
-                        }
+                        applyAircraft(form, aircraft, aircraftSettings);
                       } else {
                         form.change('immatriculation', null)
                       }
@@ -149,19 +226,9 @@ const AircraftPage = (props) => {
   );
 };
 
-AircraftPage.propTypes = {
-  onSubmit: PropTypes.func.isRequired,
-  cancel: PropTypes.func.isRequired,
-  readOnly: PropTypes.bool,
-  formValues: PropTypes.object.isRequired,
-  aircraftSettings: PropTypes.shape({
-    club: PropTypes.objectOf(PropTypes.bool),
-    homeBase: PropTypes.objectOf(PropTypes.bool)
-  }).isRequired
-};
-
-const mapStateToProps = state => ({
-  aircraftSettings: state.settings.aircrafts
+const mapStateToProps = (state: any) => ({
+  aircraftSettings: state.settings.aircrafts,
+  profileAircrafts: state.profile.profile?.aircrafts,
 });
 
 export default connect(mapStateToProps)(AircraftPage);

--- a/src/containers/ProfilePageContainer.tsx
+++ b/src/containers/ProfilePageContainer.tsx
@@ -1,5 +1,5 @@
 import {connect} from 'react-redux';
-import {loadProfile, saveProfile} from '../modules/profile';
+import {loadProfile, saveProfile, addAircraft, updateAircraft, removeAircraft} from '../modules/profile';
 import ProfilePage from '../components/ProfilePage';
 import {RootState} from '../modules';
 
@@ -11,6 +11,9 @@ const mapStateToProps = (state: RootState) => ({
 const mapActionCreators = {
   loadProfile,
   saveProfile,
+  addAircraft,
+  updateAircraft,
+  removeAircraft,
 };
 
 export default connect(mapStateToProps, mapActionCreators)(ProfilePage);

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -286,12 +286,15 @@
     "firstname": "Vorname",
     "email": "E-Mail",
     "phone": "Telefon",
-    "aircraft": "Flugzeug",
+    "aircraft": "Flugzeuge",
     "immatriculation": "Immatrikulation",
     "type": "Typ",
     "mtow": "Maximales Abfluggewicht (in Kilogramm)",
     "category": "Kategorie",
-    "save": "Speichern"
+    "save": "Speichern",
+    "addAircraft": "Flugzeug hinzufügen",
+    "removeAircraft": "Entfernen",
+    "noAircraft": "Noch keine Flugzeuge gespeichert."
   },
   "lockMovements": {
     "heading": "Erfasste Bewegungen sperren",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -291,7 +291,10 @@
     "type": "Type",
     "mtow": "Maximum takeoff weight (in kilograms)",
     "category": "Category",
-    "save": "Save"
+    "save": "Save",
+    "addAircraft": "Add aircraft",
+    "removeAircraft": "Remove",
+    "noAircraft": "No aircraft saved."
   },
   "lockMovements": {
     "heading": "Lock recorded movements",

--- a/src/modules/movements/sagas.ts
+++ b/src/modules/movements/sagas.ts
@@ -10,6 +10,7 @@ import {error} from '../../util/log';
 import dates from '../../util/dates';
 import ImmutableItemsArray from '../../util/ImmutableItemsArray';
 import {loadRemote} from '../profile'
+import {toAircraftsArray} from '../profile/migration'
 import {FIREBASE_AUTHENTICATION_EVENT} from '../auth'
 import {history} from '../../history'
 
@@ -34,9 +35,25 @@ export function* getProfileDefaultValues() {
 
   const p = snapshot.val() || {};
   const result: Record<string, any> = {};
-  for (const key of ['memberNr', 'email', 'firstname', 'lastname', 'phone', 'immatriculation', 'aircraftCategory', 'aircraftType', 'mtow']) {
+  for (const key of ['memberNr', 'email', 'firstname', 'lastname', 'phone']) {
     if (key in p) result[key] = p[key];
   }
+
+  const aircrafts = toAircraftsArray(p.aircrafts) || [];
+  if (aircrafts.length === 1) {
+    const defaultAircraft = aircrafts[0];
+    for (const key of ['immatriculation', 'aircraftCategory', 'aircraftType', 'mtow']) {
+      if (key in defaultAircraft && defaultAircraft[key] != null) {
+        result[key] = defaultAircraft[key];
+      }
+    }
+  } else if (!p.aircrafts) {
+    // Backwards compat: profile not yet migrated
+    for (const key of ['immatriculation', 'aircraftCategory', 'aircraftType', 'mtow']) {
+      if (key in p) result[key] = p[key];
+    }
+  }
+
   if (!result.email && auth.email) {
     result.email = auth.email;
   }

--- a/src/modules/profile/actions.ts
+++ b/src/modules/profile/actions.ts
@@ -4,6 +4,11 @@ export const SAVE_PROFILE = 'SAVE_PROFILE' as const;
 export const SAVE_PROFILE_SUCCESS = 'SAVE_PROFILE_SUCCESS' as const;
 export const SAVE_PROFILE_FAILURE = 'SAVE_PROFILE_FAILURE' as const;
 export const SAVE_LANGUAGE = 'SAVE_LANGUAGE' as const;
+export const ADD_PROFILE_AIRCRAFT = 'ADD_PROFILE_AIRCRAFT' as const;
+export const UPDATE_PROFILE_AIRCRAFT = 'UPDATE_PROFILE_AIRCRAFT' as const;
+export const REMOVE_PROFILE_AIRCRAFT = 'REMOVE_PROFILE_AIRCRAFT' as const;
+
+import type { Aircraft } from './migration';
 
 export type ProfileAction =
   | { type: typeof LOAD_PROFILE }
@@ -11,7 +16,10 @@ export type ProfileAction =
   | { type: typeof SAVE_PROFILE; payload: { values: Record<string, unknown> } }
   | { type: typeof SAVE_PROFILE_SUCCESS }
   | { type: typeof SAVE_PROFILE_FAILURE }
-  | { type: typeof SAVE_LANGUAGE; payload: { language: string } };
+  | { type: typeof SAVE_LANGUAGE; payload: { language: string } }
+  | { type: typeof ADD_PROFILE_AIRCRAFT; payload: { aircraft: Aircraft } }
+  | { type: typeof UPDATE_PROFILE_AIRCRAFT; payload: { index: number; aircraft: Aircraft } }
+  | { type: typeof REMOVE_PROFILE_AIRCRAFT; payload: { index: number } };
 
 export function loadProfile() {
   return {
@@ -53,5 +61,26 @@ export function saveLanguage(language: string) {
   return {
     type: SAVE_LANGUAGE,
     payload: { language },
+  };
+}
+
+export function addAircraft(aircraft: Aircraft) {
+  return {
+    type: ADD_PROFILE_AIRCRAFT,
+    payload: { aircraft },
+  };
+}
+
+export function updateAircraft(index: number, aircraft: Aircraft) {
+  return {
+    type: UPDATE_PROFILE_AIRCRAFT,
+    payload: { index, aircraft },
+  };
+}
+
+export function removeAircraft(index: number) {
+  return {
+    type: REMOVE_PROFILE_AIRCRAFT,
+    payload: { index },
   };
 }

--- a/src/modules/profile/index.ts
+++ b/src/modules/profile/index.ts
@@ -3,7 +3,10 @@ import sagas from './sagas';
 
 export {
   loadProfile,
-  saveProfile
+  saveProfile,
+  addAircraft,
+  updateAircraft,
+  removeAircraft,
 } from './actions';
 
 export {

--- a/src/modules/profile/migration.spec.ts
+++ b/src/modules/profile/migration.spec.ts
@@ -1,0 +1,144 @@
+import { migrateProfile, toAircraftsArray } from './migration';
+
+describe('migrateProfile', () => {
+  it('returns profile unchanged when aircrafts array already exists', () => {
+    const profile = {
+      firstname: 'Hans',
+      aircrafts: [{ immatriculation: 'HB-ABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'single-engine' }],
+    };
+    const result = migrateProfile(profile);
+    expect(result.needsMigration).toBe(false);
+    expect(result.profile).toBe(profile);
+  });
+
+  it('migrates flat aircraft fields into aircrafts array', () => {
+    const profile = {
+      firstname: 'Hans',
+      immatriculation: 'HB-ABC',
+      aircraftType: 'C172',
+      mtow: 1100,
+      aircraftCategory: 'single-engine',
+    };
+    const result = migrateProfile(profile);
+    expect(result.needsMigration).toBe(true);
+    expect(result.profile.aircrafts).toEqual([{
+      immatriculation: 'HB-ABC',
+      aircraftType: 'C172',
+      mtow: 1100,
+      aircraftCategory: 'single-engine',
+    }]);
+    expect(result.profile.immatriculation).toBeUndefined();
+    expect(result.profile.aircraftType).toBeUndefined();
+    expect(result.profile.mtow).toBeUndefined();
+    expect(result.profile.aircraftCategory).toBeUndefined();
+    expect(result.profile.firstname).toBe('Hans');
+  });
+
+  it('migrates partial flat fields (only immatriculation)', () => {
+    const profile = { immatriculation: 'HB-XYZ' };
+    const result = migrateProfile(profile);
+    expect(result.needsMigration).toBe(true);
+    expect(result.profile.aircrafts).toEqual([{
+      immatriculation: 'HB-XYZ',
+      aircraftType: null,
+      mtow: null,
+      aircraftCategory: null,
+    }]);
+  });
+
+  it('sets empty aircrafts array when no aircraft data exists', () => {
+    const profile = { firstname: 'Hans', lastname: 'Meier' };
+    const result = migrateProfile(profile);
+    expect(result.needsMigration).toBe(false);
+    expect(result.profile.aircrafts).toEqual([]);
+  });
+
+  it('sets empty aircrafts array for empty profile', () => {
+    const result = migrateProfile({});
+    expect(result.needsMigration).toBe(false);
+    expect(result.profile.aircrafts).toEqual([]);
+  });
+
+  it('does not migrate when flat fields are all null', () => {
+    const profile = {
+      firstname: 'Hans',
+      immatriculation: null,
+      aircraftType: null,
+      mtow: null,
+      aircraftCategory: null,
+    };
+    const result = migrateProfile(profile);
+    expect(result.needsMigration).toBe(false);
+    expect(result.profile.aircrafts).toEqual([]);
+  });
+
+  it('preserves existing aircrafts array even if empty', () => {
+    const profile = { firstname: 'Hans', aircrafts: [] };
+    const result = migrateProfile(profile);
+    expect(result.needsMigration).toBe(false);
+    expect(result.profile.aircrafts).toEqual([]);
+  });
+
+  it('handles Firebase object format (non-array) for aircrafts', () => {
+    const profile = {
+      firstname: 'Hans',
+      aircrafts: {
+        '0': { immatriculation: 'HB-ABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' },
+        '1': { immatriculation: 'HB-XYZ', aircraftType: 'PA28', mtow: 1100, aircraftCategory: 'Flugzeug' },
+      },
+    };
+    const result = migrateProfile(profile);
+    expect(result.needsMigration).toBe(false);
+    expect(result.profile.aircrafts).toEqual([
+      { immatriculation: 'HB-ABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' },
+      { immatriculation: 'HB-XYZ', aircraftType: 'PA28', mtow: 1100, aircraftCategory: 'Flugzeug' },
+    ]);
+  });
+
+  it('handles sparse Firebase object for aircrafts', () => {
+    const profile = {
+      aircrafts: {
+        '0': { immatriculation: 'HB-ABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' },
+        '2': { immatriculation: 'HB-XYZ', aircraftType: 'PA28', mtow: 1100, aircraftCategory: 'Flugzeug' },
+      },
+    };
+    const result = migrateProfile(profile);
+    expect(result.needsMigration).toBe(false);
+    expect(Array.isArray(result.profile.aircrafts)).toBe(true);
+    expect((result.profile.aircrafts as any[]).length).toBe(2);
+  });
+});
+
+describe('toAircraftsArray', () => {
+  it('returns array as-is', () => {
+    const arr = [{ immatriculation: 'HB-ABC', aircraftType: null, mtow: null, aircraftCategory: null }];
+    expect(toAircraftsArray(arr)).toBe(arr);
+  });
+
+  it('converts Firebase object to array', () => {
+    const obj = { '0': { immatriculation: 'HB-ABC' }, '1': { immatriculation: 'HB-XYZ' } };
+    expect(toAircraftsArray(obj)).toEqual([{ immatriculation: 'HB-ABC' }, { immatriculation: 'HB-XYZ' }]);
+  });
+
+  it('returns null for null', () => {
+    expect(toAircraftsArray(null)).toBe(null);
+  });
+
+  it('returns null for undefined', () => {
+    expect(toAircraftsArray(undefined)).toBe(null);
+  });
+
+  it('returns null for non-object primitives', () => {
+    expect(toAircraftsArray('string')).toBe(null);
+    expect(toAircraftsArray(42)).toBe(null);
+    expect(toAircraftsArray(true)).toBe(null);
+  });
+
+  it('returns empty array for empty object', () => {
+    expect(toAircraftsArray({})).toEqual([]);
+  });
+
+  it('returns empty array for empty array', () => {
+    expect(toAircraftsArray([])).toEqual([]);
+  });
+});

--- a/src/modules/profile/migration.ts
+++ b/src/modules/profile/migration.ts
@@ -1,0 +1,53 @@
+export interface Aircraft {
+  immatriculation: string | null;
+  aircraftType: string | null;
+  mtow: number | null;
+  aircraftCategory: string | null;
+}
+
+const AIRCRAFT_FIELDS = ['immatriculation', 'aircraftType', 'mtow', 'aircraftCategory'] as const;
+
+export function toAircraftsArray(value: unknown): Aircraft[] | null {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.values(value as Record<string, Aircraft>);
+  }
+  return null;
+}
+
+export function migrateProfile(profile: Record<string, unknown>): {
+  profile: Record<string, unknown>;
+  needsMigration: boolean;
+} {
+  const existing = toAircraftsArray(profile.aircrafts);
+  if (existing !== null) {
+    if (!Array.isArray(profile.aircrafts)) {
+      return { profile: { ...profile, aircrafts: existing }, needsMigration: false };
+    }
+    return { profile, needsMigration: false };
+  }
+
+  const hasFlat = AIRCRAFT_FIELDS.some(
+    key => key in profile && profile[key] != null
+  );
+
+  if (hasFlat) {
+    const aircraft: Aircraft = {
+      immatriculation: typeof profile.immatriculation === 'string' ? profile.immatriculation : null,
+      aircraftType: typeof profile.aircraftType === 'string' ? profile.aircraftType : null,
+      mtow: typeof profile.mtow === 'number' ? profile.mtow : null,
+      aircraftCategory: typeof profile.aircraftCategory === 'string' ? profile.aircraftCategory : null,
+    };
+
+    const migrated = { ...profile, aircrafts: [aircraft] };
+    for (const key of AIRCRAFT_FIELDS) {
+      delete migrated[key];
+    }
+
+    return { profile: migrated, needsMigration: true };
+  }
+
+  return { profile: { ...profile, aircrafts: [] }, needsMigration: false };
+}

--- a/src/modules/profile/remote.ts
+++ b/src/modules/profile/remote.ts
@@ -1,5 +1,6 @@
 import firebase from '../../util/firebase';
-import {get, update} from 'firebase/database';
+import {get, set, update} from 'firebase/database';
+import type { Aircraft } from './migration';
 
 export function load(username: string) {
   return get(firebase(`/profiles/${username}`));
@@ -7,4 +8,18 @@ export function load(username: string) {
 
 export function save(username: string, profile: Record<string, unknown>) {
   return update(firebase(`/profiles/${username}`), profile);
+}
+
+export function saveAircraftsList(username: string, aircrafts: Aircraft[]) {
+  return set(firebase(`/profiles/${username}/aircrafts`), aircrafts.length > 0 ? aircrafts : null);
+}
+
+export async function migrateAircrafts(username: string, aircrafts: Aircraft[]) {
+  await set(firebase(`/profiles/${username}/aircrafts`), aircrafts);
+  await update(firebase(`/profiles/${username}`), {
+    immatriculation: null,
+    aircraftType: null,
+    mtow: null,
+    aircraftCategory: null,
+  });
 }

--- a/src/modules/profile/sagas.spec.ts
+++ b/src/modules/profile/sagas.spec.ts
@@ -24,10 +24,11 @@ describe('modules', () => {
           expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
 
           const profileData = { firstname: 'Hans', lastname: 'Meier' };
+          const migratedProfile = { ...profileData, aircrafts: [] };
           const snapshot = { val: () => profileData };
-          expect(generator.next(snapshot).value).toEqual(put(actions.profileLoaded(profileData)));
+          expect(generator.next(snapshot).value).toEqual(put(actions.profileLoaded(migratedProfile)));
 
-          expect(generator.next().value).toEqual(call(sagas.recordPrivacyPolicyAcceptance, auth, profileData));
+          expect(generator.next().value).toEqual(call(sagas.recordPrivacyPolicyAcceptance, auth, migratedProfile));
 
           expect(generator.next().done).toEqual(true);
         });
@@ -41,11 +42,12 @@ describe('modules', () => {
           expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
 
           const profileData = { firstname: 'Hans', language: 'en' };
+          const migratedProfile = { ...profileData, aircrafts: [] };
           const snapshot = { val: () => profileData };
-          expect(generator.next(snapshot).value).toEqual(put(actions.profileLoaded(profileData)));
+          expect(generator.next(snapshot).value).toEqual(put(actions.profileLoaded(migratedProfile)));
 
           // Next step should call recordPrivacyPolicyAcceptance (changeLanguage is called inline)
-          expect(generator.next().value).toEqual(call(sagas.recordPrivacyPolicyAcceptance, auth, profileData));
+          expect(generator.next().value).toEqual(call(sagas.recordPrivacyPolicyAcceptance, auth, migratedProfile));
 
           expect(generator.next().done).toEqual(true);
           expect(mockChangeLanguage).toHaveBeenCalledWith('en');
@@ -60,9 +62,10 @@ describe('modules', () => {
           expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
 
           const snapshot = { val: () => null };
-          expect(generator.next(snapshot).value).toEqual(put(actions.profileLoaded({})));
+          const emptyProfile = { aircrafts: [] };
+          expect(generator.next(snapshot).value).toEqual(put(actions.profileLoaded(emptyProfile)));
 
-          expect(generator.next().value).toEqual(call(sagas.recordPrivacyPolicyAcceptance, auth, {}));
+          expect(generator.next().value).toEqual(call(sagas.recordPrivacyPolicyAcceptance, auth, emptyProfile));
 
           expect(generator.next().done).toEqual(true);
         });
@@ -238,10 +241,6 @@ describe('modules', () => {
             firstname: 'Hans',
             lastname: 'Meier',
             phone: '+41791234567',
-            immatriculation: 'HBABC',
-            aircraftCategory: 'Motorflugzeug',
-            aircraftType: 'C172',
-            mtow: 1000
           };
           const action = actions.saveProfile(values);
           const generator = sagas.saveProfile(action);
@@ -255,10 +254,6 @@ describe('modules', () => {
             firstname: 'Hans',
             lastname: 'Meier',
             phone: '+41791234567',
-            immatriculation: 'HBABC',
-            aircraftCategory: 'Motorflugzeug',
-            aircraftType: 'C172',
-            mtow: 1000
           };
           expect(generator.next(auth).value).toEqual(call(remote.save, auth.uid, valuesToSave));
 
@@ -276,10 +271,6 @@ describe('modules', () => {
             firstname: 'Hans',
             lastname: 'Meier',
             phone: null,
-            immatriculation: null,
-            aircraftCategory: null,
-            aircraftType: null,
-            mtow: 'notanumber'
           };
           const action = actions.saveProfile(values);
           const generator = sagas.saveProfile(action);
@@ -293,10 +284,6 @@ describe('modules', () => {
             firstname: 'Hans',
             lastname: 'Meier',
             phone: null,
-            immatriculation: null,
-            aircraftCategory: null,
-            aircraftType: null,
-            mtow: null
           };
           expect(generator.next(auth).value).toEqual(call(remote.save, auth.uid, valuesToSave));
 
@@ -356,6 +343,225 @@ describe('modules', () => {
 
           expect(generator.next().done).toEqual(true);
         });
+      });
+    });
+
+    describe('loadProfile with migration', () => {
+      it('should migrate flat aircraft fields to aircrafts array', () => {
+        const generator = sagas.loadProfile();
+
+        expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+        const auth = { uid: 'user-123', guest: false, kiosk: false };
+        expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
+
+        const profileData = {
+          firstname: 'Hans',
+          immatriculation: 'HBABC',
+          aircraftType: 'C172',
+          mtow: 1100,
+          aircraftCategory: 'Flugzeug',
+        };
+        const snapshot = { val: () => profileData };
+        const migratedAircrafts = [{
+          immatriculation: 'HBABC',
+          aircraftType: 'C172',
+          mtow: 1100,
+          aircraftCategory: 'Flugzeug',
+        }];
+
+        // Should call migrateAircrafts since needsMigration is true
+        expect(generator.next(snapshot).value).toEqual(
+          call(remote.migrateAircrafts, auth.uid, migratedAircrafts)
+        );
+
+        const migratedProfile = { firstname: 'Hans', aircrafts: migratedAircrafts };
+        expect(generator.next().value).toEqual(put(actions.profileLoaded(migratedProfile)));
+      });
+
+      it('should not migrate when aircrafts array already exists', () => {
+        const generator = sagas.loadProfile();
+
+        expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+        const auth = { uid: 'user-123' };
+        expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
+
+        const profileData = {
+          firstname: 'Hans',
+          aircrafts: [{ immatriculation: 'HBABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' }],
+        };
+        const snapshot = { val: () => profileData };
+
+        // Should go straight to profileLoaded, no migrateAircrafts call
+        expect(generator.next(snapshot).value).toEqual(put(actions.profileLoaded(profileData)));
+      });
+    });
+
+    describe('addAircraftSaga', () => {
+      const aircraft = { immatriculation: 'HBNEW', aircraftType: 'PA28', mtow: 1100, aircraftCategory: 'Flugzeug' };
+
+      it('should add aircraft and reload profile', () => {
+        const action = actions.addAircraft(aircraft);
+        const generator = sagas.addAircraftSaga(action);
+
+        expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+        const auth = { uid: 'user-123', guest: false, kiosk: false };
+        expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
+
+        const profile = { aircrafts: [{ immatriculation: 'HBABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' }] };
+        const snapshot = { val: () => profile };
+
+        // Should save sorted list
+        expect(generator.next(snapshot).value).toEqual(
+          call(remote.saveAircraftsList, auth.uid, [
+            { immatriculation: 'HBABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' },
+            { immatriculation: 'HBNEW', aircraftType: 'PA28', mtow: 1100, aircraftCategory: 'Flugzeug' },
+          ])
+        );
+
+        expect(generator.next().value).toEqual(call(sagas.loadProfile));
+        expect(generator.next().done).toEqual(true);
+      });
+
+      it('should skip duplicate immatriculation', () => {
+        const dupeAircraft = { immatriculation: 'HBABC', aircraftType: 'PA28', mtow: 900, aircraftCategory: 'Flugzeug' };
+        const action = actions.addAircraft(dupeAircraft);
+        const generator = sagas.addAircraftSaga(action);
+
+        expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+        const auth = { uid: 'user-123', guest: false, kiosk: false };
+        expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
+
+        const profile = { aircrafts: [{ immatriculation: 'HBABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' }] };
+        const snapshot = { val: () => profile };
+
+        // Should return early — no save, no reload
+        expect(generator.next(snapshot).done).toEqual(true);
+      });
+
+      it('should add to empty list', () => {
+        const action = actions.addAircraft(aircraft);
+        const generator = sagas.addAircraftSaga(action);
+
+        expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+        const auth = { uid: 'user-123', guest: false, kiosk: false };
+        expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
+
+        const snapshot = { val: () => ({}) };
+
+        expect(generator.next(snapshot).value).toEqual(
+          call(remote.saveAircraftsList, auth.uid, [aircraft])
+        );
+      });
+    });
+
+    describe('updateAircraftSaga', () => {
+      it('should update aircraft at index and reload profile', () => {
+        const updated = { immatriculation: 'HBABC', aircraftType: 'C182', mtow: 1400, aircraftCategory: 'Flugzeug' };
+        const action = actions.updateAircraft(0, updated);
+        const generator = sagas.updateAircraftSaga(action);
+
+        expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+        const auth = { uid: 'user-123', guest: false, kiosk: false };
+        expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
+
+        const profile = { aircrafts: [
+          { immatriculation: 'HBABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' },
+          { immatriculation: 'HBXYZ', aircraftType: 'PA28', mtow: 1100, aircraftCategory: 'Flugzeug' },
+        ]};
+        const snapshot = { val: () => profile };
+
+        expect(generator.next(snapshot).value).toEqual(
+          call(remote.saveAircraftsList, auth.uid, [
+            { immatriculation: 'HBABC', aircraftType: 'C182', mtow: 1400, aircraftCategory: 'Flugzeug' },
+            { immatriculation: 'HBXYZ', aircraftType: 'PA28', mtow: 1100, aircraftCategory: 'Flugzeug' },
+          ])
+        );
+
+        expect(generator.next().value).toEqual(call(sagas.loadProfile));
+        expect(generator.next().done).toEqual(true);
+      });
+
+      it('should skip if registration conflicts with another entry', () => {
+        const updated = { immatriculation: 'HBXYZ', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' };
+        const action = actions.updateAircraft(0, updated);
+        const generator = sagas.updateAircraftSaga(action);
+
+        expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+        const auth = { uid: 'user-123', guest: false, kiosk: false };
+        expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
+
+        const profile = { aircrafts: [
+          { immatriculation: 'HBABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' },
+          { immatriculation: 'HBXYZ', aircraftType: 'PA28', mtow: 1100, aircraftCategory: 'Flugzeug' },
+        ]};
+        const snapshot = { val: () => profile };
+
+        // Duplicate — should return early
+        expect(generator.next(snapshot).done).toEqual(true);
+      });
+    });
+
+    describe('removeAircraftSaga', () => {
+      it('should remove aircraft at index and reload profile', () => {
+        const action = actions.removeAircraft(1);
+        const generator = sagas.removeAircraftSaga(action);
+
+        expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+        const auth = { uid: 'user-123', guest: false, kiosk: false };
+        expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
+
+        const profile = { aircrafts: [
+          { immatriculation: 'HBABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' },
+          { immatriculation: 'HBXYZ', aircraftType: 'PA28', mtow: 1100, aircraftCategory: 'Flugzeug' },
+        ]};
+        const snapshot = { val: () => profile };
+
+        expect(generator.next(snapshot).value).toEqual(
+          call(remote.saveAircraftsList, auth.uid, [
+            { immatriculation: 'HBABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' },
+          ])
+        );
+
+        expect(generator.next().value).toEqual(call(sagas.loadProfile));
+        expect(generator.next().done).toEqual(true);
+      });
+
+      it('should save empty list when removing last aircraft', () => {
+        const action = actions.removeAircraft(0);
+        const generator = sagas.removeAircraftSaga(action);
+
+        expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+        const auth = { uid: 'user-123', guest: false, kiosk: false };
+        expect(generator.next(auth).value).toEqual(call(remote.load, auth.uid));
+
+        const profile = { aircrafts: [
+          { immatriculation: 'HBABC', aircraftType: 'C172', mtow: 1100, aircraftCategory: 'Flugzeug' },
+        ]};
+        const snapshot = { val: () => profile };
+
+        expect(generator.next(snapshot).value).toEqual(
+          call(remote.saveAircraftsList, auth.uid, [])
+        );
+      });
+
+      it('should not save for guest users', () => {
+        const action = actions.removeAircraft(0);
+        const generator = sagas.removeAircraftSaga(action);
+
+        expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+        const auth = { uid: 'guest', guest: true, kiosk: false };
+        // Should throw and be caught — generator ends
+        expect(generator.next(auth).done).toEqual(true);
       });
     });
   });

--- a/src/modules/profile/sagas.ts
+++ b/src/modules/profile/sagas.ts
@@ -1,5 +1,6 @@
 import * as actions from './actions'
 import * as remote from './remote'
+import { migrateProfile, toAircraftsArray } from './migration'
 import {FIREBASE_AUTHENTICATION_EVENT} from '../auth'
 import {all, call, put, select, takeEvery} from 'redux-saga/effects'
 import i18n from '../../i18n'
@@ -7,8 +8,8 @@ import i18n from '../../i18n'
 const str = (value: unknown): string | null =>
   typeof value === 'string' && value.trim().length > 0 ? value : null;
 
-const nr = (value: unknown): number | null =>
-  typeof value === 'number' ? value : null;
+const sortAircrafts = (aircrafts: any[]) =>
+  [...aircrafts].sort((a, b) => (a.immatriculation || '').localeCompare(b.immatriculation || ''));
 
 export const authSelector = (state: any) => state.auth.data;
 export const privacyPolicyUrlSelector = (state: any) => state.settings.privacyPolicyUrl.url;
@@ -17,10 +18,22 @@ export function* loadProfile() {
   try {
     const auth = yield select(authSelector)
     const snapshot = yield call(remote.load, auth.uid);
-    const profile = snapshot.val() || {};
+    const rawProfile = snapshot.val() || {};
+    const { profile, needsMigration } = migrateProfile(rawProfile);
+
+    if (needsMigration && auth.uid !== 'ipauth' && !auth.guest && !auth.kiosk) {
+      try {
+        yield call(remote.migrateAircrafts, auth.uid, profile.aircrafts as any[]);
+      } catch (migrationError) {
+        if (console && typeof console.error === 'function') {
+          console.error('Failed to persist profile migration', migrationError);
+        }
+      }
+    }
+
     yield put(actions.profileLoaded(profile));
     if (profile.language && profile.language !== i18n.language) {
-      i18n.changeLanguage(profile.language);
+      i18n.changeLanguage(profile.language as string);
     }
     yield call(recordPrivacyPolicyAcceptance, auth, profile);
   } catch(e) {
@@ -61,10 +74,6 @@ export function* saveProfile(action: any) {
       firstname: str(values.firstname),
       lastname: str(values.lastname),
       phone: str(values.phone),
-      immatriculation: str(values.immatriculation),
-      aircraftCategory: str(values.aircraftCategory),
-      aircraftType: str(values.aircraftType),
-      mtow: nr(values.mtow)
     }
 
     yield call(remote.save, auth.uid, valuesToSave);
@@ -75,6 +84,83 @@ export function* saveProfile(action: any) {
       console.error('Failed to save profile', e);
     }
     yield put(actions.saveProfileFailure());
+  }
+}
+
+export function* addAircraftSaga(action: any) {
+  try {
+    const auth = yield select(authSelector);
+
+    if (!auth || auth.guest || auth.kiosk || auth.uid === 'ipauth') {
+      throw new Error('Current user not allowed to save profile');
+    }
+
+    const snapshot = yield call(remote.load, auth.uid);
+    const profile = snapshot.val() || {};
+    const currentAircrafts = toAircraftsArray(profile.aircrafts) || [];
+    const duplicate = currentAircrafts.some(
+      (a: any) => a.immatriculation === action.payload.aircraft.immatriculation
+    );
+    if (duplicate) {
+      return;
+    }
+    const newAircrafts = sortAircrafts([...currentAircrafts, action.payload.aircraft]);
+    yield call(remote.saveAircraftsList, auth.uid, newAircrafts);
+    yield call(loadProfile);
+  } catch (e) {
+    if (console && typeof console.error === 'function') {
+      console.error('Failed to add aircraft', e);
+    }
+  }
+}
+
+export function* updateAircraftSaga(action: any) {
+  try {
+    const auth = yield select(authSelector);
+
+    if (!auth || auth.guest || auth.kiosk || auth.uid === 'ipauth') {
+      throw new Error('Current user not allowed to save profile');
+    }
+
+    const snapshot = yield call(remote.load, auth.uid);
+    const profile = snapshot.val() || {};
+    const currentAircrafts = toAircraftsArray(profile.aircrafts) || [];
+    const duplicate = currentAircrafts.some(
+      (a: any, i: number) => i !== action.payload.index && a.immatriculation === action.payload.aircraft.immatriculation
+    );
+    if (duplicate) {
+      return;
+    }
+    const newAircrafts = sortAircrafts(currentAircrafts.map((a: any, i: number) =>
+      i === action.payload.index ? action.payload.aircraft : a
+    ));
+    yield call(remote.saveAircraftsList, auth.uid, newAircrafts);
+    yield call(loadProfile);
+  } catch (e) {
+    if (console && typeof console.error === 'function') {
+      console.error('Failed to update aircraft', e);
+    }
+  }
+}
+
+export function* removeAircraftSaga(action: any) {
+  try {
+    const auth = yield select(authSelector);
+
+    if (!auth || auth.guest || auth.kiosk || auth.uid === 'ipauth') {
+      throw new Error('Current user not allowed to save profile');
+    }
+
+    const snapshot = yield call(remote.load, auth.uid);
+    const profile = snapshot.val() || {};
+    const currentAircrafts = toAircraftsArray(profile.aircrafts) || [];
+    const newAircrafts = currentAircrafts.filter((_: any, i: number) => i !== action.payload.index);
+    yield call(remote.saveAircraftsList, auth.uid, newAircrafts);
+    yield call(loadProfile);
+  } catch (e) {
+    if (console && typeof console.error === 'function') {
+      console.error('Failed to remove aircraft', e);
+    }
   }
 }
 
@@ -104,6 +190,9 @@ export default function* sagas() {
     takeEvery(actions.LOAD_PROFILE, loadProfile),
     takeEvery(actions.SAVE_PROFILE, saveProfile),
     takeEvery(actions.SAVE_LANGUAGE, saveLanguage),
+    takeEvery(actions.ADD_PROFILE_AIRCRAFT, addAircraftSaga),
+    takeEvery(actions.UPDATE_PROFILE_AIRCRAFT, updateAircraftSaga),
+    takeEvery(actions.REMOVE_PROFILE_AIRCRAFT, removeAircraftSaga),
     takeEvery(FIREBASE_AUTHENTICATION_EVENT, onAuthentication),
   ])
 }


### PR DESCRIPTION
## Summary
- Migrate profile aircraft storage from single flat fields to an array of aircraft objects
- **Profile page**: aircraft section with add (full 4-field form), inline edit (expand/collapse), and remove. Pilot form save button scoped inside its section. Duplicate registrations prevented. List sorted alphabetically.
- **Movement wizard**: 1 aircraft = auto-prefilled, no chips. 2+ aircraft = empty fields with favourites bar (gold star + chips, mobile-friendly 44px tap targets, wraps on narrow screens). Clicking a chip fills all 4 fields + recalculates arrival fees.
- **On-read migration**: existing profiles with flat aircraft fields auto-migrate to array on login. Migration persist is error-resilient (profile loads in-memory even if Firebase write fails, retries next login). Backwards-compat fallback in movement prefill for un-migrated profiles.
- **Firebase rules**: `aircrafts/$index` added to profiles with field validation
- **Defensive normalizer**: handles Firebase storing arrays as objects with numeric keys
- Action types prefixed (`ADD_PROFILE_AIRCRAFT` etc.) to avoid collision with `settings/aircrafts` module

## Test plan
- [x] `npm test` — 1775 tests pass (16 new)
- [x] `npm run typecheck` — clean
- [ ] Deploy Firebase rules (`firebase deploy --only database`) before testing
- [ ] Profile page: existing profile with flat aircraft auto-migrates to list
- [ ] Profile page: add, edit, remove aircraft
- [ ] Profile page: duplicate registration blocked
- [ ] New departure with 1 aircraft: prefilled, no chips
- [ ] New departure with 2+ aircraft: empty fields, chips shown, click fills form
- [ ] New arrival with chips: click recalculates landing fees
- [ ] New departure with 0 aircraft: no prefill, no chips
- [ ] ReadOnly movement: no chips
- [ ] Mobile: chips wrap, tap targets comfortable