### PR TITLE
Polish PWA install card copy and dismiss behaviour

### DIFF
--- a/src/components/StartPage/InstallCard/InstallCard.spec.tsx
+++ b/src/components/StartPage/InstallCard/InstallCard.spec.tsx
@@ -215,4 +215,22 @@ describe('InstallCard', () => {
     expect(screen.queryByTestId('install-card')).not.toBeInTheDocument();
     expect(localStorage.getItem(DISMISS_COUNT_KEY)).toBe('2');
   });
+
+  it('shows "later" label on first appearance', () => {
+    setVisitDays(5);
+    fireBeforeInstallPrompt();
+    renderWithTheme(<InstallCard authData={regularAuthData} />);
+    expect(screen.getByText('pwaInstall.dismiss')).toBeInTheDocument();
+    expect(screen.queryByText('pwaInstall.dismissPermanent')).not.toBeInTheDocument();
+  });
+
+  it('shows "don\'t show again" label when reappearing after one prior dismissal', () => {
+    setVisitDays(5);
+    localStorage.setItem(DISMISS_COUNT_KEY, '1');
+    localStorage.setItem(DISMISS_TS_KEY, String(Date.now() - 91 * 24 * 60 * 60 * 1000));
+    fireBeforeInstallPrompt();
+    renderWithTheme(<InstallCard authData={regularAuthData} />);
+    expect(screen.getByText('pwaInstall.dismissPermanent')).toBeInTheDocument();
+    expect(screen.queryByText('pwaInstall.dismiss')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/StartPage/InstallCard/InstallCard.tsx
+++ b/src/components/StartPage/InstallCard/InstallCard.tsx
@@ -9,6 +9,7 @@ const Wrapper = styled.div`
   margin: 1em auto;
   padding: 1em;
   width: 80%;
+  max-width: 500px;
 `;
 
 const Title = styled.h3`
@@ -39,8 +40,7 @@ const DismissLink = styled.button`
   color: #999;
   font-size: 0.85em;
   cursor: pointer;
-  margin-top: 0.8em;
-  padding: 0;
+  padding: 1.5em 0 0;
   display: block;
 `;
 
@@ -73,7 +73,7 @@ interface InstallCardProps {
 
 const InstallCard: React.FC<InstallCardProps> = ({ authData }) => {
   const { t } = useTranslation();
-  const { shouldShow, platform, install, dismiss } = usePwaInstall(authData);
+  const { shouldShow, platform, nextDismissIsPermanent, install, dismiss } = usePwaInstall(authData);
 
   if (!shouldShow) return null;
 
@@ -97,7 +97,7 @@ const InstallCard: React.FC<InstallCardProps> = ({ authData }) => {
         </Instructions>
       )}
       <DismissLink onClick={dismiss} data-testid="dismiss-link">
-        {t('pwaInstall.dismiss')}
+        {nextDismissIsPermanent ? t('pwaInstall.dismissPermanent') : t('pwaInstall.dismiss')}
       </DismissLink>
     </Wrapper>
   );

--- a/src/components/StartPage/InstallCard/usePwaInstall.ts
+++ b/src/components/StartPage/InstallCard/usePwaInstall.ts
@@ -10,6 +10,7 @@ type Platform = 'chromium' | 'ios-safari' | 'macos-safari' | null;
 interface PwaInstallResult {
   shouldShow: boolean;
   platform: Platform;
+  nextDismissIsPermanent: boolean;
   install: () => void;
   dismiss: () => void;
 }
@@ -136,6 +137,8 @@ export function usePwaInstall(authData: AuthData): PwaInstallResult {
     && enoughVisits
     && !isDismissed()
     && !dismissed;
+  const dismissCount = parseInt(localStorage.getItem(DISMISS_COUNT_KEY) || '0', 10);
+  const nextDismissIsPermanent = dismissCount >= 1;
 
   const install = useCallback(() => {
     if (promptRef.current) {
@@ -156,7 +159,7 @@ export function usePwaInstall(authData: AuthData): PwaInstallResult {
     setDismissed(true);
   }, []);
 
-  return { shouldShow, platform, install, dismiss };
+  return { shouldShow, platform, nextDismissIsPermanent, install, dismiss };
 }
 
 /** @internal Test-only helper to reset the module-level prompt cache between tests. */

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -523,14 +523,15 @@
     "invoice": "Rechnung"
   },
   "pwaInstall": {
-    "title": "App installieren",
-    "description": "Installieren Sie Flightbox als App für schnelleren Zugriff.",
+    "title": "Direkt vom Startbildschirm",
+    "description": "Flightbox als App installieren und künftig mit einem Tipp öffnen, ohne Umweg über den Browser.",
     "installButton": "Installieren",
     "iosInstructionsPre": "Tippen Sie auf ",
     "iosInstructionsPost": " und wählen Sie \"Zum Home-Bildschirm\".",
     "macosInstructionsPre": "Klicken Sie auf ",
     "macosInstructionsPost": " und wählen Sie \"Zum Dock hinzufügen\".",
-    "dismiss": "Nicht jetzt"
+    "dismiss": "Später",
+    "dismissPermanent": "Nicht mehr anzeigen"
   },
   "legal": {
     "privacyPolicy": "Datenschutzerklärung",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -523,14 +523,15 @@
     "invoice": "Invoice"
   },
   "pwaInstall": {
-    "title": "Install app",
-    "description": "Install Flightbox as an app for quicker access.",
+    "title": "Launch from your home screen",
+    "description": "Install Flightbox as an app and open it with one tap — no browser needed.",
     "installButton": "Install",
     "iosInstructionsPre": "Tap ",
     "iosInstructionsPost": " and select \"Add to Home Screen\".",
     "macosInstructionsPre": "Click ",
     "macosInstructionsPost": " and select \"Add to Dock\".",
-    "dismiss": "Not now"
+    "dismiss": "Later",
+    "dismissPermanent": "Don't show again"
   },
   "legal": {
     "privacyPolicy": "Privacy policy",


### PR DESCRIPTION
## Summary

- **Benefit-first copy**: "Direkt vom Startbildschirm" / "Launch from your home screen" with a description focused on the one-tap launch instead of the generic "faster access".
- **Two-strike dismiss**: second dismissal is now permanent, and the dismiss link tells users up front — label switches from "Später" to "Nicht mehr anzeigen" on the second appearance, matching the iOS review-prompt pattern.
- **Max-width cap** (500px) so the card stays visually subordinate to the main entry points on wide desktop screens.
- **Larger touch-target separation** (1.5em) between the primary install button and the dismiss link for safer tap accuracy on mobile.

## Motivation

Existing card told users "Install Flightbox as an app for quicker access" — generic benefit, easy to miss. Rewriting to lead with the concrete reward (launch from home screen with one tap) aligns with how conversion-focused onboarding prompts typically read.

The dismiss pattern already ramps to permanent after two clicks, but the user never knew — tapping "Später" a second time felt identical to the first. Showing "Nicht mehr anzeigen" on the final view respects the signal the user is sending.

## Test plan

- [ ] `npm test` — 1808 tests pass (2 new tests for label switching)
- [ ] `npm run typecheck` clean
- [ ] Install card renders with new copy on eligible platforms
- [ ] First "Später" click hides for 90 days
- [ ] After 90 days the card reappears with "Nicht mehr anzeigen" label
- [ ] Clicking that removes the card permanently