### PR TITLE
Improve finish page layout for departure and arrival

### DIFF
--- a/src/components/ImageButton/OptionalLink.tsx
+++ b/src/components/ImageButton/OptionalLink.tsx
@@ -16,7 +16,14 @@ const StyledLink = styled(Link)`
 `;
 
 const ClickableChild = styled.div`
+  display: inline-block;
   cursor: pointer;
+  padding: 1em;
+
+  &:hover {
+    background-color: #fafafa;
+    box-shadow: rgba(0, 0, 0, 0.117647) 0px 1px 6px, rgba(0, 0, 0, 0.117647) 0px 1px 4px;
+  }
 `;
 
 const OptionalLink = props =>

--- a/src/components/ImageButton/__snapshots__/ImageButton.spec.tsx.snap
+++ b/src/components/ImageButton/__snapshots__/ImageButton.spec.tsx.snap
@@ -27,7 +27,7 @@ exports[`components ImageButton propagates onClick to OptionalLink 1`] = `
     class="sc-dlnkDq iIJZep"
   >
     <div
-      class="sc-gtstET eMrqxt"
+      class="sc-gtstET BmhKC"
     >
       <div
         class="sc-hKFxUR rTqsk"
@@ -47,7 +47,7 @@ exports[`components ImageButton renders label and image 1`] = `
     class="sc-dlnkDq iIJZep"
   >
     <div
-      class="sc-gtstET eMrqxt"
+      class="sc-gtstET BmhKC"
     >
       <div
         class="sc-hKFxUR rTqsk"

--- a/src/components/ImageButton/__snapshots__/OptionalLink.spec.tsx.snap
+++ b/src/components/ImageButton/__snapshots__/OptionalLink.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`components ImageButton OptionalLink renders Link component if \`href\` 
 exports[`components ImageButton OptionalLink renders no Link component if \`href\` prop is not set 1`] = `
 <div>
   <div
-    class="sc-gtstET eMrqxt"
+    class="sc-gtstET BmhKC"
   />
 </div>
 `;

--- a/src/components/wizards/ArrivalWizard/Finish/ActionButton.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/ActionButton.tsx
@@ -1,15 +1,6 @@
 import styled from 'styled-components';
 import ImageButton from '../../../ImageButton';
 
-const ActionButton = styled(ImageButton)`
-  width: 50%;
-  display: table-cell;
-
-  @media screen and (max-width: 768px) {
-    width: 100%;
-    display: inline-block;
-    margin-top: 2em;
-  }
-`;
+const ActionButton = styled(ImageButton)``;
 
 export default ActionButton;

--- a/src/components/wizards/ArrivalWizard/Finish/ActionsWrapper.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/ActionsWrapper.tsx
@@ -1,9 +1,15 @@
 import styled from 'styled-components';
 
 const ActionsWrapper = styled.div`
-  display: table;
-  width: 80%;
-  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  gap: 2em;
+  padding-top: 1em;
+
+  @media screen and (max-width: 500px) {
+    flex-direction: column;
+    align-items: center;
+  }
 `;
 
 export default ActionsWrapper;

--- a/src/components/wizards/ArrivalWizard/Finish/Fees.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/Fees.tsx
@@ -5,13 +5,13 @@ import MaterialIcon from '../../../MaterialIcon'
 import { withTranslation, useTranslation } from 'react-i18next'
 
 const ExpandableDetails = styled.div`
-  padding: 1.5rem;
-  width: 400px;
+  padding: 0.5em 0;
+  max-width: 100%;
 `
 
 const Amount = styled.div`
-  font-size: 1.5em;
-  margin-bottom: 1em;
+  font-size: 1.3em;
+  margin-bottom: 0.75em;
 `
 
 const DetailsContainer = styled.div`
@@ -23,10 +23,9 @@ const DetailsTrigger = styled.button`
   background-color: #eee;
   border: none;
   cursor: pointer;
-  font-size: 1.2em;
-  width: 100%;
-  padding: 0.4em;
-  border-radius: 2px;
+  font-size: 1em;
+  padding: 0.4em 1.5em;
+  border-radius: 4px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/wizards/ArrivalWizard/Finish/Finish.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/Finish.tsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 import {getFromItemKey} from '../../../../util/reference-number';
 import Wrapper from './Wrapper';
 import Heading from './Heading';
@@ -10,6 +11,19 @@ import PaymentMethodImport from '../../../../containers/PaymentMethodContainer'
 const PaymentMethod = PaymentMethodImport as any
 import {HeadingType} from '../../MovementWizard'
 import Fees from './Fees'
+
+const InfoCard = styled.div`
+  background-color: #fafafa;
+  border: 1px solid #eee;
+  border-radius: 6px;
+  padding: 1em;
+  width: 100%;
+  max-width: 500px;
+`;
+
+const FullWidth = styled.div`
+  width: 100%;
+`;
 
 const Finish = props => {
   const { t } = useTranslation();
@@ -51,29 +65,35 @@ const Finish = props => {
       {heading && <Heading>{heading}</Heading>}
       {showPayment ? (
         <>
-          <ReferenceNumberMessage>{t('arrival.referenceNumber', {number: getFromItemKey(itemKey)})}</ReferenceNumberMessage>
-          <Fees fees={fees}/>
-          <PaymentMethod
-            itemKey={itemKey}
-            email={email}
-            immatriculation={immatriculation}
-            createMovementFromMovement={createMovementFromMovement}
-            finish={finish}
-            amount={totalGross}
-            landings={landings}
-            landingFeeSingle={landingFeeSingle}
-            landingFeeCode={landingFeeCode}
-            landingFeeTotal={landingFeeTotal}
-            goArounds={goArounds}
-            goAroundFeeSingle={goAroundFeeSingle}
-            goAroundFeeCode={goAroundFeeCode}
-            goAroundFeeTotal={goAroundFeeTotal}
-            enabledPaymentMethods={enabledPaymentMethods}
-            invoiceRecipientNames={invoiceRecipientNames}
-          />
+          <InfoCard>
+            <ReferenceNumberMessage>{t('arrival.referenceNumber', {number: getFromItemKey(itemKey)})}</ReferenceNumberMessage>
+            <Fees fees={fees}/>
+          </InfoCard>
+          <FullWidth>
+            <PaymentMethod
+              itemKey={itemKey}
+              email={email}
+              immatriculation={immatriculation}
+              createMovementFromMovement={createMovementFromMovement}
+              finish={finish}
+              amount={totalGross}
+              landings={landings}
+              landingFeeSingle={landingFeeSingle}
+              landingFeeCode={landingFeeCode}
+              landingFeeTotal={landingFeeTotal}
+              goArounds={goArounds}
+              goAroundFeeSingle={goAroundFeeSingle}
+              goAroundFeeCode={goAroundFeeCode}
+              goAroundFeeTotal={goAroundFeeTotal}
+              enabledPaymentMethods={enabledPaymentMethods}
+              invoiceRecipientNames={invoiceRecipientNames}
+            />
+          </FullWidth>
         </>
       ) : (
-        <FinishActions itemKey={itemKey} createMovementFromMovement={createMovementFromMovement} finish={finish}/>
+        <FullWidth>
+          <FinishActions itemKey={itemKey} createMovementFromMovement={createMovementFromMovement} finish={finish}/>
+        </FullWidth>
       )}
     </Wrapper>
   );

--- a/src/components/wizards/ArrivalWizard/Finish/Heading.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/Heading.tsx
@@ -1,8 +1,24 @@
 import styled from 'styled-components';
+import MaterialIcon from '../../../MaterialIcon';
+import React from 'react';
 
-const Heading = styled.div`
-  font-size: 2em;
-  padding: 2em;
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4em;
+  font-size: 1.5em;
+  padding: 0.5em 0;
+  color: #2e7d32;
+  max-width: 500px;
+  margin: 0 auto;
 `;
+
+const Heading = ({ children }: { children: React.ReactNode }) => (
+  <Wrapper>
+    <MaterialIcon icon="check_circle" />
+    {children}
+  </Wrapper>
+);
 
 export default Heading;

--- a/src/components/wizards/ArrivalWizard/Finish/Message.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/Message.tsx
@@ -1,14 +1,13 @@
 import styled from 'styled-components';
 
 const Message = styled.div`
-  font-size: 1.5em;
-  padding: 1em;
+  font-size: 1.2em;
+  padding: 0.5em;
 `;
 
 const ReferenceNumberMessage = styled.div`
-  font-size: 1.5em;
-  padding: 0.2em;
-  display: inline-block;
+  font-size: 1.1em;
+  color: #555;
 `;
 
 export {ReferenceNumberMessage}

--- a/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.tsx
@@ -12,6 +12,7 @@ import {withRouter} from 'react-router-dom'
 import {getFromItemKey} from '../../../../util/reference-number'
 import {PAYMENT_METHODS} from '../../../../util/paymentMethods'
 import CardExternalPaymentMessage from './CardExternalPaymentMessage'
+import Heading from './Heading'
 
 const Container = styled.div`
 `
@@ -26,15 +27,6 @@ const SelectContainer = styled.div`
 const InstructionMessage = styled.div`
   font-size: 1.2em;
   margin: 1em;
-`
-
-const SuccessMessage = styled.div`
-  font-size: 1.5em;
-  margin: 0 auto 3em auto;
-  max-width: 800px;
-  padding: 1em;
-  background-color: #bddda9;
-  border-radius: 10px;
 `
 
 const FailureMessage = styled(InstructionMessage)`
@@ -201,7 +193,7 @@ class PaymentMethod extends Component<any, any> {
             ) : method === 'card_external' ? (
               <CardExternalPaymentMessage {...{itemKey} as any}/>
             ) : method === 'checkout' ? (
-              <SuccessMessage>{t('arrival.payment.success')}</SuccessMessage>
+              <Heading>{t('arrival.payment.success')}</Heading>
             ) : null}
             <FinishActions itemKey={itemKey}
                            createMovementFromMovement={createMovementFromMovement}

--- a/src/components/wizards/ArrivalWizard/Finish/Wrapper.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/Wrapper.tsx
@@ -3,9 +3,12 @@ import styled from 'styled-components';
 const Wrapper = styled.div`
   text-align: center;
   display: flex;
-  padding: 2em;
-  gap: 2em;
+  padding: 1.5em 2em;
+  gap: 1.5em;
   flex-direction: column;
+  align-items: center;
+  min-height: 60vh;
+  justify-content: center;
 `;
 
 export default Wrapper;

--- a/src/components/wizards/DepartureWizard/Finish/Finish.tsx
+++ b/src/components/wizards/DepartureWizard/Finish/Finish.tsx
@@ -1,24 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'styled-components';
 import ImageButton from '../../../ImageButton';
+import Wrapper from '../../ArrivalWizard/Finish/Wrapper';
+import Heading from '../../ArrivalWizard/Finish/Heading';
 import { useTranslation } from 'react-i18next';
-
-const Wrapper = styled.div`
-  text-align: center;
-`;
-
-const Message = styled.div`
-  font-size: 2em;
-  padding: 2em;
-`;
 
 const Finish = props => {
   const { t } = useTranslation();
   const exitImagePath = require('./ic_exit_to_app_black_48dp_2x.png');
   return (
     <Wrapper>
-      <Message>{props.isUpdate === true ? t('departure.updated') : t('departure.created')}</Message>
+      <Heading>{props.isUpdate === true ? t('departure.updated') : t('departure.created')}</Heading>
       <ImageButton label={t('departure.finish')} img={exitImagePath} onClick={props.finish} dataCy="finish-button"/>
     </Wrapper>
   );


### PR DESCRIPTION
## Summary
- Green checkmark heading for success state (replaces oversized plain text)
- Fee info grouped in a card with subtle border and background
- Vertically centered content with max-width constraint
- Compact details trigger button (narrower, smaller font)
- Consistent action button sizing across departure and arrival
- Hover effect (shadow) on clickable ImageButtons
- Payment success message uses the same Heading component
- Departure finish reuses arrival finish Wrapper and Heading

## Test plan
- [x] `npm test` — 1775 tests pass
- [x] `npm run typecheck` — clean
- [ ] Departure finish page — green heading, centered layout, hover on Beenden
- [ ] Arrival finish with payment — info card, payment flow, consistent heading
- [ ] Arrival finish without payment — FinishActions with hover
- [ ] Mobile — responsive layout