### PR TITLE
Merge selected environment config into __CONF__

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,9 +12,12 @@ const env = process.env.ENV === 'production'
   ? projectConf.environments.production
   : projectConf.environments.test;
 
+const { environments, ...projectConfWithoutEnvironments } = projectConf;
+const mergedConf = { ...projectConfWithoutEnvironments, ...env };
+
 const globals = {
   __DEV__: process.env.DEV || false,
-  __CONF__: projects.packinize(projectConf),
+  __CONF__: projects.packinize(mergedConf),
   __THEME__: JSON.stringify(projectConf.theme),
   __FIREBASE_PROJECT_ID__: JSON.stringify(env.firebaseProjectId),
   __FIREBASE_DATABASE_NAME__: JSON.stringify(env.firebaseDatabaseName),


### PR DESCRIPTION
## Summary

- Keys defined under `projectConf.environments.<env>` now override the top-level config before it is packinized into `__CONF__`.
- Clients can read env-specific flags via `__CONF__.<key>` directly.
- Enables per-environment feature toggles without introducing new webpack globals.

## Motivation

Today webpack already picks the per-environment block (test vs production) to derive the Firebase globals (`__FIREBASE_PROJECT_ID__`, etc.). But everything else in `__CONF__` is project-wide. If a project wants an opt-in flag that is `true` in test and `false` in prod (or vice versa), the only way is another top-level webpack global — which doesn't scale.

With this change, a project can define under `environments.test` (or `environments.production`) any key that is also accepted at the top level, and the selected environment's value wins at build time.

## Test plan

- [ ] `npm test` — all 1806 tests pass
- [ ] `npm run typecheck` clean
- [ ] `npm run build --project=<any>` produces a working bundle
- [ ] No observable change for any existing project — no env block currently defines keys that collide with top-level config