### PR TITLE
Add loading, success and error feedback to passkey prompt tile

### DIFF
--- a/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.spec.tsx
+++ b/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ThemeProvider } from 'styled-components';
 import { BrowserRouter } from 'react-router-dom';
-import { renderWithTheme, screen, fireEvent } from '../../../test/renderWithTheme';
+import { act, renderWithTheme, screen, fireEvent } from '../../../test/renderWithTheme';
 import PostLoginPasskeyPrompt from './PostLoginPasskeyPrompt';
 
 const theme = { colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' }, images: { logo: '' } };
@@ -14,6 +14,13 @@ const withWrappers = (el: React.ReactElement) => (
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
+
+jest.mock('../MaterialIcon', () => {
+  const ReactLocal = require('react');
+  return function MockMaterialIcon({ icon }: { icon: string }) {
+    return ReactLocal.createElement('span', { 'data-testid': `icon-${icon}` });
+  };
+});
 
 describe('PostLoginPasskeyPrompt', () => {
   const baseProps = {
@@ -126,21 +133,44 @@ describe('PostLoginPasskeyPrompt', () => {
     expect(window.localStorage.getItem('passkeyPromptDismissCount')).toBe('2');
   });
 
-  it('auto-dismisses after a successful registration (submitting true → false, no failure)', () => {
-    const { container, rerender } = renderWithTheme(
-      <PostLoginPasskeyPrompt {...baseProps} submitting={true} />
-    );
-    expect(container.firstChild).not.toBeNull();
-    rerender(withWrappers(<PostLoginPasskeyPrompt {...baseProps} submitting={false} failure={false} />));
-    expect(container.firstChild).toBeNull();
-    expect(window.localStorage.getItem('passkeyPromptDismissCount')).toBe('1');
+  it('shows the loading spinner and disables the button while submitting', () => {
+    renderWithTheme(<PostLoginPasskeyPrompt {...baseProps} submitting />);
+    expect(screen.getByTestId('icon-sync')).toBeInTheDocument();
+    const btn = screen.getByText('profile.passkeyPromptRegister').closest('button') as HTMLButtonElement;
+    expect(btn).toBeDisabled();
   });
 
-  it('stays visible when registration fails', () => {
+  it('shows the success card after registration succeeds, then auto-dismisses', () => {
+    jest.useFakeTimers();
     const { container, rerender } = renderWithTheme(
-      <PostLoginPasskeyPrompt {...baseProps} submitting={true} />
+      <PostLoginPasskeyPrompt {...baseProps} submitting />
     );
-    rerender(withWrappers(<PostLoginPasskeyPrompt {...baseProps} submitting={false} failure={true} />));
+    rerender(withWrappers(<PostLoginPasskeyPrompt {...baseProps} submitting={false} failure={false} />));
+
+    expect(screen.getByText('profile.passkeyPromptSuccessTitle')).toBeInTheDocument();
+    expect(screen.getByText('profile.passkeyPromptSuccessDescription')).toBeInTheDocument();
+    expect(screen.queryByText('profile.passkeyPromptRegister')).not.toBeInTheDocument();
+    expect(window.localStorage.getItem('passkeyPromptDismissCount')).toBe('1');
+
+    act(() => {
+      jest.advanceTimersByTime(3500);
+    });
+    expect(container.firstChild).toBeNull();
+    jest.useRealTimers();
+  });
+
+  it('shows an error notice when registration fails, stays visible', () => {
+    const { container, rerender } = renderWithTheme(
+      <PostLoginPasskeyPrompt {...baseProps} submitting />
+    );
+    rerender(withWrappers(<PostLoginPasskeyPrompt {...baseProps} submitting={false} failure />));
     expect(container.firstChild).not.toBeNull();
+    expect(screen.getByText('profile.passkeysRegistrationFailure')).toBeInTheDocument();
+    expect(screen.queryByText('profile.passkeyPromptSuccessTitle')).not.toBeInTheDocument();
+  });
+
+  it('does not show error notice when idle', () => {
+    renderWithTheme(<PostLoginPasskeyPrompt {...baseProps} />);
+    expect(screen.queryByText('profile.passkeysRegistrationFailure')).not.toBeInTheDocument();
   });
 });

--- a/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.tsx
+++ b/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
+import Button from '../Button';
 
 const DISMISS_TS_KEY = 'passkeyPromptDismissedAt';
 const DISMISS_COUNT_KEY = 'passkeyPromptDismissCount';
 const DISMISS_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const SUCCESS_DISMISS_MS = 3500;
 
 const Wrapper = styled.div`
   border-radius: 10px;
@@ -30,21 +32,6 @@ const Description = styled.p`
   line-height: 1.4;
 `;
 
-const RegisterButton = styled.button`
-  background-color: ${props => props.theme.colors.main};
-  color: #fff;
-  border: none;
-  border-radius: 5px;
-  padding: 0.6em 1.5em;
-  font-size: 1em;
-  cursor: pointer;
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-`;
-
 const DismissLink = styled.button`
   background: none;
   border: none;
@@ -54,6 +41,12 @@ const DismissLink = styled.button`
   margin-top: auto;
   padding: 1.5em 0 0;
   display: block;
+`;
+
+const ErrorMessage = styled.p`
+  color: #ed351c;
+  font-size: 0.9em;
+  margin: 0.75em 0 0;
 `;
 
 function getDismissCount(): number {
@@ -107,6 +100,7 @@ const PostLoginPasskeyPrompt: React.FC<Props> = ({
   const [dismissed, setDismissed] = useState(isDismissed());
   const nextDismissIsPermanent = getDismissCount() >= 1;
   const [wasSubmitting, setWasSubmitting] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
 
   useEffect(() => {
     if (show) {
@@ -117,10 +111,16 @@ const PostLoginPasskeyPrompt: React.FC<Props> = ({
   useEffect(() => {
     if (wasSubmitting && !submitting && !failure) {
       markDismissed();
-      setDismissed(true);
+      setShowSuccess(true);
     }
     setWasSubmitting(submitting);
   }, [submitting, failure]);
+
+  useEffect(() => {
+    if (!showSuccess) return;
+    const timer = setTimeout(() => setDismissed(true), SUCCESS_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [showSuccess]);
 
   if (!show || dismissed) return null;
 
@@ -132,18 +132,33 @@ const PostLoginPasskeyPrompt: React.FC<Props> = ({
     setDismissed(true);
   };
 
+  if (showSuccess) {
+    return (
+      <Wrapper data-cy="passkey-prompt-success">
+        <Title>{t('profile.passkeyPromptSuccessTitle')}</Title>
+        <Description>{t('profile.passkeyPromptSuccessDescription')}</Description>
+      </Wrapper>
+    );
+  }
+
   return (
     <Wrapper data-cy="passkey-prompt">
       <Title>{t('profile.passkeyPromptTitle')}</Title>
       <Description>{t('profile.passkeyPromptDescription')}</Description>
-      <RegisterButton
+      <Button
         type="button"
+        label={t('profile.passkeyPromptRegister')}
         onClick={() => registerPasskey()}
+        loading={submitting}
         disabled={submitting}
-        data-cy="passkey-prompt-register"
-      >
-        {t('profile.passkeyPromptRegister')}
-      </RegisterButton>
+        primary
+        dataCy="passkey-prompt-register"
+      />
+      {failure && (
+        <ErrorMessage data-cy="passkey-prompt-error">
+          {t('profile.passkeysRegistrationFailure')}
+        </ErrorMessage>
+      )}
       <DismissLink
         type="button"
         onClick={handleDismiss}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -319,6 +319,8 @@
     "passkeyPromptTitle": "Schneller anmelden",
     "passkeyPromptDescription": "Künftig mit Fingerabdruck oder Gesichtserkennung anmelden, ohne auf den E-Mail-Code zu warten.",
     "passkeyPromptRegister": "Passkey einrichten",
+    "passkeyPromptSuccessTitle": "Eingerichtet!",
+    "passkeyPromptSuccessDescription": "Beim nächsten Mal melden Sie sich ohne E-Mail-Code an.",
     "passkeyPromptDismiss": "Später",
     "passkeyPromptDismissPermanent": "Nicht mehr anzeigen"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -319,6 +319,8 @@
     "passkeyPromptTitle": "Sign in faster",
     "passkeyPromptDescription": "Sign in with your fingerprint or face, without waiting for an email code.",
     "passkeyPromptRegister": "Set up passkey",
+    "passkeyPromptSuccessTitle": "All set!",
+    "passkeyPromptSuccessDescription": "Next time you sign in without an email code.",
     "passkeyPromptDismiss": "Later",
     "passkeyPromptDismissPermanent": "Don't show again"
   },


### PR DESCRIPTION
## Summary

The post-login passkey tile on the start page previously had three UX gaps during the registration flow:

1. **No loading feedback**: button disabled on click but no spinner — user unsure if anything was happening.
2. **No success confirmation**: on successful registration the tile silently disappeared — user could wonder whether it worked.
3. **No error display**: on failure the button simply re-enabled with no explanation.

All three are now addressed.

### Changes

- **Loading**: replaces the custom styled button with the shared ``<Button>`` component using ``loading={submitting}`` — same spinner pattern as ``PasskeyLoginButton`` (login page) and ``PasskeyManager`` (profile page).
- **Success**: on successful registration the card replaces its content with a brief confirmation — "Eingerichtet! Beim nächsten Mal melden Sie sich ohne E-Mail-Code an." — shown for 3.5s before auto-dismissing. Matches the original tile promise ("ohne auf den E-Mail-Code zu warten").
- **Failure**: inline ``ErrorMessage`` below the button showing the existing ``profile.passkeysRegistrationFailure`` translation. Tile stays visible so the user can retry.

### Test plan

- [ ] 1932 tests pass, typecheck clean
- [ ] Register a passkey via the tile on ``lszm-test``
- [ ] Cancel the biometric — tile shows error
- [ ] Complete the biometric — tile shows success briefly, then dismisses
- [ ] Reload the page — tile no longer appears (user has a passkey)