### PR TITLE
Use shared Button component in PWA install card

### DIFF
--- a/src/components/StartPage/InstallCard/InstallCard.spec.tsx
+++ b/src/components/StartPage/InstallCard/InstallCard.spec.tsx
@@ -120,7 +120,6 @@ describe('InstallCard', () => {
     fireBeforeInstallPrompt();
     renderWithTheme(<InstallCard authData={regularAuthData} />);
     expect(screen.getByTestId('install-card')).toBeInTheDocument();
-    expect(screen.getByTestId('install-button')).toBeInTheDocument();
     expect(screen.getByText('pwaInstall.installButton')).toBeInTheDocument();
   });
 
@@ -163,7 +162,7 @@ describe('InstallCard', () => {
     setVisitDays(5);
     const event = fireBeforeInstallPrompt();
     renderWithTheme(<InstallCard authData={regularAuthData} />);
-    fireEvent.click(screen.getByTestId('install-button'));
+    fireEvent.click(screen.getByText('pwaInstall.installButton'));
     expect(event.prompt).toHaveBeenCalled();
   });
 
@@ -173,7 +172,7 @@ describe('InstallCard', () => {
     renderWithTheme(<InstallCard authData={regularAuthData} />);
     expect(screen.getByTestId('install-card')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId('install-button'));
+    fireEvent.click(screen.getByText('pwaInstall.installButton'));
     expect(screen.queryByTestId('install-card')).not.toBeInTheDocument();
   });
 
@@ -184,7 +183,7 @@ describe('InstallCard', () => {
     expect(screen.getByTestId('install-card')).toBeInTheDocument();
 
     await act(async () => {
-      fireEvent.click(screen.getByTestId('install-button'));
+      fireEvent.click(screen.getByText('pwaInstall.installButton'));
     });
     expect(screen.queryByTestId('install-card')).not.toBeInTheDocument();
   });

--- a/src/components/StartPage/InstallCard/InstallCard.tsx
+++ b/src/components/StartPage/InstallCard/InstallCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
+import Button from '../../Button';
 import { usePwaInstall, AuthData } from './usePwaInstall';
 
 const Wrapper = styled.div`
@@ -25,16 +26,6 @@ const Description = styled.p`
   margin: 0 0 1em;
   font-size: 0.95em;
   line-height: 1.4;
-`;
-
-const InstallButton = styled.button`
-  background-color: ${props => props.theme.colors.main};
-  color: #fff;
-  border: none;
-  border-radius: 5px;
-  padding: 0.6em 1.5em;
-  font-size: 1em;
-  cursor: pointer;
 `;
 
 const DismissLink = styled.button`
@@ -86,9 +77,13 @@ const InstallCard: React.FC<InstallCardProps> = ({ authData }) => {
       <Title>{t('pwaInstall.title')}</Title>
       <Description>{t('pwaInstall.description')}</Description>
       {platform === 'chromium' && (
-        <InstallButton onClick={install} data-testid="install-button">
-          {t('pwaInstall.installButton')}
-        </InstallButton>
+        <Button
+          type="button"
+          label={t('pwaInstall.installButton')}
+          onClick={install}
+          primary
+          dataCy="install-button"
+        />
       )}
       {platform === 'ios-safari' && (
         <Instructions data-testid="ios-instructions">


### PR DESCRIPTION
## Summary

Swap the PWA install card's custom styled ``InstallButton`` for the shared ``<Button>`` component so it matches the passkey prompt tile when both are rendered side-by-side on the start page.

### Why

After #713 moved ``PostLoginPasskeyPrompt`` to the shared ``<Button>``, the two cards on the start page had mismatched CTAs:

- **Passkey tile**: shared ``<Button>`` — uppercase, 2px radius, box-shadow, 1.2em font
- **PWA install card**: custom ``InstallButton`` — title case, 5px radius, no shadow, 1em font

Side-by-side this reads as inconsistent. Now both use the same button.

### Changes

- Remove the ``InstallButton`` styled component
- Render ``<Button primary label={...} onClick={install} dataCy="install-button" />`` instead
- Update tests to locate the button by text rather than by ``data-testid`` (the shared component exposes ``data-cy``)

No behaviour change — the button still calls ``install()`` on click and the card still hides immediately.

### Test plan

- [ ] 1932 tests pass, typecheck clean
- [ ] Visually verified side-by-side on ``localhost:8080`` with both tiles forced visible