### PR TITLE
Enable passkey login on lspl-test

### DIFF
--- a/projects/lspl.json
+++ b/projects/lspl.json
@@ -51,7 +51,8 @@
     "test": {
       "firebaseProjectId": "lspl-test",
       "firebaseDatabaseUrl": "https://lspl-test-default-rtdb.europe-west1.firebasedatabase.app",
-      "firebaseApiKey": "AIzaSyAMrXeJqssO1Wixyf25T-_UBJFyR8emcdk"
+      "firebaseApiKey": "AIzaSyAMrXeJqssO1Wixyf25T-_UBJFyR8emcdk",
+      "passkeysEnabled": true
     }
   },
   "theme": "lspl",


### PR DESCRIPTION
## Summary

Opt ``lspl-test`` into the passkey login feature flag.

- ``projects/lspl.json``: ``passkeysEnabled: true`` under ``environments.test`` only.
- Production unchanged (inherits ``passkeysEnabled: false`` from ``projects/default.json``).
- Functions runtime config (``webauthn.rpid=lspl-test.web.app``, ``webauthn.origins=https://lspl-test.web.app``) already set on the ``lspl-test`` Firebase project.

## Effect after merge

CI rebuilds and redeploys ``lspl-test``; users on ``https://lspl-test.web.app`` can register passkeys from the profile page and the start-page prompt, and use them to sign in. OTP remains the baseline.