### PR TITLE
Don't persist dismissal when passkey registration succeeds

### DIFF
--- a/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.spec.tsx
+++ b/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.spec.tsx
@@ -150,7 +150,10 @@ describe('PostLoginPasskeyPrompt', () => {
     expect(screen.getByText('profile.passkeyPromptSuccessTitle')).toBeInTheDocument();
     expect(screen.getByText('profile.passkeyPromptSuccessDescription')).toBeInTheDocument();
     expect(screen.queryByText('profile.passkeyPromptRegister')).not.toBeInTheDocument();
-    expect(window.localStorage.getItem('passkeyPromptDismissCount')).toBe('1');
+    // The persistent dismiss counter must NOT be bumped on successful
+    // registration — otherwise the tile can't return after the user removes
+    // all their passkeys.
+    expect(window.localStorage.getItem('passkeyPromptDismissCount')).toBeNull();
 
     act(() => {
       jest.advanceTimersByTime(3500);
@@ -193,5 +196,27 @@ describe('PostLoginPasskeyPrompt', () => {
   it('does not show error notice when idle', () => {
     renderWithTheme(<PostLoginPasskeyPrompt {...baseProps} />);
     expect(screen.queryByText('profile.passkeysRegistrationFailure')).not.toBeInTheDocument();
+  });
+
+  it('reappears on a fresh mount after a successful registration then passkey removal', () => {
+    jest.useFakeTimers();
+    // User registers a passkey from the tile.
+    const first = renderWithTheme(<PostLoginPasskeyPrompt {...baseProps} submitting />);
+    first.rerender(withWrappers(
+      <PostLoginPasskeyPrompt {...baseProps} submitting={false} show={false} />
+    ));
+    act(() => { jest.advanceTimersByTime(3500); });
+    jest.useRealTimers();
+    first.unmount();
+
+    // The persistent dismiss counter must remain empty so the tile can
+    // return after the user removes all their passkeys and revisits.
+    expect(window.localStorage.getItem('passkeyPromptDismissCount')).toBeNull();
+
+    // User removes all passkeys; the container flips show back to true on
+    // the next visit (fresh mount).
+    renderWithTheme(<PostLoginPasskeyPrompt {...baseProps} submitting={false} show={true} />);
+    expect(screen.getByText('profile.passkeyPromptTitle')).toBeInTheDocument();
+    expect(screen.getByText('profile.passkeyPromptRegister')).toBeInTheDocument();
   });
 });

--- a/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.tsx
+++ b/src/components/PostLoginPasskeyPrompt/PostLoginPasskeyPrompt.tsx
@@ -110,7 +110,10 @@ const PostLoginPasskeyPrompt: React.FC<Props> = ({
 
   useEffect(() => {
     if (wasSubmitting && !submitting && !failure) {
-      markDismissed();
+      // Don't call markDismissed() here — the persistent dismiss counter is
+      // reserved for explicit user dismissals. After a successful
+      // registration the passkeys.length === 0 gate already hides the tile,
+      // and if the user later removes all passkeys the tile should return.
       setShowSuccess(true);
     }
     setWasSubmitting(submitting);


### PR DESCRIPTION
## Summary

Fixes a UX bug: after successfully registering a passkey from the start-page tile, the tile never reappeared on that browser/PWA even after the user removed all their passkeys.

## Root cause

The success effect in ``PostLoginPasskeyPrompt`` called ``markDismissed()`` on every successful registration, which bumped ``passkeyPromptDismissCount`` to 1 and wrote a timestamp. That state persists in ``localStorage`` for 30 days.

Meanwhile the container's ``show`` gate — ``passkeysEnabled && isRealUser && passkeys.length === 0`` — already handles the *have-a-passkey* case. So the persistent dismissal did nothing useful on the happy path but blocked the tile from returning once the user removed all their passkeys:

1. Register passkey → ``markDismissed()`` persists ``count=1``, recent timestamp
2. Remove all passkeys → ``passkeys.length === 0`` flips ``show`` back to ``true``
3. Component remounts → ``useState(isDismissed())`` reads persistent state → ``true`` (count=1, within 30-day TTL) → tile stays hidden

## Fix

Drop ``markDismissed()`` from the success path. The persistent dismiss counter is now reserved exclusively for explicit user dismissals (Später / Nicht mehr anzeigen).

Existing behaviour preserved:
- Session-level ``dismissed`` flag still flips to ``true`` via the 3.5s success-auto-dismiss timer, so the card hides within the current session.
- The tile is hidden for users who have a passkey via the ``show`` prop.

## Note for affected users

Users who already registered a passkey while the bug was live have ``passkeyPromptDismissCount=1`` in their localStorage. For them the fix applies to any future registration, but the tile won't return for up to 30 days (TTL expiry) unless they clear the site's local storage.

## Test plan

- [ ] 1934 tests pass, typecheck clean
- [ ] New regression test: register → remove → remount verifies tile returns