### PR TITLE
Update patch and minor dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "i18next": "^26.0.5",
         "process": "^0.11.10",
         "react-final-form": "^7.0.0",
-        "react-i18next": "^17.0.3"
+        "react-i18next": "^17.0.4"
       },
       "devDependencies": {
         "@babel/cli": "^7.2.3",
@@ -22,7 +22,7 @@
         "@babel/preset-react": "^7.0.0",
         "@babel/preset-typescript": "^7.0.0",
         "@babel/runtime": "^7.3.1",
-        "@sentry/react": "^10.48.0",
+        "@sentry/react": "^10.49.0",
         "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -41,7 +41,7 @@
         "css-loader": "^7.1.4",
         "csv-parse": "^6.1.0",
         "csv-stringify": "^6.6.0",
-        "cypress": "^15.13.1",
+        "cypress": "^15.14.0",
         "del": "^8.0.1",
         "firebase": "^12.12.0",
         "gulp": "^5.0.1",
@@ -72,7 +72,7 @@
         "stream-browserify": "^3.0.0",
         "style-loader": "^4.0.0",
         "styled-components": "^6.4.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "util": "^0.12.5",
         "webpack": "^5.106.2",
         "webpack-cli": "^7.0.2",
@@ -5133,80 +5133,80 @@
       "license": "MIT"
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.48.0.tgz",
-      "integrity": "sha512-SCiTLBXzugFKxev6NoKYBIhQoDk0gUh0AVVVepCBqfCJiWBG01Zvv0R5tCVohr4cWRllkQ8mlBdNQd/I7s9tdA==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.49.0.tgz",
+      "integrity": "sha512-n0QRx0Ysx6mPfIydTkz7VP0FmwM+/EqMZiRqdsU3aTYsngE9GmEDV0OL1bAy6a8N/C1xf9vntkuAtj6N/8Z51w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.48.0"
+        "@sentry/core": "10.49.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.48.0.tgz",
-      "integrity": "sha512-tGkEyOM1HDS9qebDphUMEnyk3qq/50AnuTBiFmMJyjNzowylVGmRRk0sr3xkmbVHCDXQCiYnDmSVlJ2x4SDMrQ==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.49.0.tgz",
+      "integrity": "sha512-JNsUBGv0faCFE7MeZUH99Y9lU9qq3LBALbLxpE1x7ngNrQnVYRlcFgdqaD/btNBKr8awjYL8gmcSkHBWskGqLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.48.0"
+        "@sentry/core": "10.49.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.48.0.tgz",
-      "integrity": "sha512-sevRTePfuk4PNuz9KAKpmTZEomAU0aLXyIhOwA0OnUDdxPhkY8kq5lwDbuxTHv6DQUjUX3YgFbY45VH1JEqHKA==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.49.0.tgz",
+      "integrity": "sha512-IEy4lwHVMiRE3JAcn+kFKjsTgalDOCSTf20SoFd+nkt6rN/k1RDyr4xpdfF//Kj3UdeTmbuibYjK5H/FLhhnGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.48.0",
-        "@sentry/core": "10.48.0"
+        "@sentry-internal/browser-utils": "10.49.0",
+        "@sentry/core": "10.49.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.48.0.tgz",
-      "integrity": "sha512-9nWuN2z4O+iwbTfuYV5ZmngBgJU/ZxfOo47A5RJP3Nu/kl59aJ1lUhILYOKyeNOIC/JyeERmpIcTxnlPXQzZ3Q==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.49.0.tgz",
+      "integrity": "sha512-7D/NrgH1Qwx5trDYaaTSSJmCb1yVQQLqFG4G/S9x2ltzl9876lSGJL8UeW8ReNQgF3CDAcwbmm/9aXaVSBUNZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.48.0",
-        "@sentry/core": "10.48.0"
+        "@sentry-internal/replay": "10.49.0",
+        "@sentry/core": "10.49.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.48.0.tgz",
-      "integrity": "sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.49.0.tgz",
+      "integrity": "sha512-bGCHc+wK2Dx67YoSbmtlt04alqWfQ+dasD/GVipVOq50gvw/BBIDHTEWRJEjACl+LrvszeY54V+24p8z4IgysA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.48.0",
-        "@sentry-internal/feedback": "10.48.0",
-        "@sentry-internal/replay": "10.48.0",
-        "@sentry-internal/replay-canvas": "10.48.0",
-        "@sentry/core": "10.48.0"
+        "@sentry-internal/browser-utils": "10.49.0",
+        "@sentry-internal/feedback": "10.49.0",
+        "@sentry-internal/replay": "10.49.0",
+        "@sentry-internal/replay-canvas": "10.49.0",
+        "@sentry/core": "10.49.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
-      "integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.49.0.tgz",
+      "integrity": "sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5214,14 +5214,14 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.48.0.tgz",
-      "integrity": "sha512-uc93vKjmu6gNns+JAX4qquuxWpAMit0uGPA1TYlMjct9NG1uX3TkDPJAr9Pgd1lOXx8mKqCmj5fK33QeExMpPw==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.49.0.tgz",
+      "integrity": "sha512-WdfJve0orTiumr25Ozgs2p2KaJR9xV82Z5V9IYBi0TadsurSWK6xI6SAFjw84tQht9Fp8q4UCn3QYCnApF4BfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.48.0",
-        "@sentry/core": "10.48.0"
+        "@sentry/browser": "10.49.0",
+        "@sentry/core": "10.49.0"
       },
       "engines": {
         "node": ">=18"
@@ -8486,9 +8486,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.13.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.1.tgz",
-      "integrity": "sha512-jLkgo75zlwo7PhXp0XJot+zIfFSDzN1SvTml6Xf3ETM1XHRWnH3Q4LAR3orCo/BsnxPnhjG3m5HYSvn9DAtwBg==",
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.14.0.tgz",
+      "integrity": "sha512-AHt9YLKVl6uOFfXsLM3+LSZFwsx36BJRyFv4CjsqcRgr+V9kir0IPVRZUgqZVNudRalx771A1c4yR3DmXvSiBQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -16348,9 +16348,9 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.3.tgz",
-      "integrity": "sha512-x4xjvUNZ56T+zfXWNedNnCET9Xq1IBYWX7IsWo5cCQ/RT+Rm7GWqt0h9PShFi4IhyMnsdiu1C6Jc4DE+/S3PFQ==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.4.tgz",
+      "integrity": "sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -18812,9 +18812,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.0.0",
     "@babel/runtime": "^7.3.1",
-    "@sentry/react": "^10.48.0",
+    "@sentry/react": "^10.49.0",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -44,7 +44,7 @@
     "css-loader": "^7.1.4",
     "csv-parse": "^6.1.0",
     "csv-stringify": "^6.6.0",
-    "cypress": "^15.13.1",
+    "cypress": "^15.14.0",
     "del": "^8.0.1",
     "firebase": "^12.12.0",
     "gulp": "^5.0.1",
@@ -75,7 +75,7 @@
     "stream-browserify": "^3.0.0",
     "style-loader": "^4.0.0",
     "styled-components": "^6.4.0",
-    "typescript": "^6.0.2",
+    "typescript": "^6.0.3",
     "util": "^0.12.5",
     "webpack": "^5.106.2",
     "webpack-cli": "^7.0.2",
@@ -93,6 +93,6 @@
     "i18next": "^26.0.5",
     "process": "^0.11.10",
     "react-final-form": "^7.0.0",
-    "react-i18next": "^17.0.3"
+    "react-i18next": "^17.0.4"
   }
 }


### PR DESCRIPTION
## Summary
Same-minor-version bumps:
- `@sentry/react` 10.48.0 → 10.49.0
- `cypress` 15.13.1 → 15.14.0
- `react-i18next` 17.0.3 → 17.0.4
- `typescript` 6.0.2 → 6.0.3

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 1775 tests pass, 9 snapshots pass
- [ ] CI green
- [ ] Cypress suite green