### PR TITLE
Shorten deployment workflow names

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -1,4 +1,4 @@
-name: Deploy to Firebase Hosting on merge (dev)
+name: Deploy (dev)
 'on':
   push:
     branches:

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy to Firebase Hosting on merge (prod)
+name: Deploy (prod)
 'on':
   push:
     branches:


### PR DESCRIPTION
## Summary
- Rename `Deploy to Firebase Hosting on merge (dev)` → `Deploy (dev)`
- Rename `Deploy to Firebase Hosting on merge (prod)` → `Deploy (prod)`

Full names were getting truncated in the GitHub web UI.