### PR TITLE
Add save-to-profile prompt on movement finish pages

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -16,6 +16,7 @@ import ArrivalPaymentPage from "../../containers/ArrivalPaymentPageContainer";
 import AerodromeStatusPage from '../../containers/AerodromeStatusPageContainer';
 import ProfilePage from '../../containers/ProfilePageContainer';
 
+
 const UNPROTECTED_ROUTES = [
   '/aerodrome-status'
 ]

--- a/src/components/wizards/ArrivalWizard/Finish/FinishActions.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/FinishActions.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import ActionButton from './ActionButton'
 import ActionsWrapper from './ActionsWrapper'
+import SaveProfilePrompt from '../../SaveProfilePrompt'
 import { useTranslation } from 'react-i18next'
 
 const FinishActions = ({itemKey, createMovementFromMovement, finish}) => {
@@ -10,6 +11,8 @@ const FinishActions = ({itemKey, createMovementFromMovement, finish}) => {
   const departureImagePath = require('./ic_flight_takeoff_black_48dp_2x.png');
 
   return (
+    <>
+    <SaveProfilePrompt/>
     <ActionsWrapper>
       <ActionButton
         label={t('hints.recordDeparture')}
@@ -23,6 +26,7 @@ const FinishActions = ({itemKey, createMovementFromMovement, finish}) => {
         dataCy="finish-button"
       />
     </ActionsWrapper>
+    </>
   )
 }
 

--- a/src/components/wizards/DepartureWizard/Finish/Finish.tsx
+++ b/src/components/wizards/DepartureWizard/Finish/Finish.tsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ImageButton from '../../../ImageButton';
+import SaveProfilePrompt from '../../SaveProfilePrompt';
 import Wrapper from '../../ArrivalWizard/Finish/Wrapper';
 import Heading from '../../ArrivalWizard/Finish/Heading';
 import { useTranslation } from 'react-i18next';
@@ -11,6 +12,7 @@ const Finish = props => {
   return (
     <Wrapper>
       <Heading>{props.isUpdate === true ? t('departure.updated') : t('departure.created')}</Heading>
+      {!props.isUpdate && <SaveProfilePrompt/>}
       <ImageButton label={t('departure.finish')} img={exitImagePath} onClick={props.finish} dataCy="finish-button"/>
     </Wrapper>
   );

--- a/src/components/wizards/SaveProfilePrompt.tsx
+++ b/src/components/wizards/SaveProfilePrompt.tsx
@@ -1,0 +1,201 @@
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+import MaterialIcon from '../MaterialIcon';
+import { addAircraft, updateAircraft, saveProfile } from '../../modules/profile';
+import { toAircraftsArray, Aircraft } from '../../modules/profile/migration';
+
+const Bar = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6em;
+  padding: 0.6em 1em;
+  margin: 0.5em auto;
+  background-color: #fff8e1;
+  border: 1px solid #ffe082;
+  border-radius: 6px;
+  color: #666;
+  font-size: 0.9em;
+`;
+
+const StarIcon = styled.span`
+  color: #e8a735;
+  display: flex;
+  align-items: center;
+`;
+
+const SaveLink = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: bold;
+  cursor: pointer;
+  color: ${props => props.theme.colors.main};
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const DismissButton = styled.button`
+  background: none;
+  border: none;
+  padding: 0.2em;
+  cursor: pointer;
+  color: #bbb;
+  font-size: 1.1em;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    color: #666;
+  }
+`;
+
+const SuccessMessage = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.6em 1em;
+  margin: 0.5em auto;
+  background-color: #e8f5e9;
+  border: 1px solid #a5d6a7;
+  border-radius: 6px;
+  color: #2e7d32;
+  font-size: 0.9em;
+  font-weight: bold;
+`;
+
+interface SaveProfilePromptProps {
+  wizardValues: Record<string, any>;
+  profileAircrafts: Aircraft[];
+  profileHasPersonalData: boolean;
+  auth: any;
+  addAircraft: (aircraft: Aircraft) => void;
+  updateAircraft: (index: number, aircraft: Aircraft) => void;
+  saveProfile: (values: Record<string, unknown>) => void;
+}
+
+const SaveProfilePrompt: React.FC<SaveProfilePromptProps> = ({
+  wizardValues,
+  profileAircrafts,
+  profileHasPersonalData,
+  auth,
+  addAircraft,
+  updateAircraft,
+  saveProfile,
+}) => {
+  const { t } = useTranslation();
+  const [state, setState] = useState<'prompt' | 'confirmed' | 'dismissed'>('prompt');
+
+
+  if (typeof __CONF__ !== 'undefined' && __CONF__.profileEnabled === false) {
+    return null;
+  }
+
+  if (!auth || auth.guest || auth.kiosk || auth.uid === 'ipauth') {
+    return null;
+  }
+
+  if (state === 'dismissed' || !wizardValues?.immatriculation) {
+    return null;
+  }
+
+  if (state === 'confirmed') {
+    return (
+      <SuccessMessage>
+        <MaterialIcon icon="check"/>
+        {t('common.saved')}
+      </SuccessMessage>
+    );
+  }
+
+  const movementAircraft: Aircraft = {
+    immatriculation: wizardValues.immatriculation,
+    aircraftType: wizardValues.aircraftType || null,
+    mtow: wizardValues.mtow ?? null,
+    aircraftCategory: wizardValues.aircraftCategory || null,
+  };
+
+  const existingIndex = profileAircrafts.findIndex(
+    a => a.immatriculation === movementAircraft.immatriculation
+  );
+  const existing = existingIndex >= 0 ? profileAircrafts[existingIndex] : null;
+
+  const aircraftChanged = existing && (
+    existing.aircraftType !== movementAircraft.aircraftType ||
+    existing.mtow !== movementAircraft.mtow ||
+    existing.aircraftCategory !== movementAircraft.aircraftCategory
+  );
+
+  // Determine prompt mode
+  let promptKey: string | null = null;
+  let onConfirm: () => void;
+
+  if (!profileHasPersonalData) {
+    promptKey = 'profile.saveDetailsPrompt';
+    onConfirm = () => {
+      saveProfile({
+        firstname: wizardValues.firstname || null,
+        lastname: wizardValues.lastname || null,
+        email: wizardValues.email || null,
+        phone: wizardValues.phone || null,
+        memberNr: wizardValues.memberNr || null,
+      });
+      if (!existing) {
+        addAircraft(movementAircraft);
+      } else if (aircraftChanged) {
+        updateAircraft(existingIndex, movementAircraft);
+      }
+      setState('confirmed');
+    };
+  } else if (!existing) {
+    promptKey = 'profile.saveAircraftPrompt';
+    onConfirm = () => {
+      addAircraft(movementAircraft);
+      setState('confirmed');
+    };
+  } else if (aircraftChanged) {
+    promptKey = 'profile.updateAircraftPrompt';
+    onConfirm = () => {
+      updateAircraft(existingIndex, movementAircraft);
+      setState('confirmed');
+    };
+  } else {
+    return null;
+  }
+
+  return (
+    <Bar>
+      <StarIcon><MaterialIcon icon="star"/></StarIcon>
+      {t(promptKey, { immatriculation: movementAircraft.immatriculation })}
+      <SaveLink type="button" onClick={onConfirm}>{t('common.save')}</SaveLink>
+      <DismissButton type="button" onClick={() => setState('dismissed')} aria-label="dismiss">
+        <MaterialIcon icon="close"/>
+      </DismissButton>
+    </Bar>
+  );
+};
+
+const mapStateToProps = (state: any) => {
+  const profile = state.profile.profile;
+  const aircrafts = toAircraftsArray(profile?.aircrafts) || [];
+  return {
+    wizardValues: state.ui.wizard.values,
+    profileAircrafts: aircrafts,
+    profileHasPersonalData: !!(profile?.firstname && profile?.lastname),
+    auth: state.auth.data,
+  };
+};
+
+const mapDispatchToProps = {
+  addAircraft,
+  updateAircraft,
+  saveProfile,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(SaveProfilePrompt);

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -12,6 +12,9 @@
     "login": "Anmelden",
     "confirm": "Bestätigen",
     "finish": "Beenden",
+    "yes": "Ja",
+    "no": "Nein",
+    "saved": "Gespeichert!",
     "add": "Hinzufügen",
     "download": "Herunterladen",
     "status": "Status",
@@ -294,7 +297,10 @@
     "save": "Speichern",
     "addAircraft": "Flugzeug hinzufügen",
     "removeAircraft": "Entfernen",
-    "noAircraft": "Noch keine Flugzeuge gespeichert."
+    "noAircraft": "Noch keine Flugzeuge gespeichert.",
+    "saveDetailsPrompt": "Pilotendaten und Flugzeug speichern für das nächste Mal?",
+    "saveAircraftPrompt": "{{immatriculation}} im Profil speichern?",
+    "updateAircraftPrompt": "{{immatriculation}} im Profil aktualisieren?"
   },
   "lockMovements": {
     "heading": "Erfasste Bewegungen sperren",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,6 +12,9 @@
     "login": "Log in",
     "confirm": "Confirm",
     "finish": "Finish",
+    "yes": "Yes",
+    "no": "No",
+    "saved": "Saved!",
     "add": "Add",
     "download": "Download",
     "status": "Status",
@@ -294,7 +297,10 @@
     "save": "Save",
     "addAircraft": "Add aircraft",
     "removeAircraft": "Remove",
-    "noAircraft": "No aircraft saved."
+    "noAircraft": "No aircraft saved.",
+    "saveDetailsPrompt": "Save pilot info and aircraft so they're prefilled next time?",
+    "saveAircraftPrompt": "Save {{immatriculation}} to your profile?",
+    "updateAircraftPrompt": "Update {{immatriculation}} in your profile?"
   },
   "lockMovements": {
     "heading": "Lock recorded movements",


### PR DESCRIPTION
## Summary
- Inline prompt on departure/arrival finish pages offering to save pilot info and aircraft to the profile
- **Three modes**: empty profile (saves pilot data + aircraft), aircraft not in profile (saves aircraft), aircraft changed (updates aircraft)
- Warm amber banner with star icon, "Speichern" action link + dismiss ×
- Green success confirmation pill on save
- Placed after payment completion on arrivals to avoid confusion with payment context
- Respects `profileEnabled` flag, skips guest/kiosk/ipauth users
- Checks confirmed state early to prevent Redux re-render from hiding the success message

## Test plan
- [x] `npm test` — 1775 tests pass
- [x] `npm run typecheck` — clean
- [ ] New user: first departure → "Save pilot info and aircraft" prompt → click Save → green confirmation
- [ ] Existing user, new aircraft: departure → "Save HBXYZ to your profile?" prompt
- [ ] Existing user, changed MTOW: arrival → "Update HBXYZ in your profile?" prompt
- [ ] Same aircraft, no changes: no prompt
- [ ] Arrival with payment: prompt shows after payment, not during
- [ ] Click × to dismiss: prompt disappears
- [ ] `profileEnabled: false` (lspv): no prompt
- [ ] Guest/kiosk user: no prompt