### PR TITLE
Convert router-touching classes to function components

### DIFF
--- a/src/components/AdminPage/AdminPage.tsx
+++ b/src/components/AdminPage/AdminPage.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
-import {withRouter} from "react-router-dom";
+import React, {useEffect, useState} from 'react';
+import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 import VerticalHeaderLayout from '../VerticalHeaderLayout';
 import JumpNavigation from '../JumpNavigation';
@@ -39,97 +39,88 @@ const AdminContent = styled.div`
   }
 `;
 
-class AdminPage extends Component<any, any> {
-  constructor(props) {
-    super(props);
-    this.state = {
-      activeTab: 'export'
-    };
-    this.handleTabChange = this.handleTabChange.bind(this)
+const renderSubPage = (activeTab: string) => {
+  switch (activeTab) {
+    case 'export':
+      return <AdminExportPage/>;
+    case 'lock-movements':
+      return <AdminLockMovementsPage/>;
+    case 'aerodrome-status':
+      return <AdminAerodromeStatusPage/>;
+    case 'messages':
+      return <AdminMessagesPage/>;
+    case 'import':
+      return <AdminImportPage/>;
+    case 'aircraft':
+      return <AdminAircraftPage/>;
+    case 'invoice-recipients':
+      return <AdminInvoiceRecipientsPage/>;
+    case 'guest-access':
+      return <AdminGuestAccessPage/>;
+    case 'kiosk-access':
+      return <AdminKioskAccessPage/>;
+    case 'privacy':
+      return <AdminPrivacySettingsPage/>;
+    default:
+      return <AdminExportPage/>;
+  }
+};
+
+const AdminPage = ({auth, guestAccessToken, kioskAccessToken}: any) => {
+  const history = useHistory();
+  const [activeTab, setActiveTab] = useState('export');
+  const isAdmin = auth.data.admin === true;
+
+  useEffect(() => {
+    if (!isAdmin) {
+      history.push('/');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const hiddenTabs: string[] = [];
+
+  const invoicePaymentEnabled = objectToArray(__CONF__.paymentMethods).includes('invoice');
+  const guestAccessEnabled = guestAccessToken && guestAccessToken.token;
+  const kioskAccessEnabled = kioskAccessToken && kioskAccessToken.token;
+  const memberManagementEnabled = __CONF__.memberManagement === true;
+
+  if (!invoicePaymentEnabled) {
+    hiddenTabs.push('invoice-recipients');
+  }
+  if (!guestAccessEnabled) {
+    hiddenTabs.push('guest-access');
+  }
+  if (!kioskAccessEnabled) {
+    hiddenTabs.push('kiosk-access');
+  }
+  if (!memberManagementEnabled) {
+    hiddenTabs.push('import');
+  }
+  if (__CONF__.privacySettings !== true) {
+    hiddenTabs.push('privacy');
   }
 
-  componentWillMount() {
-    if (this.props.auth.data.admin !== true) {
-      this.props.history.push('/');
-    }
-  }
-
-  handleTabChange(tab) {
-    this.setState({activeTab: tab});
-  }
-
-  renderSubPage() {
-    switch (this.state.activeTab) {
-      case 'export':
-        return <AdminExportPage/>;
-      case 'lock-movements':
-        return <AdminLockMovementsPage/>;
-      case 'aerodrome-status':
-        return <AdminAerodromeStatusPage/>;
-      case 'messages':
-        return <AdminMessagesPage/>;
-      case 'import':
-        return <AdminImportPage/>;
-      case 'aircraft':
-        return <AdminAircraftPage/>;
-      case 'invoice-recipients':
-        return <AdminInvoiceRecipientsPage/>;
-      case 'guest-access':
-        return <AdminGuestAccessPage/>;
-      case 'kiosk-access':
-        return <AdminKioskAccessPage/>;
-      case 'privacy':
-        return <AdminPrivacySettingsPage/>;
-      default:
-        return <AdminExportPage/>;
-    }
-  };
-
-  render() {
-    const hiddenTabs: string[] = []
-
-    const invoicePaymentEnabled = objectToArray(__CONF__.paymentMethods).includes('invoice')
-    const guestAccessEnabled = this.props.guestAccessToken && this.props.guestAccessToken.token
-    const kioskAccessEnabled = this.props.kioskAccessToken && this.props.kioskAccessToken.token
-    const memberManagementEnabled = __CONF__.memberManagement === true
-
-    if (!invoicePaymentEnabled) {
-      hiddenTabs.push('invoice-recipients')
-    }
-    if (!guestAccessEnabled) {
-      hiddenTabs.push('guest-access')
-    }
-    if (!kioskAccessEnabled) {
-      hiddenTabs.push('kiosk-access')
-    }
-    if (!memberManagementEnabled) {
-      hiddenTabs.push('import')
-    }
-    if (__CONF__.privacySettings !== true) {
-      hiddenTabs.push('privacy')
-    }
-
-    return (
-      <VerticalHeaderLayout>
-        {this.props.auth.data.admin === true &&
-          <Content>
-            <JumpNavigation/>
-            <AdminLayout>
-              <AdminNavigation
-                activeTab={this.state.activeTab}
-                hiddenTabs={hiddenTabs}
-                onTabChange={this.handleTabChange}
-              />
-              <AdminContent>
-                {this.renderSubPage()}
-              </AdminContent>
-            </AdminLayout>
-          </Content>
-        }
-      </VerticalHeaderLayout>
-    );
-  }
-}
+  return (
+    <VerticalHeaderLayout>
+      {isAdmin &&
+        <Content>
+          <JumpNavigation/>
+          <AdminLayout>
+            <AdminNavigation
+              activeTab={activeTab}
+              hiddenTabs={hiddenTabs}
+              onTabChange={setActiveTab}
+            />
+            <AdminContent>
+              {renderSubPage(activeTab)}
+            </AdminContent>
+          </AdminLayout>
+        </Content>
+      }
+    </VerticalHeaderLayout>
+  );
+};
 
 (AdminPage as any).propTypes = {
   auth: PropTypes.object.isRequired,
@@ -141,4 +132,4 @@ class AdminPage extends Component<any, any> {
   })
 };
 
-export default withRouter(AdminPage);
+export default AdminPage;

--- a/src/components/LoginPage/LoginPage.tsx
+++ b/src/components/LoginPage/LoginPage.tsx
@@ -4,7 +4,7 @@ import Header from './Header';
 import EmailLoginForm from '../../containers/EmailLoginFormContainer'
 import UsernamePasswordLoginForm from '../../containers/UsernamePasswordLoginFormContainer'
 import styled from 'styled-components'
-import {withRouter} from 'react-router-dom'
+import {useLocation} from 'react-router-dom'
 import getAuthQueryToken, {getGuestOnly} from '../../util/getAuthQueryToken'
 import LanguageSwitch from '../LanguageSwitch';
 
@@ -64,8 +64,9 @@ const PrivacyText = styled.p`
   }
 `
 
-const LoginPage = ({location, privacyPolicyUrl, emailSent}: {location: any, privacyPolicyUrl?: string | null, emailSent?: boolean}) => {
+const LoginPage = ({privacyPolicyUrl, emailSent}: {privacyPolicyUrl?: string | null, emailSent?: boolean}) => {
   const { t } = useTranslation();
+  const location = useLocation<any>();
   const queryToken = getAuthQueryToken(location)
   const guestOnly = getGuestOnly(location)
   return (
@@ -91,4 +92,4 @@ const LoginPage = ({location, privacyPolicyUrl, emailSent}: {location: any, priv
   );
 }
 
-export default withRouter(LoginPage);
+export default LoginPage;

--- a/src/components/MovementsPage/MovementsPage.tsx
+++ b/src/components/MovementsPage/MovementsPage.tsx
@@ -1,31 +1,37 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {useEffect} from 'react';
+import {useHistory} from 'react-router-dom';
 import Content from './Content';
 import MovementList from '../../containers/MovementListContainer';
 import JumpNavigation from '../JumpNavigation';
 import VerticalHeaderLayout from '../VerticalHeaderLayout';
 
-class MovementsPage extends Component<any, any> {
+const MovementsPage = ({loadLockDate, auth}: any) => {
+  const history = useHistory();
+  const isGuestOrKiosk = auth.data.guest === true || auth.data.kiosk === true;
 
-  componentWillMount() {
-    this.props.loadLockDate();
+  useEffect(() => {
+    loadLockDate();
 
-    if (this.props.auth.data.guest === true || this.props.auth.data.kiosk === true) {
-      this.props.history.push('/');
+    if (isGuestOrKiosk) {
+      history.push('/');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (isGuestOrKiosk) {
+    return null;
   }
 
-  render() {
-    return (
-      <VerticalHeaderLayout>
-        <Content>
-          <JumpNavigation/>
-          <MovementList/>
-        </Content>
-      </VerticalHeaderLayout>
-    );
-  }
-}
+  return (
+    <VerticalHeaderLayout>
+      <Content>
+        <JumpNavigation/>
+        <MovementList/>
+      </Content>
+    </VerticalHeaderLayout>
+  );
+};
 
 (MovementsPage as any).propTypes = {
   loadLockDate: PropTypes.func.isRequired,

--- a/src/components/wizards/ArrivalWizard/ArrivalPaymentPage/index.tsx
+++ b/src/components/wizards/ArrivalWizard/ArrivalPaymentPage/index.tsx
@@ -1,36 +1,47 @@
-import React, {Component} from 'react'
-import { withTranslation } from 'react-i18next'
+import React, {useEffect} from 'react'
+import {useTranslation} from 'react-i18next'
+import {useParams} from 'react-router-dom'
 import Finish from '../../../../containers/ArrivalFinishContainer'
 import Centered from '../../../Centered'
 import MaterialIcon from '../../../MaterialIcon'
 import VerticalHeaderLayout from '../../../VerticalHeaderLayout'
 
-class ArrivalPaymentPage extends Component<any, any> {
+const ArrivalPaymentPage = (props: any) => {
+  const {t} = useTranslation();
+  const {key} = useParams<{key?: string}>();
+  const {
+    loadLockDate,
+    loadAircraftSettings,
+    initMovement,
+    editMovement,
+    initNewMovement,
+    wizard,
+    lockDateLoading,
+    finish,
+  } = props;
 
-  componentWillMount() {
-    this.props.loadLockDate();
-    this.props.loadAircraftSettings();
-    if (typeof this.props.initMovement === 'function') {
-      this.props.initMovement();
-    } else if (this.props.match.params.key) {
-      this.props.editMovement('arrival', this.props.match.params.key);
+  useEffect(() => {
+    loadLockDate();
+    loadAircraftSettings();
+    if (typeof initMovement === 'function') {
+      initMovement();
+    } else if (key) {
+      editMovement('arrival', key);
     } else {
-      this.props.initNewMovement();
+      initNewMovement();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (wizard.initialized !== true || lockDateLoading === true) {
+    return <Centered><MaterialIcon icon="sync" rotate="left"/> {t('common.loading')}</Centered>;
   }
 
-  render() {
-    const { t } = this.props;
-    if (this.props.wizard.initialized !== true || this.props.lockDateLoading === true) {
-      return <Centered><MaterialIcon icon="sync" rotate="left"/> {t('common.loading')}</Centered>;
-    }
-
-    return (
-      <VerticalHeaderLayout>
-        <Finish finish={this.props.finish}/>
-      </VerticalHeaderLayout>
-    )
-  }
+  return (
+    <VerticalHeaderLayout>
+      <Finish finish={finish}/>
+    </VerticalHeaderLayout>
+  )
 }
 
-export default withTranslation()(ArrivalPaymentPage)
+export default ArrivalPaymentPage

--- a/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.tsx
@@ -1,6 +1,6 @@
-import React, {Component} from 'react'
+import React, {useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
-import { withTranslation } from 'react-i18next'
+import {useTranslation} from 'react-i18next'
 import styled from 'styled-components'
 import {Step} from '../../../../modules/ui/arrivalPayment'
 import SingleSelect from '../../../SingleSelect'
@@ -8,11 +8,13 @@ import {CancelButton, NextButton} from '../../../WizardNavigation'
 import CashPaymentMessage from './CashPaymentMessage'
 import FinishActions from './FinishActions'
 import TwintPaymentMessage from './TwintPaymentMessage'
-import {withRouter} from 'react-router-dom'
+import {useLocation} from 'react-router-dom'
 import {getFromItemKey} from '../../../../util/reference-number'
 import {PAYMENT_METHODS} from '../../../../util/paymentMethods'
 import CardExternalPaymentMessage from './CardExternalPaymentMessage'
 import Heading from './Heading'
+import Centered from '../../../Centered'
+import MaterialIcon from '../../../MaterialIcon'
 
 const Container = styled.div`
 `
@@ -43,39 +45,30 @@ const StyledCancelButton = styled(CancelButton)`
   margin-bottom: 1em;
 `
 
-class PaymentMethod extends Component<any, any> {
+const PaymentMethod = (props: any) => {
+  const {t} = useTranslation();
+  const location = useLocation();
+  const [initialized, setInitialized] = useState(false);
 
-  constructor(props) {
-    super(props)
-    this.confirmMethod = this.confirmMethod.bind(this);
-  }
+  const {
+    itemKey,
+    method,
+    step,
+    failure,
+    createMovementFromMovement,
+    finish,
+    setMethod,
+    cancelCardPayment,
+    enabledPaymentMethods,
+    invoiceRecipientNames,
+  } = props;
 
-  componentWillMount() {
-    // set to completed if success message from online checkout
-    const query = new URLSearchParams(this.props.location.search)
-    const successParam = query.get('success')
-    if (successParam === 'true') {
-      this.props.setMethod('checkout')
-      this.props.setStep(Step.COMPLETED)
-      return
-    }
-
-    // continue with only enabled payment method if only one
-    if (this.props.enabledPaymentMethods.length === 1) {
-      const method = this.props.enabledPaymentMethods[0]
-      this.props.setMethod(method)
-      this.confirmMethod(method)
-    }
-  }
-
-  confirmMethod(method) {
-    if (!method) {
-      return
+  const confirmMethod = (selectedMethod: string) => {
+    if (!selectedMethod) {
+      return;
     }
 
     const {
-      itemKey,
-      invoiceRecipientNames,
       email,
       immatriculation,
       amount,
@@ -89,21 +82,21 @@ class PaymentMethod extends Component<any, any> {
       goAroundFeeTotal,
       createCardPayment,
       setStep,
-      saveMovementPaymentMethod
-    } = this.props
+      saveMovementPaymentMethod,
+    } = props;
 
     const paymentMethodData: any = {
-      method
-    }
+      method: selectedMethod,
+    };
 
-    if (['cash', 'twint_external', 'card_external'].includes(method)) {
-      setStep(Step.COMPLETED)
-    } else if (method.startsWith('invoice')) {
-      paymentMethodData.method = 'invoice'
-      paymentMethodData.invoiceRecipientName = method.substring(method.indexOf('[') + 1, method.indexOf(']'))
-      setStep(Step.COMPLETED)
-    } else if (method === 'card') {
-      setStep(Step.CONFIRMED)
+    if (['cash', 'twint_external', 'card_external'].includes(selectedMethod)) {
+      setStep(Step.COMPLETED);
+    } else if (selectedMethod.startsWith('invoice')) {
+      paymentMethodData.method = 'invoice';
+      paymentMethodData.invoiceRecipientName = selectedMethod.substring(selectedMethod.indexOf('[') + 1, selectedMethod.indexOf(']'));
+      setStep(Step.COMPLETED);
+    } else if (selectedMethod === 'card') {
+      setStep(Step.CONFIRMED);
       createCardPayment(
         itemKey,
         getFromItemKey(itemKey),
@@ -120,10 +113,10 @@ class PaymentMethod extends Component<any, any> {
         goAroundFeeSingle,
         goAroundFeeCode,
         goAroundFeeTotal
-      )
-    } else if (method === 'checkout') {
-      paymentMethodData.status = 'pending'
-      setStep(Step.CONFIRMED)
+      );
+    } else if (selectedMethod === 'checkout') {
+      paymentMethodData.status = 'pending';
+      setStep(Step.CONFIRMED);
       createCardPayment(
         itemKey,
         getFromItemKey(itemKey),
@@ -140,109 +133,119 @@ class PaymentMethod extends Component<any, any> {
         goAroundFeeSingle,
         goAroundFeeCode,
         goAroundFeeTotal
-      )
+      );
     }
 
-    saveMovementPaymentMethod('arrival', itemKey, paymentMethodData)
+    saveMovementPaymentMethod('arrival', itemKey, paymentMethodData);
+  };
+
+  useEffect(() => {
+    // set to completed if success message from online checkout
+    const query = new URLSearchParams(location.search);
+    const successParam = query.get('success');
+    if (successParam === 'true') {
+      props.setMethod('checkout');
+      props.setStep(Step.COMPLETED);
+      setInitialized(true);
+      return;
+    }
+
+    // continue with only enabled payment method if only one
+    if (enabledPaymentMethods.length === 1) {
+      const onlyMethod = enabledPaymentMethods[0];
+      props.setMethod(onlyMethod);
+      confirmMethod(onlyMethod);
+    }
+
+    setInitialized(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!initialized) {
+    return <Centered><MaterialIcon icon="sync" rotate="left"/> {t('common.loading')}</Centered>;
   }
 
-  render() {
-    const { t } = this.props;
-    const {
-      itemKey,
-      method,
-      step,
-      failure,
-      createMovementFromMovement,
-      finish,
-      setMethod,
-      cancelCardPayment,
-      enabledPaymentMethods,
-      invoiceRecipientNames
-    } = this.props
+  const availableMethods = PAYMENT_METHODS
+    .filter(m => enabledPaymentMethods.includes(m.value) && m.value !== 'invoice')
+    .map(m => ({
+      ...m,
+      label: m.value === 'checkout'
+        ? t('arrival.payment.checkoutCta')
+        : t(`paymentMethods.${m.value}`)
+    }));
 
-    const availableMethods = PAYMENT_METHODS
-      .filter(method => enabledPaymentMethods.includes(method.value) && method.value !== 'invoice')
-      .map(method => ({
-        ...method,
-        label: method.value === 'checkout'
-          ? t('arrival.payment.checkoutCta')
-          : t(`paymentMethods.${method.value}`)
-      }))
-
-    if (enabledPaymentMethods.includes('invoice')) {
-      for (const invoiceRecipientName of invoiceRecipientNames) {
-        availableMethods.push({
-          value: `invoice[${invoiceRecipientName}]`,
-          label: t('arrival.payment.invoice', {recipient: invoiceRecipientName})
-        })
-      }
+  if (enabledPaymentMethods.includes('invoice')) {
+    for (const invoiceRecipientName of invoiceRecipientNames) {
+      availableMethods.push({
+        value: `invoice[${invoiceRecipientName}]`,
+        label: t('arrival.payment.invoice', {recipient: invoiceRecipientName})
+      });
     }
+  }
 
-    return (
-      <Container>
-        {failure && (
-          <FailureMessage>{t('arrival.payment.failure')}</FailureMessage>
-        )}
-        {step === Step.COMPLETED ? (
-          <>
-            {method === 'cash' ? (
-              <CashPaymentMessage itemKey={itemKey}/>
-            ) : method === 'twint_external' ? (
-              <TwintPaymentMessage {...{itemKey} as any}/>
-            ) : method === 'card_external' ? (
-              <CardExternalPaymentMessage {...{itemKey} as any}/>
-            ) : method === 'checkout' ? (
-              <Heading>{t('arrival.payment.success')}</Heading>
-            ) : null}
-            <FinishActions itemKey={itemKey}
-                           createMovementFromMovement={createMovementFromMovement}
-                           finish={finish}/>
-          </>
-        ) : step === Step.CONFIRMED ? (
-          method === 'card' ? (
-            <>
-              <InstructionMessage>{t('arrival.payment.cardInstruction')}</InstructionMessage>
-              <StyledCancelButton
-                type="button"
-                label={t('arrival.payment.cancel')}
-                onClick={() => {
-                  cancelCardPayment()
-                }}
-              />
-            </>
+  return (
+    <Container>
+      {failure && (
+        <FailureMessage>{t('arrival.payment.failure')}</FailureMessage>
+      )}
+      {step === Step.COMPLETED ? (
+        <>
+          {method === 'cash' ? (
+            <CashPaymentMessage itemKey={itemKey}/>
+          ) : method === 'twint_external' ? (
+            <TwintPaymentMessage {...{itemKey} as any}/>
+          ) : method === 'card_external' ? (
+            <CardExternalPaymentMessage {...{itemKey} as any}/>
           ) : method === 'checkout' ? (
-            <>
-              <>
-                <InstructionMessage>{t('arrival.payment.redirect')}</InstructionMessage>
-              </>
-            </>
-          ) : null
-        ) : (<>
-            <InstructionMessage>{t('arrival.payment.selectMethod')}</InstructionMessage>
-            <SelectContainer>
-              <SingleSelect
-                items={availableMethods}
-                orientation="vertical"
-                onChange={e => setMethod(e.target.value)}
-                value={method}
-              />
-            </SelectContainer>
-            <StyledNextButton
-              type="submit"
-              label={t('arrival.payment.next')}
-              icon="navigate_next"
-              onClick={() => this.confirmMethod(method)}
-              dataCy="next-button"
-              primary
-              disabled={!method}
+            <Heading>{t('arrival.payment.success')}</Heading>
+          ) : null}
+          <FinishActions itemKey={itemKey}
+                         createMovementFromMovement={createMovementFromMovement}
+                         finish={finish}/>
+        </>
+      ) : step === Step.CONFIRMED ? (
+        method === 'card' ? (
+          <>
+            <InstructionMessage>{t('arrival.payment.cardInstruction')}</InstructionMessage>
+            <StyledCancelButton
+              type="button"
+              label={t('arrival.payment.cancel')}
+              onClick={() => {
+                cancelCardPayment()
+              }}
             />
           </>
-        )}
-      </Container>
-    )
-  }
-}
+        ) : method === 'checkout' ? (
+          <>
+            <>
+              <InstructionMessage>{t('arrival.payment.redirect')}</InstructionMessage>
+            </>
+          </>
+        ) : null
+      ) : (<>
+          <InstructionMessage>{t('arrival.payment.selectMethod')}</InstructionMessage>
+          <SelectContainer>
+            <SingleSelect
+              items={availableMethods}
+              orientation="vertical"
+              onChange={e => setMethod(e.target.value)}
+              value={method}
+            />
+          </SelectContainer>
+          <StyledNextButton
+            type="submit"
+            label={t('arrival.payment.next')}
+            icon="navigate_next"
+            onClick={() => confirmMethod(method)}
+            dataCy="next-button"
+            primary
+            disabled={!method}
+          />
+        </>
+      )}
+    </Container>
+  );
+};
 
 (PaymentMethod as any).propTypes = {
   itemKey: PropTypes.string.isRequired,
@@ -267,6 +270,6 @@ class PaymentMethod extends Component<any, any> {
   setStep: PropTypes.func.isRequired,
   cancelCardPayment: PropTypes.func.isRequired,
   saveMovementPaymentMethod: PropTypes.func.isRequired
-}
+};
 
-export default withRouter(withTranslation()(PaymentMethod) as any)
+export default PaymentMethod;


### PR DESCRIPTION
## Summary
Pre-work for the upcoming `react-router-dom` v6 upgrade. Converts five
components that use legacy router APIs (`withRouter`, `match` via route
injection, `this.props.history`) to function components using v5's own
hooks. Once this lands, the v6 migration becomes a mechanical swap
(`useHistory` → `useNavigate`, `<Switch>` → `<Routes>`, etc.) without
needing synthetic-prop shims or a local `withRouter` adapter.

Covered in this PR:
- `LoginPage` — swap `withRouter` for `useLocation`.
- `MovementsPage` — class → function; `useHistory` for the guest/kiosk
  redirect; early-return `null` avoids flashing the movement list.
- `ArrivalPaymentPage` — class → function; `useParams` + mount effect.
- `AdminPage` — class → function; `useState` for tabs, `useHistory`
  for the non-admin redirect.
- `PaymentMethod` — class → function; `useLocation` + `useTranslation`.
  Adds an `initialized` state gate so the `?success=true` return path
  from hosted checkout doesn't briefly show the selector before the
  success screen.

`MovementWizard` is the last remaining class that reads `match.params`
and will land in a follow-up PR.

## Test plan
- [ ] Login flow works (email token + guest-only query string paths).
- [ ] `/movements` as a regular user renders; as guest/kiosk redirects
      to `/` without flashing the list.
- [ ] `/arrival/:key/payment` shows loading spinner then Finish.
- [ ] `/admin` as admin: all enabled tabs render, switching works.
- [ ] `/admin` as non-admin: redirects to `/`.
- [ ] Feature-flag-hidden admin tabs (`invoice-recipients`,
      `guest-access`, `kiosk-access`, `import`, `privacy`) hide/show
      correctly per `__CONF__` and redux tokens.
- [ ] Arrival finish: select method → submit → completes.
- [ ] Arrival finish with single enabled method: auto-confirms.
- [ ] Return from hosted checkout (`?success=true`): lands on success
      screen with no flash of the selector.
- [ ] Cancel card payment button still dispatches `cancelCardPayment`.
- [ ] `npm run typecheck` clean.
- [ ] `npm test` passes.