### PR TITLE
Add profileEnabled feature flag, disable for lspv

### DIFF
--- a/projects/default.json
+++ b/projects/default.json
@@ -31,5 +31,6 @@
   "loginForm": "usernamePassword",
   "maskContactInformation": true,
   "memberManagement": false,
-  "privacySettings": false
+  "privacySettings": false,
+  "profileEnabled": true
 }

--- a/projects/lspv.json
+++ b/projects/lspv.json
@@ -122,5 +122,6 @@
     }
   ],
   "paymentMethods": ["cash", "card_external", "twint_external"],
-  "memberManagement": true
+  "memberManagement": true,
+  "profileEnabled": false
 }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -55,7 +55,7 @@ class App extends React.PureComponent<any, any> {
         <Route exact path="/message" component={MessagePage}/>
         <Route exact path="/help" component={HelpPage}/>
         <Route exact path="/aerodrome-status" component={AerodromeStatusPage}/>
-        <Route exact path="/profile" component={ProfilePage}/>
+        {(typeof __CONF__ === 'undefined' || __CONF__.profileEnabled !== false) && <Route exact path="/profile" component={ProfilePage}/>}
         <Redirect to="/"/>
       </Switch>
     );

--- a/src/components/StartPage/LoginInfo.tsx
+++ b/src/components/StartPage/LoginInfo.tsx
@@ -167,7 +167,7 @@ class LoginInfo extends React.Component<any, any> {
     return (
       <StyledMenu ref={this.setMenuRef}>
         <StyledMenuUsername>{getUsername(auth, t)}</StyledMenuUsername>
-        {auth && auth.guest !== true && auth.kiosk !== true && auth.uid !== 'ipauth' && (
+        {(typeof __CONF__ === 'undefined' || __CONF__.profileEnabled !== false) && auth && auth.guest !== true && auth.kiosk !== true && auth.uid !== 'ipauth' && (
           <StyledMenuLink to="/profile" data-cy="profile">{t('login.profile')}</StyledMenuLink>
         )}
         <StyledMenuButton onClick={this.props.logout} data-cy="logout">{t('login.logout')}</StyledMenuButton>

--- a/src/components/wizards/pages/AircraftPage.tsx
+++ b/src/components/wizards/pages/AircraftPage.tsx
@@ -228,7 +228,7 @@ const AircraftPage: React.FC<AircraftPageProps> = (props) => {
 
 const mapStateToProps = (state: any) => ({
   aircraftSettings: state.settings.aircrafts,
-  profileAircrafts: state.profile.profile?.aircrafts,
+  profileAircrafts: (typeof __CONF__ === 'undefined' || __CONF__.profileEnabled !== false) ? state.profile.profile?.aircrafts : undefined,
 });
 
 export default connect(mapStateToProps)(AircraftPage);

--- a/src/modules/movements/sagas.ts
+++ b/src/modules/movements/sagas.ts
@@ -25,6 +25,10 @@ export const authSelector = (state: any) => state.auth.data;
 export const privacyPolicyUrlSelector = (state: any) => state.settings.privacyPolicyUrl.url;
 
 export function* getProfileDefaultValues() {
+  if (typeof __CONF__ !== 'undefined' && __CONF__.profileEnabled === false) {
+    return {}
+  }
+
   const auth = yield select(authSelector)
 
   if (!auth || !auth.uid || auth.guest === true || auth.kiosk === true) {

--- a/src/modules/profile/sagas.ts
+++ b/src/modules/profile/sagas.ts
@@ -179,6 +179,9 @@ export function* saveLanguage(action: any) {
 }
 
 export function* onAuthentication(action: any) {
+  if (typeof __CONF__ !== 'undefined' && __CONF__.profileEnabled === false) {
+    return;
+  }
   const authData = action.payload.authData;
   if (authData && authData.guest === false && authData.kiosk === false) {
     yield call(loadProfile);


### PR DESCRIPTION
## Summary
- Add `profileEnabled` config flag (default: `true` in `default.json`)
- Set `profileEnabled: false` in `projects/lspv.json`
- Gate all profile touchpoints: menu link, `/profile` route, auto-load on login, movement prefill, wizard quick-pick chips
- Uses `typeof __CONF__ !== 'undefined' && __CONF__.profileEnabled === false` pattern to stay safe when `__CONF__` isn't set (test environments)

## Test plan
- [x] `npm test` — 1775 tests pass
- [x] `npm run typecheck` — clean
- [ ] `npm start --project=lspv` — no profile link, no /profile route, no prefill, no favourites bar
- [ ] `npm start --project=lszm` — profile works as before