### PR TITLE
Keep passkey prompt visible to show success feedback

### DIFF
--- a/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.spec.tsx
+++ b/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.spec.tsx
@@ -159,6 +159,27 @@ describe('PostLoginPasskeyPrompt', () => {
     jest.useRealTimers();
   });
 
+  it('keeps showing the success card after show drops to false (loadPasskeys race)', () => {
+    jest.useFakeTimers();
+    const { container, rerender } = renderWithTheme(
+      <PostLoginPasskeyPrompt {...baseProps} submitting />
+    );
+    // Simulate the real flow: registerPasskeySuccess AND loadPasskeys both
+    // land in the same redux dispatch pair — submitting goes false, and
+    // the newly-loaded passkey list makes the container flip show to false.
+    rerender(withWrappers(
+      <PostLoginPasskeyPrompt {...baseProps} submitting={false} failure={false} show={false} />
+    ));
+    expect(screen.getByText('profile.passkeyPromptSuccessTitle')).toBeInTheDocument();
+    expect(screen.getByText('profile.passkeyPromptSuccessDescription')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(3500);
+    });
+    expect(container.firstChild).toBeNull();
+    jest.useRealTimers();
+  });
+
   it('shows an error notice when registration fails, stays visible', () => {
     const { container, rerender } = renderWithTheme(
       <PostLoginPasskeyPrompt {...baseProps} submitting />

--- a/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.tsx
+++ b/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.tsx
@@ -122,15 +122,7 @@ const PostLoginPasskeyPrompt: React.FC<Props> = ({
     return () => clearTimeout(timer);
   }, [showSuccess]);
 
-  if (!show || dismissed) return null;
-
-  const supported = typeof window !== 'undefined' && !!(window as any).PublicKeyCredential;
-  if (!supported) return null;
-
-  const handleDismiss = () => {
-    markDismissed();
-    setDismissed(true);
-  };
+  if (dismissed) return null;
 
   if (showSuccess) {
     return (
@@ -140,6 +132,16 @@ const PostLoginPasskeyPrompt: React.FC<Props> = ({
       </Wrapper>
     );
   }
+
+  if (!show) return null;
+
+  const supported = typeof window !== 'undefined' && !!(window as any).PublicKeyCredential;
+  if (!supported) return null;
+
+  const handleDismiss = () => {
+    markDismissed();
+    setDismissed(true);
+  };
 
   return (
     <Wrapper data-cy="passkey-prompt">


### PR DESCRIPTION
## Summary

Fixes a bug where the post-login passkey tile disappeared immediately after successful registration — the user never saw the success confirmation that #713 added.

## Root cause

The register saga fires two actions in sequence:

1. ``registerPasskeySuccess`` → ``state.auth.passkeyRegistration.submitting`` goes false
2. ``loadPasskeys`` → ``state.auth.passkeys`` populates with the new credential

The ``PostLoginPasskeyPromptContainer`` computes ``show`` as:

```
__CONF__.passkeysEnabled && isRealUser && passkeys.length === 0
```

As soon as (2) lands, ``show`` flips to ``false``. In the component render, the ``if (!show || dismissed) return null`` gate ran **before** the ``if (showSuccess)`` branch, so the component returned null the moment registration succeeded. The ``showSuccess`` effect did set the state, but the success card was never rendered.

## Fix

Re-order the render checks:

1. ``if (dismissed) return null`` — preserves the 3.5s auto-dismiss behaviour
2. ``if (showSuccess)`` → render success card (regardless of ``show``)
3. ``if (!show) return null`` — normal gate for the idle state
4. Normal ``supported`` check
5. Render the main prompt

## Test plan

- [ ] 1933 tests pass, typecheck clean (includes new regression test simulating the real redux sequence: submitting → false AND show → false in the same transition)
- [ ] Manually register a passkey from the tile on ``lszm-test``
- [ ] Confirm the success card appears with the message and auto-dismisses after ~3.5s