### PR TITLE
Refactor MovementWizard for maintainability

### DIFF
--- a/src/components/wizards/MovementWizard.spec.tsx
+++ b/src/components/wizards/MovementWizard.spec.tsx
@@ -1,0 +1,264 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { WizardState } from '../../modules/ui/wizard/reducer';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockGoToPreviousPage = jest.fn();
+const mockSubmitPage = jest.fn();
+const mockGetNextAction = jest.fn(() => jest.fn());
+
+jest.mock('./useWizardNavigation', () => () => ({
+  goToPreviousPage: mockGoToPreviousPage,
+  submitPage: mockSubmitPage,
+  getNextAction: mockGetNextAction,
+}));
+
+jest.mock('../VerticalHeaderLayout', () => {
+  return ({ children }: any) => <div data-testid="layout">{children}</div>;
+});
+
+jest.mock('./Breadcrumbs', () => {
+  return ({ title }: any) => <div data-testid="breadcrumbs">{title}</div>;
+});
+
+jest.mock('../Centered', () => {
+  return ({ children }: any) => <div data-testid="centered">{children}</div>;
+});
+
+jest.mock('../MaterialIcon', () => {
+  return () => <span data-testid="material-icon" />;
+});
+
+jest.mock('../CommitFailureDialog', () => {
+  return ({ errorMsg }: any) => <div data-testid="commit-failure-dialog">{errorMsg}</div>;
+});
+
+jest.mock('./WizardDialog', () => {
+  return () => <div data-testid="wizard-dialog" />;
+});
+
+jest.mock('../../util/reference-number', () => ({
+  getFromItemKey: (key: string) => `REF-${key}`,
+}));
+
+import MovementWizard from './MovementWizard';
+
+const MockPageComponent = (props: any) => (
+  <div
+    data-testid="page-component"
+    data-readonly={props.readOnly}
+    data-is-admin={props.isAdmin}
+    data-is-guest={props.isGuest}
+  />
+);
+
+const MockFinishComponent = (props: any) => (
+  <div
+    data-testid="finish-component"
+    data-is-update={props.isUpdate}
+    data-heading-type={props.headingType}
+  />
+);
+
+const createProps = (overrides: any = {}) => ({
+  pages: overrides.pages || [
+    { component: MockPageComponent, label: 'Aircraft' },
+    { component: MockPageComponent, label: 'Pilot' },
+  ],
+  finishComponentClass: overrides.finishComponentClass || MockFinishComponent,
+  wizard: overrides.wizard || {
+    initialized: true,
+    page: 1,
+    committed: false,
+    values: { immatriculation: 'HBABC' },
+    commitError: null,
+    dialogs: {},
+  } as WizardState,
+  match: overrides.match || { params: {} },
+  auth: overrides.auth || { data: { admin: false, guest: false } },
+  newMovementLabel: overrides.newMovementLabel || 'New Departure',
+  updateMovementLabel: overrides.updateMovementLabel || 'Edit Departure',
+  lockDateLoading: overrides.lockDateLoading ?? false,
+  locked: overrides.locked ?? false,
+
+  initNewMovement: overrides.initNewMovement || jest.fn(),
+  editMovement: overrides.editMovement || jest.fn(),
+  initMovement: overrides.initMovement !== undefined ? overrides.initMovement : null,
+  updateValues: overrides.updateValues || jest.fn(),
+  nextPage: overrides.nextPage || jest.fn(),
+  previousPage: overrides.previousPage || jest.fn(),
+  cancel: overrides.cancel || jest.fn(),
+  finish: overrides.finish || jest.fn(),
+  showDialog: overrides.showDialog || jest.fn(),
+  hideDialog: overrides.hideDialog || jest.fn(),
+  saveMovement: overrides.saveMovement || jest.fn(),
+  unsetCommitError: overrides.unsetCommitError || jest.fn(),
+  loadLockDate: overrides.loadLockDate || jest.fn(),
+  loadAircraftSettings: overrides.loadAircraftSettings || jest.fn(),
+});
+
+describe('MovementWizard', () => {
+  describe('initialization', () => {
+    it('calls loadLockDate and loadAircraftSettings on mount', () => {
+      const loadLockDate = jest.fn();
+      const loadAircraftSettings = jest.fn();
+      render(<MovementWizard {...createProps({ loadLockDate, loadAircraftSettings })} />);
+
+      expect(loadLockDate).toHaveBeenCalled();
+      expect(loadAircraftSettings).toHaveBeenCalled();
+    });
+
+    it('calls initNewMovement when no key and no initMovement', () => {
+      const initNewMovement = jest.fn();
+      render(<MovementWizard {...createProps({ initNewMovement })} />);
+
+      expect(initNewMovement).toHaveBeenCalled();
+    });
+
+    it('calls editMovement with key when match.params.key is set', () => {
+      const editMovement = jest.fn();
+      render(<MovementWizard {...createProps({
+        editMovement,
+        match: { params: { key: 'abc123' } },
+      })} />);
+
+      expect(editMovement).toHaveBeenCalledWith('abc123');
+    });
+
+    it('calls initMovement when provided as a function', () => {
+      const initMovement = jest.fn();
+      const initNewMovement = jest.fn();
+      const editMovement = jest.fn();
+      render(<MovementWizard {...createProps({
+        initMovement,
+        initNewMovement,
+        editMovement,
+      })} />);
+
+      expect(initMovement).toHaveBeenCalled();
+      expect(initNewMovement).not.toHaveBeenCalled();
+      expect(editMovement).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows loading text when wizard is not initialized', () => {
+      render(<MovementWizard {...createProps({
+        wizard: { initialized: false, page: 1, committed: false, values: {}, commitError: null, dialogs: {} },
+      })} />);
+
+      expect(screen.getByText('wizard.loading')).toBeTruthy();
+    });
+
+    it('shows loading text when lockDateLoading is true', () => {
+      render(<MovementWizard {...createProps({ lockDateLoading: true })} />);
+
+      expect(screen.getByText('wizard.loading')).toBeTruthy();
+    });
+  });
+
+  describe('breadcrumbs', () => {
+    it('shows breadcrumbs when initialized and not committed', () => {
+      render(<MovementWizard {...createProps()} />);
+
+      expect(screen.getByTestId('breadcrumbs')).toBeTruthy();
+    });
+
+    it('hides breadcrumbs when not initialized', () => {
+      render(<MovementWizard {...createProps({
+        wizard: { initialized: false, page: 1, committed: false, values: {}, commitError: null, dialogs: {} },
+      })} />);
+
+      expect(screen.queryByTestId('breadcrumbs')).toBeNull();
+    });
+
+    it('hides breadcrumbs when committed', () => {
+      render(<MovementWizard {...createProps({
+        wizard: { initialized: true, page: 1, committed: true, values: {}, commitError: null, dialogs: {} },
+      })} />);
+
+      expect(screen.queryByTestId('breadcrumbs')).toBeNull();
+    });
+
+    it('shows new movement label when no key', () => {
+      render(<MovementWizard {...createProps({ newMovementLabel: 'New Arrival' })} />);
+
+      expect(screen.getByTestId('breadcrumbs').textContent).toBe('New Arrival');
+    });
+
+    it('shows update movement label with reference when key is set', () => {
+      render(<MovementWizard {...createProps({
+        match: { params: { key: 'dep123' } },
+        updateMovementLabel: 'Edit Departure',
+      })} />);
+
+      expect(screen.getByTestId('breadcrumbs').textContent).toBe('Edit Departure (REF-dep123)');
+    });
+  });
+
+  describe('committed state', () => {
+    it('renders finish component with CREATED for new movement', () => {
+      render(<MovementWizard {...createProps({
+        wizard: { initialized: true, page: 1, committed: true, values: {}, commitError: null, dialogs: {} },
+      })} />);
+
+      const finish = screen.getByTestId('finish-component');
+      expect(finish.getAttribute('data-is-update')).toBe('false');
+      expect(finish.getAttribute('data-heading-type')).toBe('CREATED');
+    });
+
+    it('renders finish component with UPDATED for existing movement', () => {
+      render(<MovementWizard {...createProps({
+        match: { params: { key: 'dep123' } },
+        wizard: { initialized: true, page: 1, committed: true, values: {}, commitError: null, dialogs: {} },
+      })} />);
+
+      const finish = screen.getByTestId('finish-component');
+      expect(finish.getAttribute('data-is-update')).toBe('true');
+      expect(finish.getAttribute('data-heading-type')).toBe('UPDATED');
+    });
+  });
+
+  describe('active page state', () => {
+    it('renders the current page component', () => {
+      render(<MovementWizard {...createProps()} />);
+
+      expect(screen.getByTestId('page-component')).toBeTruthy();
+    });
+
+    it('passes correct props to page component', () => {
+      render(<MovementWizard {...createProps({
+        locked: true,
+        auth: { data: { admin: true, guest: false } },
+      })} />);
+
+      const page = screen.getByTestId('page-component');
+      expect(page.getAttribute('data-readonly')).toBe('true');
+      expect(page.getAttribute('data-is-admin')).toBe('true');
+      expect(page.getAttribute('data-is-guest')).toBe('false');
+    });
+  });
+
+  describe('commit error', () => {
+    it('renders CommitFailureDialog when commitError is set', () => {
+      render(<MovementWizard {...createProps({
+        wizard: {
+          initialized: true, page: 1, committed: false, values: {},
+          commitError: { message: 'Save failed' }, dialogs: {},
+        },
+      })} />);
+
+      const dialog = screen.getByTestId('commit-failure-dialog');
+      expect(dialog.textContent).toBe('Save failed');
+    });
+
+    it('does not render CommitFailureDialog when commitError is null', () => {
+      render(<MovementWizard {...createProps()} />);
+
+      expect(screen.queryByTestId('commit-failure-dialog')).toBeNull();
+    });
+  });
+});

--- a/src/components/wizards/MovementWizard.tsx
+++ b/src/components/wizards/MovementWizard.tsx
@@ -8,6 +8,7 @@ import {getFromItemKey} from '../../util/reference-number';
 import Breadcrumbs from './Breadcrumbs';
 import { WizardState } from '../../modules/ui/wizard/reducer';
 import useWizardNavigation from './useWizardNavigation';
+import WizardDialog from './WizardDialog';
 
 export const HeadingType = {
   CREATED: 'CREATED',
@@ -87,22 +88,7 @@ const MovementWizard = (props: MovementWizardProps) => {
     showDialog: props.showDialog,
   });
 
-  const getDialog = () => {
-    const dialogConf = props.pages[props.wizard.page - 1].dialog;
-    if (dialogConf && props.wizard.dialogs[dialogConf.name] === true) {
-      const nextAction = getNextAction();
-      return (
-        <dialogConf.component
-          onCancel={props.hideDialog.bind(null, dialogConf.name)}
-          onConfirm={() => {
-            props.hideDialog(dialogConf.name);
-            nextAction();
-          }}
-        />
-      );
-    }
-    return null;
-  };
+  const currentPageDialog = props.pages[props.wizard.page - 1].dialog;
 
   const getMiddleItem = () => {
     if (props.wizard.initialized !== true || props.lockDateLoading === true) {
@@ -131,7 +117,14 @@ const MovementWizard = (props: MovementWizardProps) => {
       />
     );
 
-    const dialog = getDialog();
+    const dialog = (
+      <WizardDialog
+        dialogConf={currentPageDialog}
+        isVisible={!!(currentPageDialog && props.wizard.dialogs[currentPageDialog.name])}
+        hideDialog={props.hideDialog}
+        getNextAction={getNextAction}
+      />
+    );
 
     const commitFailureDialog = props.wizard.commitError
       ? (

--- a/src/components/wizards/MovementWizard.tsx
+++ b/src/components/wizards/MovementWizard.tsx
@@ -1,5 +1,5 @@
-import React, {Component} from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
+import React, {useEffect} from 'react';
+import { useTranslation } from 'react-i18next';
 import CommitFailureDialog from '../CommitFailureDialog';
 import Centered from '../Centered';
 import VerticalHeaderLayout from '../VerticalHeaderLayout';
@@ -26,7 +26,7 @@ export interface WizardPage {
   dialog?: PageDialog;
 }
 
-interface MovementWizardProps extends WithTranslation {
+interface MovementWizardProps {
   pages: WizardPage[];
   finishComponentClass: React.ComponentType<any>;
   wizard: WizardState;
@@ -54,69 +54,117 @@ interface MovementWizardProps extends WithTranslation {
   loadAircraftSettings: () => void;
 }
 
-class MovementWizard extends Component<MovementWizardProps> {
+const MovementWizard = (props: MovementWizardProps) => {
+  const { t } = useTranslation();
 
-  componentWillMount() {
-    this.props.loadLockDate();
-    this.props.loadAircraftSettings();
-    if (typeof this.props.initMovement === 'function') {
-      this.props.initMovement();
-    } else if (this.props.match.params.key) {
-      this.props.editMovement(this.props.match.params.key);
+  useEffect(() => {
+    props.loadLockDate();
+    props.loadAircraftSettings();
+    if (typeof props.initMovement === 'function') {
+      props.initMovement();
+    } else if (props.match.params.key) {
+      props.editMovement(props.match.params.key);
     } else {
-      this.props.initNewMovement();
+      props.initNewMovement();
     }
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  render() {
-    const breadcrumbsTitle = this.isUpdate()
-      ? this.props.updateMovementLabel + ' (' + getFromItemKey(this.props.match.params.key) + ')'
-      : this.props.newMovementLabel;
-    return (
-      <VerticalHeaderLayout>
-        <div>
-          {this.props.wizard.initialized === true && this.props.wizard.committed !== true &&
-            <Breadcrumbs title={breadcrumbsTitle} items={this.buildBreadcrumbItems()} activeItem={this.props.wizard.page - 1}/>}
-          <div>{this.getMiddleItem()}</div>
-        </div>
-      </VerticalHeaderLayout>
-    );
-  }
+  const isUpdate = typeof props.match.params.key === 'string' && props.match.params.key.length > 0;
 
-  getMiddleItem() {
-    if (this.props.wizard.initialized !== true || this.props.lockDateLoading === true) {
-      const { t } = this.props;
+  const breadcrumbItems = props.pages.map(page => ({
+    label: page.label,
+  }));
+
+  const goToPreviousPage = (data: Record<string, unknown>) => {
+    props.updateValues(data)
+    props.previousPage()
+  };
+
+  const submitPage = (data: Record<string, unknown>) => {
+    props.updateValues(data)
+
+    const isLast = props.wizard.page === props.pages.length;
+
+    const nextAction = isLast
+      ? props.saveMovement
+      : props.nextPage;
+
+    const dialogConf = props.pages[props.wizard.page - 1].dialog;
+
+    if (!dialogConf) {
+      nextAction();
+      return;
+    }
+
+    if (!dialogConf.predicate) {
+      props.showDialog(dialogConf.name);
+      return;
+    }
+
+    return dialogConf.predicate(data).then(show => {
+      if (show === true) {
+        props.showDialog(dialogConf.name);
+      } else {
+        nextAction();
+      }
+    });
+  };
+
+  const getDialog = () => {
+    const dialogConf = props.pages[props.wizard.page - 1].dialog;
+    if (dialogConf && props.wizard.dialogs[dialogConf.name] === true) {
+      const isLast = props.wizard.page === props.pages.length;
+      const nextAction = isLast
+        ? props.saveMovement
+        : props.nextPage;
+      return (
+        <dialogConf.component
+          onCancel={props.hideDialog.bind(null, dialogConf.name)}
+          onConfirm={() => {
+            props.hideDialog(dialogConf.name);
+            nextAction();
+          }}
+        />
+      );
+    }
+    return null;
+  };
+
+  const getMiddleItem = () => {
+    if (props.wizard.initialized !== true || props.lockDateLoading === true) {
       return <Centered><MaterialIcon icon="sync" rotate="left"/> {t('wizard.loading')}</Centered>;
     }
 
-    if (this.props.wizard.committed === true) {
-      return <this.props.finishComponentClass
-        finish={this.props.finish}
-        isUpdate={this.isUpdate()}
-        headingType={this.isUpdate() ? HeadingType.UPDATED : HeadingType.CREATED}
+    if (props.wizard.committed === true) {
+      const FinishComponent = props.finishComponentClass;
+      return <FinishComponent
+        finish={props.finish}
+        isUpdate={isUpdate}
+        headingType={isUpdate ? HeadingType.UPDATED : HeadingType.CREATED}
       />;
     }
 
-    const pageObj = this.props.pages[this.props.wizard.page - 1];
+    const pageObj = props.pages[props.wizard.page - 1];
     const pageComponent = (
       <pageObj.component
-        previousPage={this.goToPreviousPage.bind(this)}
-        onSubmit={this.submitPage.bind(this)}
-        cancel={this.props.cancel}
-        readOnly={this.props.locked}
-        isAdmin={this.props.auth.data.admin}
-        isGuest={this.props.auth.data.guest}
-        formValues={this.props.wizard.values}
+        previousPage={goToPreviousPage}
+        onSubmit={submitPage}
+        cancel={props.cancel}
+        readOnly={props.locked}
+        isAdmin={props.auth.data.admin}
+        isGuest={props.auth.data.guest}
+        formValues={props.wizard.values}
       />
     );
 
-    const dialog = this.getDialog();
+    const dialog = getDialog();
 
-    const commitFailureDialog = this.props.wizard.commitError
+    const commitFailureDialog = props.wizard.commitError
       ? (
         <CommitFailureDialog
-          onClose={this.props.unsetCommitError}
-          errorMsg={(this.props.wizard.commitError as any).message}
+          onClose={props.unsetCommitError}
+          errorMsg={(props.wizard.commitError as any).message}
         />
       ) : null;
 
@@ -127,72 +175,21 @@ class MovementWizard extends Component<MovementWizardProps> {
         {commitFailureDialog}
       </div>
     );
-  }
+  };
 
-  getDialog() {
-    const dialogConf = this.props.pages[this.props.wizard.page - 1].dialog;
-    if (dialogConf && this.props.wizard.dialogs[dialogConf.name] === true) {
-      const isLast = this.props.wizard.page === this.props.pages.length;
-      const nextAction = isLast
-        ? this.props.saveMovement
-        : this.props.nextPage;
-      return (
-        <dialogConf.component
-          onCancel={this.props.hideDialog.bind(null, dialogConf.name)}
-          onConfirm={() => {
-            this.props.hideDialog(dialogConf.name);
-            nextAction();
-          }}
-        />
-      );
-    }
-    return null;
-  }
+  const breadcrumbsTitle = isUpdate
+    ? props.updateMovementLabel + ' (' + getFromItemKey(props.match.params.key) + ')'
+    : props.newMovementLabel;
 
-  goToPreviousPage(data: Record<string, unknown>) {
-    this.props.updateValues(data)
-    this.props.previousPage()
-  }
+  return (
+    <VerticalHeaderLayout>
+      <div>
+        {props.wizard.initialized === true && props.wizard.committed !== true &&
+          <Breadcrumbs title={breadcrumbsTitle} items={breadcrumbItems} activeItem={props.wizard.page - 1}/>}
+        <div>{getMiddleItem()}</div>
+      </div>
+    </VerticalHeaderLayout>
+  );
+};
 
-  submitPage(data: Record<string, unknown>) {
-    this.props.updateValues(data)
-
-    const isLast = this.props.wizard.page === this.props.pages.length;
-
-    const nextAction = isLast
-      ? this.props.saveMovement
-      : this.props.nextPage;
-
-    const dialogConf = this.props.pages[this.props.wizard.page - 1].dialog;
-
-    if (!dialogConf) {
-      nextAction();
-      return;
-    }
-
-    if (!dialogConf.predicate) {
-      this.props.showDialog(dialogConf.name);
-      return;
-    }
-
-    return dialogConf.predicate(data).then(show => {
-      if (show === true) {
-        this.props.showDialog(dialogConf.name);
-      } else {
-        nextAction();
-      }
-    });
-  }
-
-  buildBreadcrumbItems() {
-    return this.props.pages.map(page => ({
-      label: page.label,
-    }));
-  }
-
-  isUpdate() {
-    return typeof this.props.match.params.key === 'string' && this.props.match.params.key.length > 0;
-  }
-}
-
-export default withTranslation()(MovementWizard);
+export default MovementWizard;

--- a/src/components/wizards/MovementWizard.tsx
+++ b/src/components/wizards/MovementWizard.tsx
@@ -7,6 +7,7 @@ import MaterialIcon from '../MaterialIcon';
 import {getFromItemKey} from '../../util/reference-number';
 import Breadcrumbs from './Breadcrumbs';
 import { WizardState } from '../../modules/ui/wizard/reducer';
+import useWizardNavigation from './useWizardNavigation';
 
 export const HeadingType = {
   CREATED: 'CREATED',
@@ -76,48 +77,20 @@ const MovementWizard = (props: MovementWizardProps) => {
     label: page.label,
   }));
 
-  const goToPreviousPage = (data: Record<string, unknown>) => {
-    props.updateValues(data)
-    props.previousPage()
-  };
-
-  const submitPage = (data: Record<string, unknown>) => {
-    props.updateValues(data)
-
-    const isLast = props.wizard.page === props.pages.length;
-
-    const nextAction = isLast
-      ? props.saveMovement
-      : props.nextPage;
-
-    const dialogConf = props.pages[props.wizard.page - 1].dialog;
-
-    if (!dialogConf) {
-      nextAction();
-      return;
-    }
-
-    if (!dialogConf.predicate) {
-      props.showDialog(dialogConf.name);
-      return;
-    }
-
-    return dialogConf.predicate(data).then(show => {
-      if (show === true) {
-        props.showDialog(dialogConf.name);
-      } else {
-        nextAction();
-      }
-    });
-  };
+  const { goToPreviousPage, submitPage, getNextAction } = useWizardNavigation({
+    pages: props.pages,
+    wizard: props.wizard,
+    updateValues: props.updateValues,
+    nextPage: props.nextPage,
+    previousPage: props.previousPage,
+    saveMovement: props.saveMovement,
+    showDialog: props.showDialog,
+  });
 
   const getDialog = () => {
     const dialogConf = props.pages[props.wizard.page - 1].dialog;
     if (dialogConf && props.wizard.dialogs[dialogConf.name] === true) {
-      const isLast = props.wizard.page === props.pages.length;
-      const nextAction = isLast
-        ? props.saveMovement
-        : props.nextPage;
+      const nextAction = getNextAction();
       return (
         <dialogConf.component
           onCancel={props.hideDialog.bind(null, dialogConf.name)}

--- a/src/components/wizards/MovementWizard.tsx
+++ b/src/components/wizards/MovementWizard.tsx
@@ -1,12 +1,12 @@
-import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import { withTranslation } from 'react-i18next';
+import { withTranslation, WithTranslation } from 'react-i18next';
 import CommitFailureDialog from '../CommitFailureDialog';
 import Centered from '../Centered';
 import VerticalHeaderLayout from '../VerticalHeaderLayout';
 import MaterialIcon from '../MaterialIcon';
 import {getFromItemKey} from '../../util/reference-number';
 import Breadcrumbs from './Breadcrumbs';
+import { WizardState } from '../../modules/ui/wizard/reducer';
 
 export const HeadingType = {
   CREATED: 'CREATED',
@@ -14,7 +14,47 @@ export const HeadingType = {
   NONE: 'NONE'
 };
 
-class MovementWizard extends Component<any, any> {
+interface PageDialog {
+  name: string;
+  component: React.ComponentType<{ onCancel: () => void; onConfirm: () => void }>;
+  predicate?: (data: Record<string, unknown>) => Promise<boolean>;
+}
+
+export interface WizardPage {
+  component: React.ComponentType<any>;
+  label: string;
+  dialog?: PageDialog;
+}
+
+interface MovementWizardProps extends WithTranslation {
+  pages: WizardPage[];
+  finishComponentClass: React.ComponentType<any>;
+  wizard: WizardState;
+  match: { params: Record<string, string> };
+  auth: { data: { admin: boolean; guest: boolean } };
+  newMovementLabel: string;
+  updateMovementLabel: string;
+  lockDateLoading: boolean;
+  locked: boolean;
+  className?: string;
+
+  initNewMovement: () => void;
+  editMovement: (key: string) => void;
+  initMovement?: (() => void) | null;
+  updateValues: (values: Record<string, unknown>) => void;
+  nextPage: () => void;
+  previousPage: () => void;
+  cancel: () => void;
+  finish: () => void;
+  showDialog: (name: string) => void;
+  hideDialog: (name: string) => void;
+  saveMovement: () => void;
+  unsetCommitError: () => void;
+  loadLockDate: () => void;
+  loadAircraftSettings: () => void;
+}
+
+class MovementWizard extends Component<MovementWizardProps> {
 
   componentWillMount() {
     this.props.loadLockDate();
@@ -76,7 +116,7 @@ class MovementWizard extends Component<any, any> {
       ? (
         <CommitFailureDialog
           onClose={this.props.unsetCommitError}
-          errorMsg={this.props.wizard.commitError.message}
+          errorMsg={(this.props.wizard.commitError as any).message}
         />
       ) : null;
 
@@ -109,12 +149,12 @@ class MovementWizard extends Component<any, any> {
     return null;
   }
 
-  goToPreviousPage(data) {
+  goToPreviousPage(data: Record<string, unknown>) {
     this.props.updateValues(data)
     this.props.previousPage()
   }
 
-  submitPage(data) {
+  submitPage(data: Record<string, unknown>) {
     this.props.updateValues(data)
 
     const isLast = this.props.wizard.page === this.props.pages.length;
@@ -154,42 +194,5 @@ class MovementWizard extends Component<any, any> {
     return typeof this.props.match.params.key === 'string' && this.props.match.params.key.length > 0;
   }
 }
-
-(MovementWizard as any).propTypes = {
-  pages: PropTypes.arrayOf(PropTypes.shape({
-    component: PropTypes.object.isRequired,
-    label: PropTypes.string.isRequired,
-    dialog: PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      component: PropTypes.func.isRequired,
-      predicate: PropTypes.func,
-    })
-  })).isRequired,
-  finishComponentClass: PropTypes.func.isRequired,
-  wizard: PropTypes.object.isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.object.isRequired
-  }).isRequired,
-  newMovementLabel: PropTypes.string.isRequired,
-  updateMovementLabel: PropTypes.string.isRequired,
-  lockDateLoading: PropTypes.bool.isRequired,
-  locked: PropTypes.bool.isRequired,
-  className: PropTypes.string,
-
-  initNewMovement: PropTypes.func.isRequired,
-  editMovement: PropTypes.func.isRequired,
-  initMovement: PropTypes.func,
-  updateValues: PropTypes.func.isRequired,
-  nextPage: PropTypes.func.isRequired,
-  previousPage: PropTypes.func.isRequired,
-  cancel: PropTypes.func.isRequired,
-  finish: PropTypes.func.isRequired,
-  showDialog: PropTypes.func,
-  hideDialog: PropTypes.func,
-  saveMovement: PropTypes.func.isRequired,
-  unsetCommitError: PropTypes.func,
-  loadLockDate: PropTypes.func.isRequired,
-  loadAircraftSettings: PropTypes.func.isRequired,
-};
 
 export default withTranslation()(MovementWizard);

--- a/src/components/wizards/WizardDialog.spec.tsx
+++ b/src/components/wizards/WizardDialog.spec.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import WizardDialog from './WizardDialog';
+
+const MockDialog = ({ onCancel, onConfirm }: { onCancel: () => void; onConfirm: () => void }) => (
+  <div>
+    <button onClick={onCancel}>Cancel</button>
+    <button onClick={onConfirm}>Confirm</button>
+  </div>
+);
+
+describe('WizardDialog', () => {
+  it('renders nothing when dialogConf is undefined', () => {
+    const { container } = render(
+      <WizardDialog
+        isVisible={true}
+        hideDialog={jest.fn()}
+        getNextAction={() => jest.fn()}
+      />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when isVisible is false', () => {
+    const { container } = render(
+      <WizardDialog
+        dialogConf={{ name: 'CONFIRM', component: MockDialog }}
+        isVisible={false}
+        hideDialog={jest.fn()}
+        getNextAction={() => jest.fn()}
+      />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the dialog component when visible', () => {
+    render(
+      <WizardDialog
+        dialogConf={{ name: 'CONFIRM', component: MockDialog }}
+        isVisible={true}
+        hideDialog={jest.fn()}
+        getNextAction={() => jest.fn()}
+      />
+    );
+    expect(screen.getByText('Cancel')).toBeTruthy();
+    expect(screen.getByText('Confirm')).toBeTruthy();
+  });
+
+  it('calls hideDialog with dialog name on cancel', () => {
+    const hideDialog = jest.fn();
+    render(
+      <WizardDialog
+        dialogConf={{ name: 'LOCATION_CONFIRMATION', component: MockDialog }}
+        isVisible={true}
+        hideDialog={hideDialog}
+        getNextAction={() => jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(hideDialog).toHaveBeenCalledWith('LOCATION_CONFIRMATION');
+  });
+
+  it('calls hideDialog and nextAction on confirm', () => {
+    const hideDialog = jest.fn();
+    const nextAction = jest.fn();
+    render(
+      <WizardDialog
+        dialogConf={{ name: 'LOCATION_CONFIRMATION', component: MockDialog }}
+        isVisible={true}
+        hideDialog={hideDialog}
+        getNextAction={() => nextAction}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Confirm'));
+    expect(hideDialog).toHaveBeenCalledWith('LOCATION_CONFIRMATION');
+    expect(nextAction).toHaveBeenCalled();
+  });
+});

--- a/src/components/wizards/WizardDialog.tsx
+++ b/src/components/wizards/WizardDialog.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface PageDialog {
+  name: string;
+  component: React.ComponentType<{ onCancel: () => void; onConfirm: () => void }>;
+}
+
+interface WizardDialogProps {
+  dialogConf?: PageDialog;
+  isVisible: boolean;
+  hideDialog: (name: string) => void;
+  getNextAction: () => () => void;
+}
+
+const WizardDialog = ({ dialogConf, isVisible, hideDialog, getNextAction }: WizardDialogProps) => {
+  if (!dialogConf || !isVisible) {
+    return null;
+  }
+
+  const DialogComponent = dialogConf.component;
+  const nextAction = getNextAction();
+
+  return (
+    <DialogComponent
+      onCancel={() => hideDialog(dialogConf.name)}
+      onConfirm={() => {
+        hideDialog(dialogConf.name);
+        nextAction();
+      }}
+    />
+  );
+};
+
+export default WizardDialog;

--- a/src/components/wizards/useWizardNavigation.spec.ts
+++ b/src/components/wizards/useWizardNavigation.spec.ts
@@ -1,0 +1,184 @@
+import useWizardNavigation from './useWizardNavigation';
+import { WizardState } from '../../modules/ui/wizard/reducer';
+
+const mockPage = (dialog?: any) => ({
+  component: {} as any,
+  label: 'Page',
+  dialog,
+});
+
+const createArgs = (overrides: any = {}) => ({
+  pages: overrides.pages || [mockPage(), mockPage()],
+  wizard: overrides.wizard || { page: 1, initialized: true, committed: false, values: {}, commitError: null, dialogs: {} } as WizardState,
+  updateValues: overrides.updateValues || jest.fn(),
+  nextPage: overrides.nextPage || jest.fn(),
+  previousPage: overrides.previousPage || jest.fn(),
+  saveMovement: overrides.saveMovement || jest.fn(),
+  showDialog: overrides.showDialog || jest.fn(),
+});
+
+describe('useWizardNavigation', () => {
+  describe('getNextAction', () => {
+    it('returns nextPage when not on last page', () => {
+      const nextPage = jest.fn();
+      const saveMovement = jest.fn();
+      const { getNextAction } = useWizardNavigation(createArgs({
+        wizard: { page: 1 } as WizardState,
+        pages: [mockPage(), mockPage()],
+        nextPage,
+        saveMovement,
+      }));
+
+      expect(getNextAction()).toBe(nextPage);
+    });
+
+    it('returns saveMovement when on last page', () => {
+      const nextPage = jest.fn();
+      const saveMovement = jest.fn();
+      const { getNextAction } = useWizardNavigation(createArgs({
+        wizard: { page: 2 } as WizardState,
+        pages: [mockPage(), mockPage()],
+        nextPage,
+        saveMovement,
+      }));
+
+      expect(getNextAction()).toBe(saveMovement);
+    });
+  });
+
+  describe('goToPreviousPage', () => {
+    it('calls updateValues with data and previousPage', () => {
+      const updateValues = jest.fn();
+      const previousPage = jest.fn();
+      const { goToPreviousPage } = useWizardNavigation(createArgs({
+        updateValues,
+        previousPage,
+      }));
+
+      const data = { immatriculation: 'HBABC' };
+      goToPreviousPage(data);
+
+      expect(updateValues).toHaveBeenCalledWith(data);
+      expect(previousPage).toHaveBeenCalled();
+    });
+  });
+
+  describe('submitPage', () => {
+    it('calls updateValues and nextPage when no dialog configured', () => {
+      const updateValues = jest.fn();
+      const nextPage = jest.fn();
+      const { submitPage } = useWizardNavigation(createArgs({
+        updateValues,
+        nextPage,
+        pages: [mockPage(), mockPage()],
+        wizard: { page: 1 } as WizardState,
+      }));
+
+      const data = { immatriculation: 'HBABC' };
+      submitPage(data);
+
+      expect(updateValues).toHaveBeenCalledWith(data);
+      expect(nextPage).toHaveBeenCalled();
+    });
+
+    it('calls saveMovement on last page when no dialog configured', () => {
+      const updateValues = jest.fn();
+      const saveMovement = jest.fn();
+      const nextPage = jest.fn();
+      const { submitPage } = useWizardNavigation(createArgs({
+        updateValues,
+        saveMovement,
+        nextPage,
+        pages: [mockPage(), mockPage()],
+        wizard: { page: 2 } as WizardState,
+      }));
+
+      submitPage({});
+
+      expect(saveMovement).toHaveBeenCalled();
+      expect(nextPage).not.toHaveBeenCalled();
+    });
+
+    it('shows dialog when dialog has no predicate', () => {
+      const showDialog = jest.fn();
+      const nextPage = jest.fn();
+      const dialog = { name: 'CONFIRM', component: {} as any };
+      const { submitPage } = useWizardNavigation(createArgs({
+        showDialog,
+        nextPage,
+        pages: [mockPage(dialog)],
+        wizard: { page: 1 } as WizardState,
+      }));
+
+      submitPage({});
+
+      expect(showDialog).toHaveBeenCalledWith('CONFIRM');
+      expect(nextPage).not.toHaveBeenCalled();
+    });
+
+    it('shows dialog when predicate resolves to true', async () => {
+      const showDialog = jest.fn();
+      const nextPage = jest.fn();
+      const dialog = {
+        name: 'CONFIRM',
+        component: {} as any,
+        predicate: jest.fn().mockResolvedValue(true),
+      };
+      const { submitPage } = useWizardNavigation(createArgs({
+        showDialog,
+        nextPage,
+        pages: [mockPage(dialog)],
+        wizard: { page: 1 } as WizardState,
+      }));
+
+      const data = { location: 'LSZT' };
+      await submitPage(data);
+
+      expect(dialog.predicate).toHaveBeenCalledWith(data);
+      expect(showDialog).toHaveBeenCalledWith('CONFIRM');
+      expect(nextPage).not.toHaveBeenCalled();
+    });
+
+    it('calls nextPage when predicate resolves to false', async () => {
+      const showDialog = jest.fn();
+      const nextPage = jest.fn();
+      const dialog = {
+        name: 'CONFIRM',
+        component: {} as any,
+        predicate: jest.fn().mockResolvedValue(false),
+      };
+      const { submitPage } = useWizardNavigation(createArgs({
+        showDialog,
+        nextPage,
+        pages: [mockPage(dialog), mockPage()],
+        wizard: { page: 1 } as WizardState,
+      }));
+
+      await submitPage({ location: 'LSZT' });
+
+      expect(showDialog).not.toHaveBeenCalled();
+      expect(nextPage).toHaveBeenCalled();
+    });
+
+    it('calls saveMovement on last page when predicate resolves to false', async () => {
+      const saveMovement = jest.fn();
+      const nextPage = jest.fn();
+      const dialog = {
+        name: 'CONFIRM',
+        component: {} as any,
+        predicate: jest.fn().mockResolvedValue(false),
+      };
+      const { submitPage } = useWizardNavigation(createArgs({
+        saveMovement,
+        nextPage,
+        pages: [mockPage(dialog)],
+        wizard: { page: 1 } as WizardState,
+      }));
+
+      await submitPage({});
+
+      expect(saveMovement).toHaveBeenCalled();
+      expect(nextPage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/wizards/useWizardNavigation.ts
+++ b/src/components/wizards/useWizardNavigation.ts
@@ -1,0 +1,53 @@
+import { WizardPage } from './MovementWizard';
+import { WizardState } from '../../modules/ui/wizard/reducer';
+
+interface UseWizardNavigationArgs {
+  pages: WizardPage[];
+  wizard: WizardState;
+  updateValues: (values: Record<string, unknown>) => void;
+  nextPage: () => void;
+  previousPage: () => void;
+  saveMovement: () => void;
+  showDialog: (name: string) => void;
+}
+
+export default function useWizardNavigation({
+  pages, wizard, updateValues, nextPage, previousPage,
+  saveMovement, showDialog
+}: UseWizardNavigationArgs) {
+  const getNextAction = () =>
+    wizard.page === pages.length ? saveMovement : nextPage;
+
+  const goToPreviousPage = (data: Record<string, unknown>) => {
+    updateValues(data)
+    previousPage()
+  };
+
+  const submitPage = (data: Record<string, unknown>) => {
+    updateValues(data)
+
+    const nextAction = getNextAction();
+
+    const dialogConf = pages[wizard.page - 1].dialog;
+
+    if (!dialogConf) {
+      nextAction();
+      return;
+    }
+
+    if (!dialogConf.predicate) {
+      showDialog(dialogConf.name);
+      return;
+    }
+
+    return dialogConf.predicate(data).then(show => {
+      if (show === true) {
+        showDialog(dialogConf.name);
+      } else {
+        nextAction();
+      }
+    });
+  };
+
+  return { goToPreviousPage, submitPage, getNextAction };
+}


### PR DESCRIPTION
## Summary

- Replace PropTypes with TypeScript interface for compile-time type safety
- Convert class component to functional component with hooks
- Extract page navigation logic into `useWizardNavigation` hook
- Extract dialog rendering into `WizardDialog` component
- Add 31 new tests covering all extracted logic and component branches

## Test plan

- [x] `npm test` passes (no new failures)
- [x] TypeScript type check passes (no new errors)
- [ ] Manual smoke test: create and edit a departure and arrival movement