### PR TITLE
Add specs for 30 class components before migration

### DIFF
--- a/src/components/AerodromeStatusForm/AerodromeStatusForm.spec.tsx
+++ b/src/components/AerodromeStatusForm/AerodromeStatusForm.spec.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('./StatusForm', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="status-form" data-disabled={String(props.disabled)} />
+  ),
+}));
+
+jest.mock('./StatusList', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="status-list" data-count={props.items.array.length} />
+  ),
+}));
+
+import AerodromeStatusForm from './AerodromeStatusForm';
+
+const makeProps = (overrides: any = {}) => ({
+  data: { status: 'open', details: '' },
+  disabled: false,
+  dirty: false,
+  latest: { array: [] },
+  selected: null,
+  loadAerodromeStatus: jest.fn(),
+  updateAerodromeStatus: jest.fn(),
+  saveAerodromeStatus: jest.fn(),
+  selectAerodromeStatus: jest.fn(),
+  ...overrides,
+});
+
+describe('<AerodromeStatusForm>', () => {
+  it('dispatches loadAerodromeStatus on mount', () => {
+    const loadAerodromeStatus = jest.fn();
+    render(
+      wrap(<AerodromeStatusForm {...makeProps({ loadAerodromeStatus })} />)
+    );
+    expect(loadAerodromeStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the StatusForm', () => {
+    const { getByTestId } = render(
+      wrap(<AerodromeStatusForm {...makeProps()} />)
+    );
+    expect(getByTestId('status-form')).toBeTruthy();
+  });
+
+  it('does not render the StatusList when latest array is empty', () => {
+    const { queryByTestId } = render(
+      wrap(<AerodromeStatusForm {...makeProps()} />)
+    );
+    expect(queryByTestId('status-list')).toBeNull();
+  });
+
+  it('renders the StatusList when there are latest items', () => {
+    const { getByTestId } = render(
+      wrap(
+        <AerodromeStatusForm
+          {...makeProps({
+            latest: { array: [{ key: 'a' }, { key: 'b' }] },
+          })}
+        />
+      )
+    );
+    expect(getByTestId('status-list').getAttribute('data-count')).toBe('2');
+  });
+
+  it('passes disabled through to StatusForm', () => {
+    const { getByTestId } = render(
+      wrap(<AerodromeStatusForm {...makeProps({ disabled: true })} />)
+    );
+    expect(getByTestId('status-form').getAttribute('data-disabled')).toBe(
+      'true'
+    );
+  });
+});

--- a/src/components/AerodromeStatusForm/AerodromeStatusForm.spec.tsx
+++ b/src/components/AerodromeStatusForm/AerodromeStatusForm.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/components/AerodromeStatusForm/StatusForm.spec.tsx
+++ b/src/components/AerodromeStatusForm/StatusForm.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/components/AerodromeStatusForm/StatusForm.spec.tsx
+++ b/src/components/AerodromeStatusForm/StatusForm.spec.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('./AerodromeStatusDropdown', () => ({
+  __esModule: true,
+  default: ({ value, onChange }: any) => (
+    <select
+      data-testid="status-dropdown"
+      value={value}
+      onChange={e => onChange(e.target.value)}
+    >
+      <option value="open">open</option>
+      <option value="closed">closed</option>
+      <option value="restricted">restricted</option>
+    </select>
+  ),
+}));
+
+jest.mock('../TextArea', () => ({
+  __esModule: true,
+  default: ({ value, onChange, rows }: any) => (
+    <textarea
+      data-testid="details"
+      value={value}
+      rows={rows}
+      onChange={onChange}
+    />
+  ),
+}));
+
+jest.mock('../Button', () => ({
+  __esModule: true,
+  default: ({ label, type, disabled }: any) => (
+    <button data-testid="save" type={type} disabled={disabled}>
+      {label}
+    </button>
+  ),
+}));
+
+import StatusForm from './StatusForm';
+
+const makeProps = (overrides: any = {}) => ({
+  data: { status: 'open', details: 'Current details' },
+  disabled: false,
+  dirty: false,
+  updateAerodromeStatus: jest.fn(),
+  saveAerodromeStatus: jest.fn(),
+  ...overrides,
+});
+
+describe('<StatusForm>', () => {
+  it('renders form with dropdown, textarea, and save button', () => {
+    const { getByTestId } = render(wrap(<StatusForm {...makeProps()} />));
+    expect(getByTestId('status-dropdown')).toBeTruthy();
+    expect(getByTestId('details')).toBeTruthy();
+    expect(getByTestId('save')).toBeTruthy();
+  });
+
+  it('passes data.status to dropdown', () => {
+    const { getByTestId } = render(
+      wrap(
+        <StatusForm
+          {...makeProps({ data: { status: 'closed', details: '' } })}
+        />
+      )
+    );
+    expect((getByTestId('status-dropdown') as HTMLSelectElement).value).toBe(
+      'closed'
+    );
+  });
+
+  it('passes data.details to textarea', () => {
+    const { getByTestId } = render(
+      wrap(
+        <StatusForm
+          {...makeProps({ data: { status: 'open', details: 'hello' } })}
+        />
+      )
+    );
+    expect((getByTestId('details') as HTMLTextAreaElement).value).toBe('hello');
+  });
+
+  it('calls updateAerodromeStatus on status change (with current details)', () => {
+    const updateAerodromeStatus = jest.fn();
+    const { getByTestId } = render(
+      wrap(
+        <StatusForm
+          {...makeProps({
+            updateAerodromeStatus,
+            data: { status: 'open', details: 'keep' },
+          })}
+        />
+      )
+    );
+    fireEvent.change(getByTestId('status-dropdown'), {
+      target: { value: 'restricted' },
+    });
+    expect(updateAerodromeStatus).toHaveBeenCalledWith('restricted', 'keep');
+  });
+
+  it('calls updateAerodromeStatus on details change (with current status)', () => {
+    const updateAerodromeStatus = jest.fn();
+    const { getByTestId } = render(
+      wrap(
+        <StatusForm
+          {...makeProps({
+            updateAerodromeStatus,
+            data: { status: 'closed', details: '' },
+          })}
+        />
+      )
+    );
+    fireEvent.change(getByTestId('details'), {
+      target: { value: 'new text' },
+    });
+    expect(updateAerodromeStatus).toHaveBeenCalledWith('closed', 'new text');
+  });
+
+  it('submitting the form calls saveAerodromeStatus with current data', () => {
+    const saveAerodromeStatus = jest.fn();
+    const data = { status: 'restricted', details: 'x' };
+    const { container } = render(
+      wrap(
+        <StatusForm {...makeProps({ saveAerodromeStatus, data, dirty: true })} />
+      )
+    );
+    fireEvent.submit(container.querySelector('form')!);
+    expect(saveAerodromeStatus).toHaveBeenCalledWith(data);
+  });
+
+  it('disables save button when not dirty', () => {
+    const { getByTestId } = render(
+      wrap(<StatusForm {...makeProps({ dirty: false })} />)
+    );
+    expect((getByTestId('save') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('enables save button when dirty and not disabled', () => {
+    const { getByTestId } = render(
+      wrap(<StatusForm {...makeProps({ dirty: true })} />)
+    );
+    expect((getByTestId('save') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('disables save button when disabled is true (even if dirty)', () => {
+    const { getByTestId } = render(
+      wrap(<StatusForm {...makeProps({ dirty: true, disabled: true })} />)
+    );
+    expect((getByTestId('save') as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/src/components/AerodromeStatusForm/StatusList.spec.tsx
+++ b/src/components/AerodromeStatusForm/StatusList.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/components/AerodromeStatusForm/StatusList.spec.tsx
+++ b/src/components/AerodromeStatusForm/StatusList.spec.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('./StatusHeader', () => ({
+  __esModule: true,
+  default: ({ item, selected, active, onClick }: any) => (
+    <div
+      data-testid="status-header"
+      data-key={item.key}
+      data-selected={String(selected)}
+      data-active={String(active)}
+      onClick={onClick}
+    >
+      {item.status}
+    </div>
+  ),
+}));
+
+jest.mock('./StatusContent', () => ({
+  __esModule: true,
+  default: ({ item }: any) => (
+    <div data-testid="status-content">{item.key}</div>
+  ),
+}));
+
+import StatusList from './StatusList';
+
+const makeStatus = (key: string, status = 'open') => ({
+  key,
+  status,
+  details: '',
+  by: 'admin',
+  timestamp: 0,
+});
+
+const makeProps = (overrides: any = {}) => ({
+  items: { array: [] },
+  selected: null,
+  selectStatus: jest.fn(),
+  ...overrides,
+});
+
+describe('<StatusList>', () => {
+  it('renders one StatusHeader per item', () => {
+    const { getAllByTestId } = render(
+      wrap(
+        <StatusList
+          {...makeProps({
+            items: {
+              array: [makeStatus('s1'), makeStatus('s2'), makeStatus('s3')],
+            },
+          })}
+        />
+      )
+    );
+    expect(getAllByTestId('status-header').length).toBe(3);
+  });
+
+  it('marks the first item as active', () => {
+    const { getAllByTestId } = render(
+      wrap(
+        <StatusList
+          {...makeProps({
+            items: { array: [makeStatus('s1'), makeStatus('s2')] },
+          })}
+        />
+      )
+    );
+    const headers = getAllByTestId('status-header');
+    expect(headers[0].getAttribute('data-active')).toBe('true');
+    expect(headers[1].getAttribute('data-active')).toBe('false');
+  });
+
+  it('renders StatusContent for the active (first) item', () => {
+    const { getAllByTestId } = render(
+      wrap(
+        <StatusList
+          {...makeProps({
+            items: { array: [makeStatus('s1'), makeStatus('s2')] },
+          })}
+        />
+      )
+    );
+    const contents = getAllByTestId('status-content');
+    expect(contents.length).toBe(1);
+    expect(contents[0].textContent).toBe('s1');
+  });
+
+  it('renders StatusContent for the selected non-active item too', () => {
+    const { getAllByTestId } = render(
+      wrap(
+        <StatusList
+          {...makeProps({
+            items: { array: [makeStatus('s1'), makeStatus('s2'), makeStatus('s3')] },
+            selected: 's3',
+          })}
+        />
+      )
+    );
+    const contents = getAllByTestId('status-content');
+    const keys = contents.map(n => n.textContent);
+    expect(keys).toEqual(expect.arrayContaining(['s1', 's3']));
+    expect(contents.length).toBe(2);
+  });
+
+  it('dispatches selectStatus with key on non-active header click', () => {
+    const selectStatus = jest.fn();
+    const { getAllByTestId } = render(
+      wrap(
+        <StatusList
+          {...makeProps({
+            items: { array: [makeStatus('s1'), makeStatus('s2')] },
+            selectStatus,
+          })}
+        />
+      )
+    );
+    fireEvent.click(getAllByTestId('status-header')[1]);
+    expect(selectStatus).toHaveBeenCalledWith('s2');
+  });
+
+  it('dispatches selectStatus(null) when clicking currently selected item', () => {
+    const selectStatus = jest.fn();
+    const { getAllByTestId } = render(
+      wrap(
+        <StatusList
+          {...makeProps({
+            items: { array: [makeStatus('s1'), makeStatus('s2')] },
+            selected: 's2',
+            selectStatus,
+          })}
+        />
+      )
+    );
+    fireEvent.click(getAllByTestId('status-header')[1]);
+    expect(selectStatus).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/components/AerodromeStatusPage/AerodromeStatusPage.spec.tsx
+++ b/src/components/AerodromeStatusPage/AerodromeStatusPage.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/components/AerodromeStatusPage/AerodromeStatusPage.spec.tsx
+++ b/src/components/AerodromeStatusPage/AerodromeStatusPage.spec.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('../Logo', () => ({
+  __esModule: true,
+  default: () => <div data-testid="logo" />,
+}));
+
+jest.mock('../MaterialIcon', () => ({
+  __esModule: true,
+  default: ({ icon }: any) => <span data-testid="icon" data-icon={icon} />,
+}));
+
+jest.mock('../AerodromeStatusForm/StatusOptions', () => ({
+  getLabel: (status: string) => `label:${status}`,
+}));
+
+import AerodromeStatusPage from './AerodromeStatusPage';
+
+const makeProps = (overrides: any = {}) => ({
+  status: undefined,
+  watchCurrentAerodromeStatus: jest.fn(),
+  ...overrides,
+});
+
+describe('<AerodromeStatusPage>', () => {
+  it('dispatches watchCurrentAerodromeStatus on mount', () => {
+    const watchCurrentAerodromeStatus = jest.fn();
+    render(
+      wrap(
+        <AerodromeStatusPage
+          {...makeProps({ watchCurrentAerodromeStatus })}
+        />
+      )
+    );
+    expect(watchCurrentAerodromeStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders loading indicator when status is undefined', () => {
+    const { container, getByTestId } = render(
+      wrap(<AerodromeStatusPage {...makeProps()} />)
+    );
+    expect(getByTestId('icon').getAttribute('data-icon')).toBe('sync');
+    expect(container.textContent).toContain('common.loading');
+  });
+
+  it('renders unavailable message when status is null', () => {
+    const { container } = render(
+      wrap(<AerodromeStatusPage {...makeProps({ status: null })} />)
+    );
+    expect(container.textContent).toContain('aerodromeStatus.unavailable');
+  });
+
+  it('renders status details when status is present', () => {
+    const { container } = render(
+      wrap(
+        <AerodromeStatusPage
+          {...makeProps({
+            status: {
+              status: 'open',
+              details: 'All good',
+              by: 'admin',
+              timestamp: 1716393600000,
+            },
+          })}
+        />
+      )
+    );
+    expect(container.textContent).toContain('label:open');
+    expect(container.textContent).toContain('All good');
+  });
+});

--- a/src/components/App/App.spec.tsx
+++ b/src/components/App/App.spec.tsx
@@ -75,7 +75,7 @@ jest.mock(
 
 import App from './App';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 

--- a/src/components/App/App.spec.tsx
+++ b/src/components/App/App.spec.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { Route, Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { ThemeProvider } from 'styled-components';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'de' } }),
+  withTranslation: () => (Component: any) => {
+    const WrappedComponent = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    WrappedComponent.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return WrappedComponent;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+}));
+
+jest.mock('../MaterialIcon', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../Centered', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock(
+  '../../containers/LoginPageContainer',
+  () => ({ __esModule: true, default: () => <div>login-page</div> })
+);
+jest.mock(
+  '../../containers/MessagePageContainer',
+  () => ({ __esModule: true, default: () => <div>message-page</div> })
+);
+jest.mock(
+  '../../containers/StartPageContainer',
+  () => ({ __esModule: true, default: () => <div>start-page</div> })
+);
+jest.mock(
+  '../../containers/DeparturePageContainer',
+  () => ({ __esModule: true, default: () => <div>departure-page</div> })
+);
+jest.mock(
+  '../../containers/HelpPageContainer',
+  () => ({ __esModule: true, default: () => <div>help-page</div> })
+);
+jest.mock(
+  '../../containers/MovementsPageContainer',
+  () => ({ __esModule: true, default: () => <div>movements-page</div> })
+);
+jest.mock(
+  '../../containers/AdminPageContainer',
+  () => ({ __esModule: true, default: () => <div>admin-page</div> })
+);
+jest.mock(
+  '../../containers/ArrivalPageContainer',
+  () => ({ __esModule: true, default: () => <div>arrival-page</div> })
+);
+jest.mock(
+  '../../containers/ArrivalPaymentPageContainer',
+  () => ({ __esModule: true, default: () => <div>arrival-payment-page</div> })
+);
+jest.mock(
+  '../../containers/AerodromeStatusPageContainer',
+  () => ({ __esModule: true, default: () => <div>aerodrome-status-page</div> })
+);
+jest.mock(
+  '../../containers/ProfilePageContainer',
+  () => ({ __esModule: true, default: () => <div>profile-page</div> })
+);
+
+import App from './App';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+
+type AuthProps = { initialized: boolean; authenticated?: boolean };
+
+const renderApp = (auth: AuthProps, initialEntries: string[] = ['/']) => {
+  const history = createMemoryHistory({ initialEntries });
+  const utils = render(
+    <ThemeProvider theme={theme}>
+      <Router history={history}>
+        <Route
+          render={(routeProps: any) => (
+            <App {...routeProps} auth={auth} showLogin={false} />
+          )}
+        />
+      </Router>
+    </ThemeProvider>
+  );
+  return { history, ...utils };
+};
+
+describe('<App>', () => {
+  let scrollToSpy: jest.Mock;
+  let originalScrollTo: typeof window.scrollTo;
+
+  beforeEach(() => {
+    originalScrollTo = window.scrollTo;
+    scrollToSpy = jest.fn();
+    (window as any).scrollTo = scrollToSpy;
+    (global as any).__CONF__ = { profileEnabled: false };
+  });
+
+  afterEach(() => {
+    (window as any).scrollTo = originalScrollTo;
+  });
+
+  describe('scroll restore', () => {
+    it('scrolls to top on PUSH navigation', () => {
+      const { history } = renderApp({ initialized: true, authenticated: true });
+      scrollToSpy.mockClear();
+      act(() => {
+        history.push('/help');
+      });
+      expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('scrolls to top on REPLACE navigation', () => {
+      const { history } = renderApp({ initialized: true, authenticated: true });
+      scrollToSpy.mockClear();
+      act(() => {
+        history.replace('/movements');
+      });
+      expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('does not scroll on POP navigation', () => {
+      const { history } = renderApp({ initialized: true, authenticated: true });
+      act(() => {
+        history.push('/help');
+      });
+      scrollToSpy.mockClear();
+      act(() => {
+        history.goBack();
+      });
+      expect(scrollToSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not scroll on initial render', () => {
+      renderApp({ initialized: true, authenticated: true });
+      expect(scrollToSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('auth gating', () => {
+    it('renders loading indicator when auth is not initialized', () => {
+      const { container } = renderApp({ initialized: false });
+      expect(container.textContent).toContain('common.loading');
+    });
+
+    it('renders login page when unauthenticated on a protected route', () => {
+      const { container } = renderApp(
+        { initialized: true, authenticated: false },
+        ['/movements']
+      );
+      expect(container.textContent).toContain('login-page');
+    });
+
+    it('allows unauthenticated access to /aerodrome-status', () => {
+      const { container } = renderApp(
+        { initialized: true, authenticated: false },
+        ['/aerodrome-status']
+      );
+      expect(container.textContent).toContain('aerodrome-status-page');
+    });
+
+    it('renders the route target when authenticated', () => {
+      const { container } = renderApp(
+        { initialized: true, authenticated: true },
+        ['/movements']
+      );
+      expect(container.textContent).toContain('movements-page');
+    });
+  });
+
+  describe('profileEnabled feature flag', () => {
+    it('routes to profile page when flag is enabled', () => {
+      (global as any).__CONF__ = { profileEnabled: true };
+      const { container } = renderApp(
+        { initialized: true, authenticated: true },
+        ['/profile']
+      );
+      expect(container.textContent).toContain('profile-page');
+    });
+
+    it('redirects away from /profile when flag is disabled', () => {
+      (global as any).__CONF__ = { profileEnabled: false };
+      const { container } = renderApp(
+        { initialized: true, authenticated: true },
+        ['/profile']
+      );
+      expect(container.textContent).toContain('start-page');
+    });
+  });
+});

--- a/src/components/DatePicker/DatePicker.spec.tsx
+++ b/src/components/DatePicker/DatePicker.spec.tsx
@@ -151,6 +151,17 @@ describe('DatePicker', () => {
       fireEvent.click(screen.getByRole('button'));
       expect(onChange).toHaveBeenCalledWith({ value: null });
     });
+
+    it('does not open the picker when the clear button is clicked', () => {
+      renderWithTheme(
+        <DatePicker value="2024-06-15" clearable={true} onChange={jest.fn()} />
+      );
+      // Confirm picker is initially closed
+      expect(screen.queryByTestId('day-picker')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button'));
+      // Click event must not have bubbled to the outer Value div
+      expect(screen.queryByTestId('day-picker')).not.toBeInTheDocument();
+    });
   });
 
   describe('prop updates via componentWillReceiveProps', () => {

--- a/src/components/DatePicker/DatePicker.spec.tsx
+++ b/src/components/DatePicker/DatePicker.spec.tsx
@@ -5,8 +5,8 @@ import DatePicker from './DatePicker';
 // Mock the styled DayPicker wrapper (imported as ./DayPicker in DatePicker.tsx)
 jest.mock('./DayPicker', () => {
   const React = require('react');
-  const MockDayPicker = ({ onSelect }) => (
-    <div data-testid="day-picker">
+  const MockDayPicker = ({ onSelect, locale }) => (
+    <div data-testid="day-picker" data-locale={locale && locale.code}>
       <button
         data-testid="day-picker-day"
         type="button"
@@ -154,24 +154,58 @@ describe('DatePicker', () => {
   });
 
   describe('prop updates via componentWillReceiveProps', () => {
-    it('updates displayed value when value prop changes', () => {
-      const { ThemeProvider } = require('styled-components');
-      const { BrowserRouter } = require('react-router-dom');
-      const { render: rtlRender } = require('@testing-library/react');
-      const theme = {
-        colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
-      };
-      const wrap = el => (
-        <BrowserRouter>
-          <ThemeProvider theme={theme}>{el}</ThemeProvider>
-        </BrowserRouter>
-      );
+    const { ThemeProvider } = require('styled-components');
+    const { BrowserRouter } = require('react-router-dom');
+    const { render: rtlRender } = require('@testing-library/react');
+    const theme = {
+      colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+    };
+    const wrap = el => (
+      <BrowserRouter>
+        <ThemeProvider theme={theme}>{el}</ThemeProvider>
+      </BrowserRouter>
+    );
 
+    it('updates displayed value when value prop changes', () => {
       const { rerender } = rtlRender(
         wrap(<DatePicker value="2024-01-01" onChange={jest.fn()} />)
       );
       rerender(wrap(<DatePicker value="2024-12-31" onChange={jest.fn()} />));
       expect(screen.getByText(/31/)).toBeInTheDocument();
+    });
+
+    it('clears displayed value when value prop becomes null', () => {
+      const { rerender, container } = rtlRender(
+        wrap(<DatePicker value="2024-06-15" onChange={jest.fn()} />)
+      );
+      rerender(wrap(<DatePicker value={null} onChange={jest.fn()} />));
+      // Non-breaking space placeholder is rendered when no value
+      expect(container.textContent).toMatch(/\u00a0/);
+    });
+
+    it('accepts new value after user selected a different one (prop wins)', () => {
+      const { rerender, container } = rtlRender(
+        wrap(<DatePicker value="2024-01-01" onChange={jest.fn()} />)
+      );
+      const valueDiv = container.firstChild!.firstChild;
+      fireEvent.click(valueDiv!);
+      fireEvent.click(screen.getByTestId('day-picker-day'));
+      // User picked 2024-06-15 and wrote it into state; then parent re-sends
+      // a different value and cWRP must mirror it into state.
+      rerender(wrap(<DatePicker value="2025-03-10" onChange={jest.fn()} />));
+      expect(screen.getByText(/10/)).toBeInTheDocument();
+    });
+  });
+
+  describe('locale (i18n)', () => {
+    it('uses German locale by default', () => {
+      const { container } = renderWithTheme(
+        <DatePicker onChange={jest.fn()} />
+      );
+      const valueDiv = container.firstChild!.firstChild;
+      fireEvent.click(valueDiv!);
+      const picker = screen.getByTestId('day-picker');
+      expect(picker.getAttribute('data-locale')).toBe('de');
     });
   });
 

--- a/src/components/HelpPage/HelpPage.spec.tsx
+++ b/src/components/HelpPage/HelpPage.spec.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { renderWithTheme, fireEvent } from '../../../test/renderWithTheme';
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${Component.displayName || Component.name})`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../VerticalHeaderLayout', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div data-testid="layout">{children}</div>,
+}));
+
+jest.mock('../JumpNavigation', () => ({
+  __esModule: true,
+  default: () => <div data-testid="jump-nav" />,
+}));
+
+const origConf = (global as any).__CONF__;
+
+(global as any).__CONF__ = {
+  aerodrome: { name: 'Testfield', ICAO: 'LSZT' },
+};
+
+import HelpPage from './HelpPage';
+
+describe('<HelpPage>', () => {
+  let scrollIntoViewSpy: jest.Mock;
+  let originalScrollIntoView: any;
+
+  beforeEach(() => {
+    (global as any).__CONF__ = {
+      aerodrome: { name: 'Testfield', ICAO: 'LSZT' },
+    };
+    originalScrollIntoView = (HTMLElement.prototype as any).scrollIntoView;
+    scrollIntoViewSpy = jest.fn();
+    (HTMLElement.prototype as any).scrollIntoView = scrollIntoViewSpy;
+  });
+
+  afterEach(() => {
+    (HTMLElement.prototype as any).scrollIntoView = originalScrollIntoView;
+    (global as any).__CONF__ = origConf;
+  });
+
+  const renderPage = () => renderWithTheme(<HelpPage />);
+
+  it('renders one question item per question in the nav list', () => {
+    const { container } = renderPage();
+    const items = container.querySelectorAll('ol > li');
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  it('scrolls the nth LabeledBox into view when the nth question is clicked', () => {
+    const { container } = renderPage();
+    const items = container.querySelectorAll('ol > li');
+    fireEvent.click(items[2]);
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls scrollIntoView each time a question is clicked', () => {
+    const { container } = renderPage();
+    const items = container.querySelectorAll('ol > li');
+    fireEvent.click(items[0]);
+    fireEvent.click(items[1]);
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('scrollIntoView is called on a DOM element (i.e. box ref was captured)', () => {
+    const { container } = renderPage();
+    const items = container.querySelectorAll('ol > li');
+    fireEvent.click(items[0]);
+    const calledOn = scrollIntoViewSpy.mock.instances[0];
+    expect(calledOn).toBeInstanceOf(HTMLElement);
+  });
+});

--- a/src/components/InvoiceRecipientsList/InvoiceRecipient.spec.tsx
+++ b/src/components/InvoiceRecipientsList/InvoiceRecipient.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/components/InvoiceRecipientsList/InvoiceRecipient.spec.tsx
+++ b/src/components/InvoiceRecipientsList/InvoiceRecipient.spec.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('../MaterialIcon', () => ({
+  __esModule: true,
+  default: ({ icon }: any) => <span data-testid="material-icon" data-icon={icon} />,
+}));
+
+jest.mock('../Button', () => ({
+  __esModule: true,
+  default: ({ label, onClick }: any) => (
+    <button data-testid="button" onClick={onClick}>
+      {label}
+    </button>
+  ),
+}));
+
+jest.mock('../ItemList', () => ({
+  __esModule: true,
+  default: ({ items, newItem, changeNewItem, addItem, placeholder }: any) => (
+    <div data-testid="item-list">
+      <input
+        data-testid="new-item-input"
+        value={newItem}
+        placeholder={placeholder}
+        onChange={e => changeNewItem(e.target.value)}
+      />
+      <button data-testid="add-item" onClick={() => addItem(newItem)}>
+        add
+      </button>
+      <ul data-testid="items">
+        {items.map((item: string) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  ),
+}));
+
+jest.mock('./DeleteDialog', () => ({
+  __esModule: true,
+  default: ({ question, onConfirm, onCancel }: any) => (
+    <div data-testid="delete-dialog">
+      {question}
+      <button data-testid="confirm" onClick={onConfirm}>confirm</button>
+      <button data-testid="cancel" onClick={onCancel}>cancel</button>
+    </div>
+  ),
+}));
+
+import InvoiceRecipient from './InvoiceRecipient';
+
+const makeProps = (overrides: any = {}) => ({
+  recipient: { name: 'Acme', emails: [] },
+  expanded: true,
+  onRemove: jest.fn(),
+  onAddEmail: jest.fn(),
+  onRemoveEmail: jest.fn(),
+  onExpandedChange: jest.fn(),
+  ...overrides,
+});
+
+describe('<InvoiceRecipient>', () => {
+  it('renders the recipient name', () => {
+    const { container } = render(
+      wrap(<InvoiceRecipient {...makeProps()} />)
+    );
+    expect(container.textContent).toContain('Acme');
+  });
+
+  it('toggles expansion on header click', () => {
+    const onExpandedChange = jest.fn();
+    const { container } = render(
+      wrap(
+        <InvoiceRecipient
+          {...makeProps({ expanded: false, onExpandedChange })}
+        />
+      )
+    );
+    const header = container.querySelector('div[class]')!.firstChild as HTMLElement;
+    fireEvent.click(header);
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('shows ItemList only when expanded', () => {
+    const { queryByTestId, rerender } = render(
+      wrap(<InvoiceRecipient {...makeProps({ expanded: false })} />)
+    );
+    expect(queryByTestId('item-list')).toBeNull();
+    rerender(wrap(<InvoiceRecipient {...makeProps({ expanded: true })} />));
+    expect(queryByTestId('item-list')).toBeTruthy();
+  });
+
+  it('sorts emails alphabetically case-insensitively', () => {
+    const { getByTestId } = render(
+      wrap(
+        <InvoiceRecipient
+          {...makeProps({
+            recipient: {
+              name: 'Acme',
+              emails: ['charlie@x.ch', 'Alice@x.ch', 'bob@x.ch'],
+            },
+          })}
+        />
+      )
+    );
+    const emails = Array.from(
+      getByTestId('items').children
+    ).map(n => n.textContent);
+    expect(emails).toEqual(['Alice@x.ch', 'bob@x.ch', 'charlie@x.ch']);
+  });
+
+  it('updates newEmail state on ItemList change', () => {
+    const { getByTestId } = render(
+      wrap(<InvoiceRecipient {...makeProps()} />)
+    );
+    const input = getByTestId('new-item-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'new@example.ch' } });
+    expect(input.value).toBe('new@example.ch');
+  });
+
+  it('clears newEmail after emails length grows', () => {
+    const { getByTestId, rerender } = render(
+      wrap(<InvoiceRecipient {...makeProps()} />)
+    );
+    const input = () => getByTestId('new-item-input') as HTMLInputElement;
+    fireEvent.change(input(), { target: { value: 'new@example.ch' } });
+    expect(input().value).toBe('new@example.ch');
+    rerender(
+      wrap(
+        <InvoiceRecipient
+          {...makeProps({
+            recipient: { name: 'Acme', emails: ['new@example.ch'] },
+          })}
+        />
+      )
+    );
+    expect(input().value).toBe('');
+  });
+
+  it('does not clear newEmail when emails length did not grow', () => {
+    const { getByTestId, rerender } = render(
+      wrap(
+        <InvoiceRecipient
+          {...makeProps({
+            recipient: { name: 'Acme', emails: ['existing@x.ch'] },
+          })}
+        />
+      )
+    );
+    const input = () => getByTestId('new-item-input') as HTMLInputElement;
+    fireEvent.change(input(), { target: { value: 'typing@x.ch' } });
+    rerender(
+      wrap(
+        <InvoiceRecipient
+          {...makeProps({
+            recipient: { name: 'Acme', emails: ['existing@x.ch'] },
+          })}
+        />
+      )
+    );
+    expect(input().value).toBe('typing@x.ch');
+  });
+
+  it('does not clear newEmail when emails shrinks', () => {
+    const { getByTestId, rerender } = render(
+      wrap(
+        <InvoiceRecipient
+          {...makeProps({
+            recipient: { name: 'Acme', emails: ['a@x.ch', 'b@x.ch'] },
+          })}
+        />
+      )
+    );
+    const input = () => getByTestId('new-item-input') as HTMLInputElement;
+    fireEvent.change(input(), { target: { value: 'typing@x.ch' } });
+    rerender(
+      wrap(
+        <InvoiceRecipient
+          {...makeProps({
+            recipient: { name: 'Acme', emails: ['a@x.ch'] },
+          })}
+        />
+      )
+    );
+    expect(input().value).toBe('typing@x.ch');
+  });
+
+  it('opens delete dialog when delete button clicked', () => {
+    const { queryByTestId, getByTestId } = render(
+      wrap(<InvoiceRecipient {...makeProps()} />)
+    );
+    expect(queryByTestId('delete-dialog')).toBeNull();
+    fireEvent.click(getByTestId('button'));
+    expect(getByTestId('delete-dialog')).toBeTruthy();
+  });
+
+  it('dispatches onRemove when delete is confirmed', () => {
+    const onRemove = jest.fn();
+    const { getByTestId } = render(
+      wrap(<InvoiceRecipient {...makeProps({ onRemove })} />)
+    );
+    fireEvent.click(getByTestId('button'));
+    fireEvent.click(getByTestId('confirm'));
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  it('closes delete dialog on cancel without calling onRemove', () => {
+    const onRemove = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      wrap(<InvoiceRecipient {...makeProps({ onRemove })} />)
+    );
+    fireEvent.click(getByTestId('button'));
+    fireEvent.click(getByTestId('cancel'));
+    expect(queryByTestId('delete-dialog')).toBeNull();
+    expect(onRemove).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/InvoiceRecipientsList/InvoiceRecipientsList.spec.tsx
+++ b/src/components/InvoiceRecipientsList/InvoiceRecipientsList.spec.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('../MaterialIcon', () => ({
+  __esModule: true,
+  default: ({ icon }: any) => <span data-icon={icon} />,
+}));
+
+jest.mock('./InvoiceRecipient', () => ({
+  __esModule: true,
+  default: ({ recipient }: any) => (
+    <div data-testid="recipient">{recipient.name}</div>
+  ),
+}));
+
+import InvoiceRecipientsList from './InvoiceRecipientsList';
+
+const makeProps = (overrides: any = {}) => ({
+  invoiceRecipients: [],
+  addInvoiceRecipient: jest.fn(),
+  addInvoiceRecipientEmail: jest.fn(),
+  removeInvoiceRecipient: jest.fn(),
+  removeInvoiceRecipientEmail: jest.fn(),
+  ...overrides,
+});
+
+describe('<InvoiceRecipientsList>', () => {
+  it('renders one InvoiceRecipient per entry', () => {
+    const { getAllByTestId } = render(
+      wrap(
+        <InvoiceRecipientsList
+          {...makeProps({
+            invoiceRecipients: [
+              { name: 'A', emails: [] },
+              { name: 'B', emails: [] },
+            ],
+          })}
+        />
+      )
+    );
+    expect(getAllByTestId('recipient').length).toBe(2);
+  });
+
+  it('sorts recipients alphabetically case-insensitively', () => {
+    const { getAllByTestId } = render(
+      wrap(
+        <InvoiceRecipientsList
+          {...makeProps({
+            invoiceRecipients: [
+              { name: 'charlie', emails: [] },
+              { name: 'Alice', emails: [] },
+              { name: 'bob', emails: [] },
+            ],
+          })}
+        />
+      )
+    );
+    const names = getAllByTestId('recipient').map(n => n.textContent);
+    expect(names).toEqual(['Alice', 'bob', 'charlie']);
+  });
+
+  it('updates the name input on change', () => {
+    const { container } = render(
+      wrap(<InvoiceRecipientsList {...makeProps()} />)
+    );
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'New Name' } });
+    expect(input.value).toBe('New Name');
+  });
+
+  it('disables the add button when name is empty', () => {
+    const { container } = render(
+      wrap(<InvoiceRecipientsList {...makeProps()} />)
+    );
+    const button = container.querySelector(
+      'button[type="submit"]'
+    ) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it('enables the add button once a name is typed', () => {
+    const { container } = render(
+      wrap(<InvoiceRecipientsList {...makeProps()} />)
+    );
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'New' } });
+    const button = container.querySelector(
+      'button[type="submit"]'
+    ) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+  });
+
+  it('dispatches addInvoiceRecipient with the typed name on submit', () => {
+    const addInvoiceRecipient = jest.fn();
+    const { container } = render(
+      wrap(
+        <InvoiceRecipientsList {...makeProps({ addInvoiceRecipient })} />
+      )
+    );
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'New Name' } });
+    fireEvent.submit(container.querySelector('form')!);
+    expect(addInvoiceRecipient).toHaveBeenCalledWith('New Name');
+  });
+
+  it('clears newRecipientName after recipients length grows', () => {
+    const { container, rerender } = render(
+      wrap(<InvoiceRecipientsList {...makeProps()} />)
+    );
+    const input = () =>
+      container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input(), { target: { value: 'New Name' } });
+    expect(input().value).toBe('New Name');
+    rerender(
+      wrap(
+        <InvoiceRecipientsList
+          {...makeProps({
+            invoiceRecipients: [{ name: 'New Name', emails: [] }],
+          })}
+        />
+      )
+    );
+    expect(input().value).toBe('');
+  });
+
+  it('does not clear newRecipientName when length did not grow', () => {
+    const { container, rerender } = render(
+      wrap(
+        <InvoiceRecipientsList
+          {...makeProps({
+            invoiceRecipients: [{ name: 'Existing', emails: [] }],
+          })}
+        />
+      )
+    );
+    const input = () =>
+      container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input(), { target: { value: 'Typing' } });
+    rerender(
+      wrap(
+        <InvoiceRecipientsList
+          {...makeProps({
+            invoiceRecipients: [{ name: 'Existing', emails: [] }],
+          })}
+        />
+      )
+    );
+    expect(input().value).toBe('Typing');
+  });
+
+  it('does not clear newRecipientName when length shrinks', () => {
+    const { container, rerender } = render(
+      wrap(
+        <InvoiceRecipientsList
+          {...makeProps({
+            invoiceRecipients: [
+              { name: 'A', emails: [] },
+              { name: 'B', emails: [] },
+            ],
+          })}
+        />
+      )
+    );
+    const input = () =>
+      container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input(), { target: { value: 'Typing' } });
+    rerender(
+      wrap(
+        <InvoiceRecipientsList
+          {...makeProps({
+            invoiceRecipients: [{ name: 'A', emails: [] }],
+          })}
+        />
+      )
+    );
+    expect(input().value).toBe('Typing');
+  });
+});

--- a/src/components/InvoiceRecipientsList/InvoiceRecipientsList.spec.tsx
+++ b/src/components/InvoiceRecipientsList/InvoiceRecipientsList.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/components/LockMovementsForm/LockMovementsForm.spec.tsx
+++ b/src/components/LockMovementsForm/LockMovementsForm.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/components/LockMovementsForm/LockMovementsForm.spec.tsx
+++ b/src/components/LockMovementsForm/LockMovementsForm.spec.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('../DatePicker', () => ({
+  __esModule: true,
+  default: ({ value, onChange }: any) => (
+    <input
+      data-testid="date-picker"
+      defaultValue={value || ''}
+      onChange={e => onChange({ value: e.target.value })}
+    />
+  ),
+}));
+
+import LockMovementsForm from './LockMovementsForm';
+
+const makeProps = (overrides: any = {}) => ({
+  lockDate: { date: null, loading: false },
+  loadLockDate: jest.fn(),
+  setLockDate: jest.fn(),
+  ...overrides,
+});
+
+describe('<LockMovementsForm>', () => {
+  it('dispatches loadLockDate on mount', () => {
+    const loadLockDate = jest.fn();
+    render(wrap(<LockMovementsForm {...makeProps({ loadLockDate })} />));
+    expect(loadLockDate).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders DatePicker with null value when no lockDate', () => {
+    const { getByTestId } = render(
+      wrap(<LockMovementsForm {...makeProps()} />)
+    );
+    expect((getByTestId('date-picker') as HTMLInputElement).value).toBe('');
+  });
+
+  it('renders DatePicker with formatted lockDate', () => {
+    const date = new Date(2026, 3, 15).getTime();
+    const { getByTestId } = render(
+      wrap(
+        <LockMovementsForm
+          {...makeProps({ lockDate: { date, loading: false } })}
+        />
+      )
+    );
+    expect((getByTestId('date-picker') as HTMLInputElement).value).toBe(
+      '2026-04-15'
+    );
+  });
+
+  it('dispatches setLockDate with epoch ms on date change', () => {
+    const setLockDate = jest.fn();
+    const { getByTestId } = render(
+      wrap(<LockMovementsForm {...makeProps({ setLockDate })} />)
+    );
+    fireEvent.change(getByTestId('date-picker'), {
+      target: { value: '2026-05-01' },
+    });
+    const expectedMs = new Date('2026-05-01').getTime();
+    expect(setLockDate).toHaveBeenCalledWith(expectedMs);
+  });
+
+  it('dispatches setLockDate with null when cleared', () => {
+    const setLockDate = jest.fn();
+    const date = new Date(2026, 3, 15).getTime();
+    const { getByTestId } = render(
+      wrap(
+        <LockMovementsForm
+          {...makeProps({ setLockDate, lockDate: { date, loading: false } })}
+        />
+      )
+    );
+    fireEvent.change(getByTestId('date-picker'), { target: { value: '' } });
+    expect(setLockDate).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/components/MaskedInput/MaskedInput.spec.tsx
+++ b/src/components/MaskedInput/MaskedInput.spec.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { renderWithTheme, fireEvent } from '../../../test/renderWithTheme';
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${Component.displayName || Component.name})`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../MaterialIcon', () => ({
+  __esModule: true,
+  default: ({ icon }: any) => <span data-testid="material-icon" data-icon={icon} />,
+}));
+
+import MaskedInput from './MaskedInput';
+
+const makeProps = ({ input, meta, ...rest }: any = {}) => ({
+  input: {
+    name: 'phone',
+    value: '+41 79 123 45 67',
+    onChange: jest.fn(),
+    onFocus: jest.fn(),
+    onBlur: jest.fn(),
+    ...input,
+  },
+  meta: { active: false, ...meta },
+  type: 'tel',
+  ...rest,
+});
+
+describe('<MaskedInput>', () => {
+  describe('when value present and field not active', () => {
+    it('renders masked content', () => {
+      const props = makeProps();
+      const { container } = renderWithTheme(<MaskedInput {...props} />);
+      expect(container.textContent).not.toContain('+41 79 123 45 67');
+      expect(container.querySelector('[data-cy="phone"]')).toBeTruthy();
+    });
+
+    it('renders clear button', () => {
+      const { getByTestId } = renderWithTheme(<MaskedInput {...makeProps()} />);
+      expect(getByTestId('material-icon').getAttribute('data-icon')).toBe('clear');
+    });
+
+    it('shows tooltip on mouse enter', () => {
+      const { container } = renderWithTheme(<MaskedInput {...makeProps()} />);
+      const wrapper = container.querySelector('[data-cy="phone"]')!;
+      expect(container.textContent).not.toContain('maskedInput.tooltip');
+      fireEvent.mouseEnter(wrapper);
+      expect(container.textContent).toContain('maskedInput.tooltip');
+    });
+
+    it('hides tooltip on mouse leave', () => {
+      const { container } = renderWithTheme(<MaskedInput {...makeProps()} />);
+      const wrapper = container.querySelector('[data-cy="phone"]')!;
+      fireEvent.mouseEnter(wrapper);
+      fireEvent.mouseLeave(wrapper);
+      expect(container.textContent).not.toContain('maskedInput.tooltip');
+    });
+
+    it('calls onChange(null) when clear button is clicked', () => {
+      const onChange = jest.fn();
+      const props = makeProps({ input: { onChange } });
+      const { container } = renderWithTheme(<MaskedInput {...props} />);
+      const clearBtn = container.querySelector('button')!;
+      fireEvent.click(clearBtn);
+      expect(onChange).toHaveBeenCalledWith(null);
+    });
+
+    it('masks email differently from phone', () => {
+      const emailProps = makeProps({
+        input: { name: 'e', value: 'roland@example.com', onChange: jest.fn() },
+        type: 'email',
+      });
+      const { container } = renderWithTheme(<MaskedInput {...emailProps} />);
+      expect(container.textContent).not.toContain('roland@example.com');
+    });
+  });
+
+  describe('when field active', () => {
+    it('renders raw input (unmasked)', () => {
+      const props = makeProps({ meta: { active: true } });
+      const { container } = renderWithTheme(<MaskedInput {...props} />);
+      const input = container.querySelector('input') as HTMLInputElement;
+      expect(input).toBeTruthy();
+      expect(input.value).toBe('+41 79 123 45 67');
+    });
+  });
+
+  describe('when value empty', () => {
+    it('renders raw input', () => {
+      const props = makeProps({ input: { value: '' } });
+      const { container } = renderWithTheme(<MaskedInput {...props} />);
+      expect(container.querySelector('input')).toBeTruthy();
+    });
+  });
+});

--- a/src/components/MessageForm/MessageForm.spec.tsx
+++ b/src/components/MessageForm/MessageForm.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/components/MessageForm/MessageForm.spec.tsx
+++ b/src/components/MessageForm/MessageForm.spec.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('./Dialog', () => ({
+  __esModule: true,
+  default: ({ heading, onClose }: any) => (
+    <div data-testid="dialog" onClick={onClose}>
+      {heading}
+    </div>
+  ),
+}));
+
+jest.mock('./renderField', () => ({
+  renderInputField: ({ input, label }: any) => (
+    <label>
+      {label}
+      <input data-testid={`input-${input.name}`} {...input} />
+    </label>
+  ),
+  renderPhoneField: ({ input, label }: any) => (
+    <label>
+      {label}
+      <input data-testid={`input-${input.name}`} {...input} />
+    </label>
+  ),
+  renderTextArea: ({ input, label }: any) => (
+    <label>
+      {label}
+      <textarea data-testid={`input-${input.name}`} {...input} />
+    </label>
+  ),
+}));
+
+import MessageForm from './MessageForm';
+
+const makeProps = (overrides: any = {}) => ({
+  sent: false,
+  commitFailed: false,
+  onSubmit: jest.fn(),
+  resetMessageForm: jest.fn(),
+  confirmSaveMessageSuccess: jest.fn(),
+  initialValues: {},
+  ...overrides,
+});
+
+describe('<MessageForm>', () => {
+  it('dispatches resetMessageForm on unmount', () => {
+    const resetMessageForm = jest.fn();
+    const { unmount } = render(
+      wrap(<MessageForm {...makeProps({ resetMessageForm })} />)
+    );
+    expect(resetMessageForm).not.toHaveBeenCalled();
+    unmount();
+    expect(resetMessageForm).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefills fields from initialValues', () => {
+    const { getByTestId } = render(
+      wrap(
+        <MessageForm
+          {...makeProps({
+            initialValues: {
+              name: 'Roland',
+              email: 'r@example.ch',
+              phone: '+41791234567',
+            },
+          })}
+        />
+      )
+    );
+    expect((getByTestId('input-name') as HTMLInputElement).value).toBe('Roland');
+    expect((getByTestId('input-email') as HTMLInputElement).value).toBe(
+      'r@example.ch'
+    );
+    expect((getByTestId('input-phone') as HTMLInputElement).value).toBe(
+      '+41791234567'
+    );
+  });
+
+  it('renders success dialog when sent is true', () => {
+    const { getByTestId } = render(
+      wrap(<MessageForm {...makeProps({ sent: true })} />)
+    );
+    expect(getByTestId('dialog').textContent).toBe('message.successHeading');
+  });
+
+  it('renders error dialog when commitFailed is true', () => {
+    const { getByTestId } = render(
+      wrap(<MessageForm {...makeProps({ commitFailed: true })} />)
+    );
+    expect(getByTestId('dialog').textContent).toBe('message.errorHeading');
+  });
+
+  it('calls onSubmit when form is submitted', () => {
+    const onSubmit = jest.fn();
+    const { container } = render(
+      wrap(
+        <MessageForm
+          {...makeProps({
+            onSubmit,
+            initialValues: {
+              name: 'R',
+              email: 'a@b.ch',
+              phone: '+41791234567',
+              message: 'hi',
+            },
+          })}
+        />
+      )
+    );
+    fireEvent.submit(container.querySelector('form')!);
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it('closes success dialog by dispatching confirmSaveMessageSuccess', () => {
+    const confirmSaveMessageSuccess = jest.fn();
+    const { getByTestId } = render(
+      wrap(
+        <MessageForm
+          {...makeProps({ sent: true, confirmSaveMessageSuccess })}
+        />
+      )
+    );
+    fireEvent.click(getByTestId('dialog'));
+    expect(confirmSaveMessageSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/components/MessageList/MessageList.spec.tsx
+++ b/src/components/MessageList/MessageList.spec.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('./MessageHeader', () => ({
+  __esModule: true,
+  default: ({ item, selected }: any) => (
+    <div data-testid="message-header" data-selected={String(selected)}>
+      {item.key}
+    </div>
+  ),
+}));
+
+jest.mock('./MessageContent', () => ({
+  __esModule: true,
+  default: ({ item }: any) => (
+    <div data-testid="message-content">{item.key}</div>
+  ),
+}));
+
+import MessageList from './MessageList';
+
+const makeMessage = (key: string) => ({
+  key,
+  name: `Name ${key}`,
+  message: `Message ${key}`,
+});
+
+const makeProps = (overrides: any = {}) => ({
+  messages: { data: { array: [] }, selected: null },
+  loadMessages: jest.fn(),
+  selectMessage: jest.fn(),
+  ...overrides,
+});
+
+describe('<MessageList>', () => {
+  it('dispatches loadMessages on mount', () => {
+    const loadMessages = jest.fn();
+    render(wrap(<MessageList {...makeProps({ loadMessages })} />));
+    expect(loadMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders empty state when no messages', () => {
+    const { container } = render(wrap(<MessageList {...makeProps()} />));
+    expect(container.textContent).toContain('message.noMessages');
+  });
+
+  it('renders one MessageHeader per message', () => {
+    const { getAllByTestId } = render(
+      wrap(
+        <MessageList
+          {...makeProps({
+            messages: {
+              data: {
+                array: [makeMessage('m1'), makeMessage('m2'), makeMessage('m3')],
+              },
+              selected: null,
+            },
+          })}
+        />
+      )
+    );
+    expect(getAllByTestId('message-header').length).toBe(3);
+  });
+
+  it('renders MessageContent only for the selected message', () => {
+    const { getAllByTestId, getByTestId } = render(
+      wrap(
+        <MessageList
+          {...makeProps({
+            messages: {
+              data: {
+                array: [makeMessage('m1'), makeMessage('m2')],
+              },
+              selected: 'm2',
+            },
+          })}
+        />
+      )
+    );
+    expect(getAllByTestId('message-content').length).toBe(1);
+    expect(getByTestId('message-content').textContent).toBe('m2');
+  });
+
+  it('dispatches selectMessage with key when clicked', () => {
+    const selectMessage = jest.fn();
+    const { getAllByTestId } = render(
+      wrap(
+        <MessageList
+          {...makeProps({
+            messages: {
+              data: { array: [makeMessage('m1'), makeMessage('m2')] },
+              selected: null,
+            },
+            selectMessage,
+          })}
+        />
+      )
+    );
+    fireEvent.click(getAllByTestId('message-header')[1].parentElement!);
+    expect(selectMessage).toHaveBeenCalledWith('m2');
+  });
+
+  it('dispatches selectMessage(null) when selected message is clicked again', () => {
+    const selectMessage = jest.fn();
+    const { getAllByTestId } = render(
+      wrap(
+        <MessageList
+          {...makeProps({
+            messages: {
+              data: { array: [makeMessage('m1')] },
+              selected: 'm1',
+            },
+            selectMessage,
+          })}
+        />
+      )
+    );
+    fireEvent.click(getAllByTestId('message-header')[0].parentElement!);
+    expect(selectMessage).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/components/MessageList/MessageList.spec.tsx
+++ b/src/components/MessageList/MessageList.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/components/MovementList/AssociatedMovement.spec.tsx
+++ b/src/components/MovementList/AssociatedMovement.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/components/MovementList/AssociatedMovement.spec.tsx
+++ b/src/components/MovementList/AssociatedMovement.spec.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('../MaterialIcon', () => ({
+  __esModule: true,
+  default: ({ icon }: any) => <span data-testid="material-icon" data-icon={icon} />,
+}));
+
+jest.mock('./MovementDetails', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="movement-details">{JSON.stringify(props.data)}</div>
+  ),
+}));
+
+jest.mock('./Action', () => ({
+  __esModule: true,
+  default: ({ label, onClick }: any) => (
+    <button onClick={onClick} data-testid="action">
+      {label}
+    </button>
+  ),
+}));
+
+import AssociatedMovement from './AssociatedMovement';
+
+const makeProps = (overrides: any = {}) => ({
+  movementType: 'departure',
+  movementKey: 'mov-key-1',
+  isHomeBase: false,
+  isAdmin: false,
+  loading: false,
+  associatedMovement: { key: 'assoc-key-1', type: 'arrival' },
+  associatedMovementData: undefined,
+  loadMovement: jest.fn(),
+  createMovementFromMovement: jest.fn(),
+  ...overrides,
+});
+
+describe('<AssociatedMovement>', () => {
+  describe('mount dispatch', () => {
+    it('dispatches loadMovement when data is undefined', () => {
+      const loadMovement = jest.fn();
+      render(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              loadMovement,
+              associatedMovement: { key: 'k1', type: 'arrival' },
+              associatedMovementData: undefined,
+            })}
+          />
+        )
+      );
+      expect(loadMovement).toHaveBeenCalledWith('k1', 'arrival');
+    });
+
+    it('does NOT dispatch loadMovement when data is already loaded', () => {
+      const loadMovement = jest.fn();
+      render(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              loadMovement,
+              associatedMovementData: { key: 'k1', immatriculation: 'HB-XXX' },
+            })}
+          />
+        )
+      );
+      expect(loadMovement).not.toHaveBeenCalled();
+    });
+
+    it('does NOT dispatch loadMovement when data is null (none found)', () => {
+      const loadMovement = jest.fn();
+      render(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              loadMovement,
+              associatedMovementData: null,
+            })}
+          />
+        )
+      );
+      expect(loadMovement).not.toHaveBeenCalled();
+    });
+
+    it('does NOT dispatch loadMovement when associatedMovement.type is "none"', () => {
+      const loadMovement = jest.fn();
+      render(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              loadMovement,
+              associatedMovement: { key: 'k1', type: 'none' },
+            })}
+          />
+        )
+      );
+      expect(loadMovement).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update dispatch', () => {
+    it('re-dispatches loadMovement when data becomes undefined again', () => {
+      const loadMovement = jest.fn();
+      const { rerender } = render(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              loadMovement,
+              associatedMovementData: { key: 'k1' },
+            })}
+          />
+        )
+      );
+      expect(loadMovement).not.toHaveBeenCalled();
+      rerender(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              loadMovement,
+              associatedMovementData: undefined,
+            })}
+          />
+        )
+      );
+      expect(loadMovement).toHaveBeenCalledWith('assoc-key-1', 'arrival');
+    });
+
+    it('does not re-dispatch once data is loaded', () => {
+      const loadMovement = jest.fn();
+      const { rerender } = render(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              loadMovement,
+              associatedMovementData: undefined,
+            })}
+          />
+        )
+      );
+      rerender(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              loadMovement,
+              associatedMovementData: { key: 'k1' },
+            })}
+          />
+        )
+      );
+      expect(loadMovement).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('render', () => {
+    it('shows loading icon when data undefined', () => {
+      const { getByTestId } = render(
+        wrap(<AssociatedMovement {...makeProps()} />)
+      );
+      expect(getByTestId('material-icon').getAttribute('data-icon')).toBe('sync');
+    });
+
+    it('shows details when data present', () => {
+      const { getByTestId } = render(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              associatedMovementData: { key: 'k1', immatriculation: 'HB-XYZ' },
+            })}
+          />
+        )
+      );
+      expect(getByTestId('movement-details')).toBeTruthy();
+    });
+
+    it('shows create action when data is null', () => {
+      const { getByTestId } = render(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              associatedMovementData: null,
+            })}
+          />
+        )
+      );
+      expect(getByTestId('action')).toBeTruthy();
+    });
+
+    it('triggers createMovementFromMovement when action is clicked', () => {
+      const createMovementFromMovement = jest.fn();
+      const { getByTestId } = render(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              associatedMovementData: null,
+              createMovementFromMovement,
+              movementType: 'arrival',
+              movementKey: 'mov-2',
+            })}
+          />
+        )
+      );
+      fireEvent.click(getByTestId('action'));
+      expect(createMovementFromMovement).toHaveBeenCalledWith('arrival', 'mov-2');
+    });
+  });
+});

--- a/src/components/MovementList/MovementList.spec.tsx
+++ b/src/components/MovementList/MovementList.spec.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('../../util/AutoLoad', () => ({
+  AutoLoad: (List: any) => (props: any) => <List {...props} />,
+}));
+
+jest.mock('./LoadingInfo', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loading-info" />,
+}));
+
+jest.mock('./LoadingFailureInfo', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loading-failure-info" />,
+}));
+
+jest.mock('./NoMovmementsInfo', () => ({
+  __esModule: true,
+  default: () => <div data-testid="no-movements-info" />,
+}));
+
+jest.mock('./MovementGroup', () => ({
+  __esModule: true,
+  default: ({ label }: any) => (
+    <div data-testid="movement-group">{label}</div>
+  ),
+}));
+
+jest.mock('../MovementDeleteConfirmationDialog', () => ({
+  __esModule: true,
+  default: ({ item }: any) => (
+    <div data-testid="delete-confirmation">{item.key}</div>
+  ),
+}));
+
+jest.mock('../../containers/MovementFilterContainer', () => ({
+  __esModule: true,
+  default: () => <div data-testid="movement-filter" />,
+}));
+
+import MovementList from './MovementList';
+
+const makeProps = (overrides: any = {}) => ({
+  loadItems: jest.fn(),
+  loadAircraftSettings: jest.fn(),
+  checkCustomsAvailability: jest.fn(),
+  loadAerodromes: jest.fn(),
+  items: { array: [], length: 0 },
+  selected: null,
+  onSelect: jest.fn(),
+  loading: false,
+  loadingFailed: false,
+  deleteConfirmation: null,
+  deleteItem: jest.fn(),
+  hideDeleteConfirmationDialog: jest.fn(),
+  showDeleteConfirmationDialog: jest.fn(),
+  onEdit: jest.fn(),
+  createMovementFromMovement: jest.fn(),
+  lockDate: { loading: false, date: null },
+  aircraftSettings: { club: {}, homeBase: {} },
+  isAdmin: false,
+  ...overrides,
+});
+
+describe('<MovementList>', () => {
+  describe('mount dispatches', () => {
+    it('dispatches loadAircraftSettings on mount', () => {
+      const loadAircraftSettings = jest.fn();
+      render(
+        wrap(<MovementList {...makeProps({ loadAircraftSettings })} />)
+      );
+      expect(loadAircraftSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches loadAerodromes on mount', () => {
+      const loadAerodromes = jest.fn();
+      render(wrap(<MovementList {...makeProps({ loadAerodromes })} />));
+      expect(loadAerodromes).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches checkCustomsAvailability on mount', () => {
+      const checkCustomsAvailability = jest.fn();
+      render(
+        wrap(<MovementList {...makeProps({ checkCustomsAvailability })} />)
+      );
+      expect(checkCustomsAvailability).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches onSelect(null) on mount', () => {
+      const onSelect = jest.fn();
+      render(wrap(<MovementList {...makeProps({ onSelect })} />));
+      expect(onSelect).toHaveBeenCalledWith(null);
+    });
+
+    it('dispatches loadItems(true) on mount', () => {
+      const loadItems = jest.fn();
+      render(wrap(<MovementList {...makeProps({ loadItems })} />));
+      expect(loadItems).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('loading gate', () => {
+    it('renders loading info when lockDate is loading', () => {
+      const { getAllByTestId, queryByTestId } = render(
+        wrap(
+          <MovementList
+            {...makeProps({ lockDate: { loading: true, date: null } })}
+          />
+        )
+      );
+      expect(getAllByTestId('loading-info').length).toBe(1);
+      expect(queryByTestId('movement-group')).toBeNull();
+    });
+
+    it('renders loading info when aircraftSettings.club is absent', () => {
+      const { getAllByTestId, queryByTestId } = render(
+        wrap(
+          <MovementList
+            {...makeProps({ aircraftSettings: { homeBase: {} } })}
+          />
+        )
+      );
+      expect(getAllByTestId('loading-info').length).toBe(1);
+      expect(queryByTestId('movement-group')).toBeNull();
+    });
+
+    it('renders loading info when aircraftSettings.homeBase is absent', () => {
+      const { getAllByTestId, queryByTestId } = render(
+        wrap(
+          <MovementList {...makeProps({ aircraftSettings: { club: {} } })} />
+        )
+      );
+      expect(getAllByTestId('loading-info').length).toBe(1);
+      expect(queryByTestId('movement-group')).toBeNull();
+    });
+
+    it('renders movement groups when data is ready', () => {
+      const { getAllByTestId } = render(
+        wrap(<MovementList {...makeProps()} />)
+      );
+      expect(getAllByTestId('movement-group').length).toBe(5);
+    });
+  });
+
+  describe('conditional children', () => {
+    it('renders MovementFilter only when isAdmin is true', () => {
+      const { queryByTestId, rerender } = render(
+        wrap(<MovementList {...makeProps({ isAdmin: false })} />)
+      );
+      expect(queryByTestId('movement-filter')).toBeNull();
+      rerender(wrap(<MovementList {...makeProps({ isAdmin: true })} />));
+      expect(queryByTestId('movement-filter')).toBeTruthy();
+    });
+
+    it('renders LoadingInfo when loading is true (below groups)', () => {
+      const { getAllByTestId } = render(
+        wrap(<MovementList {...makeProps({ loading: true })} />)
+      );
+      expect(getAllByTestId('loading-info').length).toBe(1);
+    });
+
+    it('renders LoadingFailureInfo when loadingFailed is true', () => {
+      const { getByTestId } = render(
+        wrap(<MovementList {...makeProps({ loadingFailed: true })} />)
+      );
+      expect(getByTestId('loading-failure-info')).toBeTruthy();
+    });
+
+    it('renders NoMovementsInfo when not loading and no items', () => {
+      const { getByTestId } = render(
+        wrap(<MovementList {...makeProps()} />)
+      );
+      expect(getByTestId('no-movements-info')).toBeTruthy();
+    });
+
+    it('does not render NoMovementsInfo while loading', () => {
+      const { queryByTestId } = render(
+        wrap(<MovementList {...makeProps({ loading: true })} />)
+      );
+      expect(queryByTestId('no-movements-info')).toBeNull();
+    });
+
+    it('renders delete confirmation dialog when deleteConfirmation is set', () => {
+      const { getByTestId } = render(
+        wrap(
+          <MovementList
+            {...makeProps({ deleteConfirmation: { key: 'mov-to-delete' } })}
+          />
+        )
+      );
+      expect(getByTestId('delete-confirmation').textContent).toBe(
+        'mov-to-delete'
+      );
+    });
+  });
+});

--- a/src/components/MovementList/MovementList.spec.tsx
+++ b/src/components/MovementList/MovementList.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/components/StartPage/LoginInfo.spec.tsx
+++ b/src/components/StartPage/LoginInfo.spec.tsx
@@ -238,5 +238,65 @@ describe('LoginInfo', () => {
       fireEvent.click(document.body);
       expect(screen.queryByText('login.logout')).not.toBeInTheDocument();
     });
+
+    it('re-opens menu after outside click closed it', () => {
+      renderWithTheme(<LoginInfo {...baseProps} />);
+      fireEvent.click(screen.getAllByText('test@example.com')[0]);
+      fireEvent.click(document.body);
+      expect(screen.queryByText('login.logout')).not.toBeInTheDocument();
+      fireEvent.click(screen.getAllByText('test@example.com')[0]);
+      expect(screen.getByText('login.logout')).toBeInTheDocument();
+    });
+
+    it('does NOT close menu when clicking inside the menu', () => {
+      renderWithTheme(<LoginInfo {...baseProps} />);
+      fireEvent.click(screen.getAllByText('test@example.com')[0]);
+      const logoutBtn = screen.getByText('login.logout');
+      // Click inside menu — should not close
+      fireEvent.click(logoutBtn);
+      // logout IS called but menu state is untouched by outside-click handler
+      expect(baseProps.logout).toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes document click listener on unmount', () => {
+      const removeSpy = jest.spyOn(document, 'removeEventListener');
+      const { unmount } = renderWithTheme(<LoginInfo {...baseProps} />);
+      removeSpy.mockClear();
+      unmount();
+      expect(
+        removeSpy.mock.calls.some(([evt]) => evt === 'click')
+      ).toBe(true);
+      removeSpy.mockRestore();
+    });
+  });
+
+  describe('profileEnabled feature flag', () => {
+    const origConf = (global as any).__CONF__;
+    afterEach(() => {
+      (global as any).__CONF__ = origConf;
+    });
+
+    it('shows profile link when __CONF__ is undefined', () => {
+      (global as any).__CONF__ = undefined;
+      renderWithTheme(<LoginInfo {...baseProps} />);
+      fireEvent.click(screen.getAllByText('test@example.com')[0]);
+      expect(screen.getByText('login.profile')).toBeInTheDocument();
+    });
+
+    it('shows profile link when profileEnabled is true', () => {
+      (global as any).__CONF__ = { profileEnabled: true };
+      renderWithTheme(<LoginInfo {...baseProps} />);
+      fireEvent.click(screen.getAllByText('test@example.com')[0]);
+      expect(screen.getByText('login.profile')).toBeInTheDocument();
+    });
+
+    it('hides profile link when profileEnabled is false', () => {
+      (global as any).__CONF__ = { profileEnabled: false };
+      renderWithTheme(<LoginInfo {...baseProps} />);
+      fireEvent.click(screen.getAllByText('test@example.com')[0]);
+      expect(screen.queryByText('login.profile')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/TimeField/NumberBlock.spec.tsx
+++ b/src/components/TimeField/NumberBlock.spec.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { renderWithTheme, fireEvent } from '../../../test/renderWithTheme';
+import NumberBlock from './NumberBlock';
+
+describe('<NumberBlock>', () => {
+  it('displays value formatted with leading zero', () => {
+    const { container } = renderWithTheme(
+      <NumberBlock value={5} dataCy="n" onChange={jest.fn()} />
+    );
+    const input = container.querySelector(
+      '[data-cy="n-input"]'
+    ) as HTMLInputElement;
+    expect(input.value).toBe('05');
+  });
+
+  it('shows typed value while editing (does not commit yet)', () => {
+    const onChange = jest.fn();
+    const { container } = renderWithTheme(
+      <NumberBlock value={10} dataCy="n" onChange={onChange} />
+    );
+    const input = container.querySelector(
+      '[data-cy="n-input"]'
+    ) as HTMLInputElement;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '2' } });
+    expect(input.value).toBe('2');
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.change(input, { target: { value: '25' } });
+    expect(input.value).toBe('25');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('rejects input with more than two digits', () => {
+    const { container } = renderWithTheme(
+      <NumberBlock value={10} dataCy="n" onChange={jest.fn()} />
+    );
+    const input = container.querySelector(
+      '[data-cy="n-input"]'
+    ) as HTMLInputElement;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '22' } });
+    expect(input.value).toBe('22');
+    fireEvent.change(input, { target: { value: '222' } });
+    expect(input.value).toBe('22');
+  });
+
+  it('rejects non-digit input', () => {
+    const { container } = renderWithTheme(
+      <NumberBlock value={10} dataCy="n" onChange={jest.fn()} />
+    );
+    const input = container.querySelector(
+      '[data-cy="n-input"]'
+    ) as HTMLInputElement;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '1' } });
+    expect(input.value).toBe('1');
+    fireEvent.change(input, { target: { value: '1a' } });
+    expect(input.value).toBe('1');
+  });
+
+  it('commits parsed value on blur', () => {
+    const onChange = jest.fn();
+    const { container } = renderWithTheme(
+      <NumberBlock value={10} dataCy="n" onChange={onChange} />
+    );
+    const input = container.querySelector(
+      '[data-cy="n-input"]'
+    ) as HTMLInputElement;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '42' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith(42);
+  });
+
+  it('commits 0 when edit value is empty on blur', () => {
+    const onChange = jest.fn();
+    const { container } = renderWithTheme(
+      <NumberBlock value={10} dataCy="n" onChange={onChange} />
+    );
+    const input = container.querySelector(
+      '[data-cy="n-input"]'
+    ) as HTMLInputElement;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  it('reverts to prop value after blur (clears editing state)', () => {
+    const onChange = jest.fn();
+    const { container, rerender } = renderWithTheme(
+      <NumberBlock value={10} dataCy="n" onChange={onChange} />
+    );
+    const input = () =>
+      container.querySelector('[data-cy="n-input"]') as HTMLInputElement;
+    fireEvent.focus(input());
+    fireEvent.change(input(), { target: { value: '42' } });
+    fireEvent.blur(input());
+    rerender(<NumberBlock value={42} dataCy="n" onChange={onChange} />);
+    expect(input().value).toBe('42');
+  });
+
+  it('increments by 1 on + mouseDown', () => {
+    const onChange = jest.fn();
+    const { container } = renderWithTheme(
+      <NumberBlock value={7} dataCy="n" onChange={onChange} />
+    );
+    const btn = container.querySelector(
+      '[data-cy="n-increment"]'
+    ) as HTMLButtonElement;
+    fireEvent.mouseDown(btn);
+    fireEvent.mouseUp(btn);
+    expect(onChange).toHaveBeenCalledWith(8);
+  });
+
+  it('decrements by 1 on - mouseDown', () => {
+    const onChange = jest.fn();
+    const { container } = renderWithTheme(
+      <NumberBlock value={7} dataCy="n" onChange={onChange} />
+    );
+    const btn = container.querySelector(
+      '[data-cy="n-decrement"]'
+    ) as HTMLButtonElement;
+    fireEvent.mouseDown(btn);
+    fireEvent.mouseUp(btn);
+    expect(onChange).toHaveBeenCalledWith(6);
+  });
+});

--- a/src/components/TimeField/TimeField.spec.tsx
+++ b/src/components/TimeField/TimeField.spec.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { renderWithTheme, fireEvent } from '../../../test/renderWithTheme';
+import TimeField from './TimeField';
+
+describe('<TimeField>', () => {
+  describe('read-only', () => {
+    it('renders formatted value', () => {
+      const { container } = renderWithTheme(
+        <TimeField value="09:05" readOnly />
+      );
+      expect(container.textContent).toContain('09:05');
+    });
+
+    it('renders 00:00 when value is undefined', () => {
+      const { container } = renderWithTheme(<TimeField readOnly />);
+      expect(container.textContent).toContain('00:00');
+    });
+
+    it('renders 00:00 when value is invalid', () => {
+      const { container } = renderWithTheme(
+        <TimeField value="not-a-time" readOnly />
+      );
+      expect(container.textContent).toContain('00:00');
+    });
+  });
+
+  describe('editable', () => {
+    it('renders hours and minutes inputs from value', () => {
+      const { container } = renderWithTheme(
+        <TimeField value="14:30" dataCy="t" onChange={jest.fn()} />
+      );
+      const hours = container.querySelector(
+        '[data-cy="t-hours-input"]'
+      ) as HTMLInputElement;
+      const minutes = container.querySelector(
+        '[data-cy="t-minutes-input"]'
+      ) as HTMLInputElement;
+      expect(hours.value).toBe('14');
+      expect(minutes.value).toBe('30');
+    });
+
+    it('mirrors prop value change into inputs (getDerivedStateFromProps)', () => {
+      const { container, rerender } = renderWithTheme(
+        <TimeField value="09:15" dataCy="t" onChange={jest.fn()} />
+      );
+      const hours = () =>
+        (container.querySelector('[data-cy="t-hours-input"]') as HTMLInputElement)
+          .value;
+      const minutes = () =>
+        (
+          container.querySelector('[data-cy="t-minutes-input"]') as HTMLInputElement
+        ).value;
+      expect(hours()).toBe('09');
+      expect(minutes()).toBe('15');
+      rerender(<TimeField value="17:42" dataCy="t" onChange={jest.fn()} />);
+      expect(hours()).toBe('17');
+      expect(minutes()).toBe('42');
+    });
+
+    it('fires onChange with new value on hours blur', () => {
+      const onChange = jest.fn();
+      const { container } = renderWithTheme(
+        <TimeField value="10:20" dataCy="t" onChange={onChange} />
+      );
+      const hours = container.querySelector(
+        '[data-cy="t-hours-input"]'
+      ) as HTMLInputElement;
+      fireEvent.focus(hours);
+      fireEvent.change(hours, { target: { value: '22' } });
+      fireEvent.blur(hours);
+      expect(onChange).toHaveBeenLastCalledWith({ value: '22:20' });
+    });
+
+    it('fires onChange with new value on minutes blur', () => {
+      const onChange = jest.fn();
+      const { container } = renderWithTheme(
+        <TimeField value="10:20" dataCy="t" onChange={onChange} />
+      );
+      const minutes = container.querySelector(
+        '[data-cy="t-minutes-input"]'
+      ) as HTMLInputElement;
+      fireEvent.focus(minutes);
+      fireEvent.change(minutes, { target: { value: '45' } });
+      fireEvent.blur(minutes);
+      expect(onChange).toHaveBeenLastCalledWith({ value: '10:45' });
+    });
+
+    it('fires onChange with null when value normalizes to 00:00', () => {
+      const onChange = jest.fn();
+      const { container } = renderWithTheme(
+        <TimeField value="00:10" dataCy="t" onChange={onChange} />
+      );
+      const minutes = container.querySelector(
+        '[data-cy="t-minutes-input"]'
+      ) as HTMLInputElement;
+      fireEvent.focus(minutes);
+      fireEvent.change(minutes, { target: { value: '00' } });
+      fireEvent.blur(minutes);
+      expect(onChange).toHaveBeenLastCalledWith({ value: null });
+    });
+
+    it('increments minutes on + mousedown and normalizes overflow', () => {
+      const onChange = jest.fn();
+      const { container } = renderWithTheme(
+        <TimeField value="09:59" dataCy="t" onChange={onChange} />
+      );
+      const incrementBtn = container.querySelector(
+        '[data-cy="t-minutes-increment"]'
+      ) as HTMLButtonElement;
+      fireEvent.mouseDown(incrementBtn);
+      fireEvent.mouseUp(incrementBtn);
+      expect(onChange).toHaveBeenLastCalledWith({ value: '10:00' });
+    });
+
+    it('decrements hours on - mousedown and normalizes negative wrap', () => {
+      const onChange = jest.fn();
+      const { container } = renderWithTheme(
+        <TimeField value="00:30" dataCy="t" onChange={onChange} />
+      );
+      const decrementBtn = container.querySelector(
+        '[data-cy="t-hours-decrement"]'
+      ) as HTMLButtonElement;
+      fireEvent.mouseDown(decrementBtn);
+      fireEvent.mouseUp(decrementBtn);
+      expect(onChange).toHaveBeenLastCalledWith({ value: '23:30' });
+    });
+
+    it('does not fire onChange on mount', () => {
+      const onChange = jest.fn();
+      renderWithTheme(
+        <TimeField value="10:20" dataCy="t" onChange={onChange} />
+      );
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when onChange is not provided', () => {
+      const { container } = renderWithTheme(
+        <TimeField value="10:20" dataCy="t" />
+      );
+      const hours = container.querySelector(
+        '[data-cy="t-hours-input"]'
+      ) as HTMLInputElement;
+      expect(() => {
+        fireEvent.focus(hours);
+        fireEvent.change(hours, { target: { value: '11' } });
+        fireEvent.blur(hours);
+      }).not.toThrow();
+    });
+  });
+});

--- a/src/components/wizards/ArrivalWizard/Finish/Fees.spec.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/Fees.spec.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+const wrap = (el: React.ReactElement) => (
+  <ThemeProvider theme={theme}>{el}</ThemeProvider>
+);
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string, opts?: any) =>
+        opts ? `${key}:${JSON.stringify(opts)}` : key
+      } />
+    );
+    Wrapped.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({
+    t: (key: string, opts?: any) =>
+      opts ? `${key}:${JSON.stringify(opts)}` : key,
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('../../../MaterialIcon', () => ({
+  __esModule: true,
+  default: ({ icon }: any) => <span data-testid="icon" data-icon={icon} />,
+}));
+
+import Fees from './Fees';
+
+const makeFees = (overrides: any = {}) => ({
+  landings: 1,
+  landingFeeSingle: 1000,
+  landingFeeTotal: 1000,
+  goArounds: 0,
+  goAroundFeeSingle: 500,
+  goAroundFeeTotal: 0,
+  totalNet: 1000,
+  vat: 0,
+  roundingDifference: 0,
+  totalGross: 1000,
+  ...overrides,
+});
+
+describe('<Fees>', () => {
+  it('renders the gross total label', () => {
+    const { container } = render(wrap(<Fees fees={makeFees()} />));
+    expect(container.textContent).toContain('arrival.fees.landingFee');
+  });
+
+  it('does not show details table by default', () => {
+    const { container } = render(wrap(<Fees fees={makeFees()} />));
+    expect(container.textContent).not.toContain('arrival.fees.total');
+    expect(container.textContent).toContain('arrival.fees.showDetails');
+  });
+
+  it('uses expand_more icon when collapsed', () => {
+    const { getByTestId } = render(wrap(<Fees fees={makeFees()} />));
+    expect(getByTestId('icon').getAttribute('data-icon')).toBe('expand_more');
+  });
+
+  it('expands details on click and switches icon + label', () => {
+    const { container, getByTestId } = render(
+      wrap(<Fees fees={makeFees()} />)
+    );
+    fireEvent.click(container.querySelector('button')!);
+    expect(container.textContent).toContain('arrival.fees.total');
+    expect(container.textContent).toContain('arrival.fees.hideDetails');
+    expect(getByTestId('icon').getAttribute('data-icon')).toBe('expand_less');
+  });
+
+  it('collapses again on second click', () => {
+    const { container } = render(wrap(<Fees fees={makeFees()} />));
+    const button = container.querySelector('button')!;
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(container.textContent).not.toContain('arrival.fees.total');
+  });
+
+  it('shows VAT row when vat > 0 (expanded)', () => {
+    const { container } = render(
+      wrap(
+        <Fees
+          fees={makeFees({ vat: 81, totalGross: 1081, totalNet: 1000 })}
+        />
+      )
+    );
+    fireEvent.click(container.querySelector('button')!);
+    expect(container.textContent).toContain('arrival.fees.vat');
+  });
+
+  it('omits VAT row when vat is zero (expanded)', () => {
+    const { container } = render(wrap(<Fees fees={makeFees()} />));
+    fireEvent.click(container.querySelector('button')!);
+    expect(container.textContent).not.toContain('arrival.fees.vat');
+  });
+
+  it('shows go-around row when goAroundFeeTotal > 0 (expanded)', () => {
+    const { container } = render(
+      wrap(
+        <Fees
+          fees={makeFees({ goArounds: 2, goAroundFeeTotal: 1000 })}
+        />
+      )
+    );
+    fireEvent.click(container.querySelector('button')!);
+    expect(container.textContent).toContain('arrival.fees.goAround');
+  });
+
+  it('shows rounding row when roundingDifference is non-zero (expanded)', () => {
+    const { container } = render(
+      wrap(
+        <Fees
+          fees={makeFees({ roundingDifference: -5, totalGross: 995 })}
+        />
+      )
+    );
+    fireEvent.click(container.querySelector('button')!);
+    expect(container.textContent).toContain('arrival.fees.rounding');
+  });
+});

--- a/src/components/wizards/ArrivalWizard/Finish/Fees.spec.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/Fees.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 const wrap = (el: React.ReactElement) => (

--- a/src/containers/containers.spec.tsx
+++ b/src/containers/containers.spec.tsx
@@ -1,0 +1,275 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { ThemeProvider } from 'styled-components';
+
+(global as any).__CONF__ = {
+  enabledFlightTypes: ['private', 'instruction'],
+  paymentMethods: {},
+  memberManagement: false,
+  aerodrome: {
+    name: 'Test',
+    ICAO: 'LSZT',
+    runways: [{ name: '06' }, { name: '24' }],
+  },
+};
+
+const theme = {
+  colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
+};
+
+interface MockStore {
+  getState: () => any;
+  dispatch: (a: any) => any;
+  subscribe: () => () => void;
+  actions: any[];
+}
+
+const makeStore = (state: any): MockStore => {
+  const actions: any[] = [];
+  return {
+    getState: () => state,
+    dispatch: (a: any) => {
+      actions.push(a);
+      return a;
+    },
+    subscribe: () => () => {},
+    actions,
+  };
+};
+
+const wrap = (store: MockStore, el: React.ReactElement) => (
+  <Provider store={store as any}>
+    <ThemeProvider theme={theme}>{el}</ThemeProvider>
+  </Provider>
+);
+
+// Mock the reports module to skip sagas (which pull in pdfmake → TextEncoder).
+jest.mock('../modules/reports', () => {
+  const actions = jest.requireActual('../modules/reports/actions');
+  return {
+    ...actions,
+    sagas: [],
+    default: () => ({}),
+  };
+});
+
+jest.mock('react-i18next', () => ({
+  withTranslation: () => (Component: any) => {
+    const Wrapped = (props: any) => (
+      <Component {...props} t={(key: string) => key} />
+    );
+    Wrapped.displayName = `withTranslation(${
+      Component.displayName || Component.name
+    })`;
+    return Wrapped;
+  },
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+// Mock inner presentational components to avoid pulling in their deps.
+jest.mock('../components/InvoiceRecipientsList', () => ({
+  __esModule: true,
+  default: () => <div data-testid="invoice-recipients-list" />,
+}));
+
+jest.mock('../components/UserDropdown', () => ({
+  __esModule: true,
+  default: () => <div data-testid="user-dropdown" />,
+}));
+
+jest.mock('../components/AircraftDropdown', () => ({
+  __esModule: true,
+  default: () => <div data-testid="aircraft-dropdown" />,
+}));
+
+jest.mock('../components/ItemList', () => ({
+  __esModule: true,
+  default: () => <div data-testid="item-list" />,
+}));
+
+jest.mock('../components/UserImportForm', () => ({
+  __esModule: true,
+  default: () => <div data-testid="user-import-form" />,
+}));
+
+jest.mock('../components/YearlySummaryReportForm', () => ({
+  __esModule: true,
+  default: () => <div data-testid="yearly-summary-report-form" />,
+}));
+
+jest.mock('../components/ReportForm', () => ({
+  __esModule: true,
+  default: () => <div data-testid="report-form" />,
+}));
+
+jest.mock('../components/AirstatReportForm', () => ({
+  __esModule: true,
+  default: () => <div data-testid="airstat-report-form" />,
+}));
+
+jest.mock('../components/wizards/ArrivalWizard/Finish', () => ({
+  __esModule: true,
+  default: () => <div data-testid="arrival-finish" />,
+  FinishLoading: () => <div data-testid="arrival-finish-loading" />,
+}));
+
+jest.mock('../components/wizards/MovementWizard', () => ({
+  HeadingType: { ARRIVAL: 'arrival', DEPARTURE: 'departure' },
+}));
+
+describe('container mount dispatches', () => {
+  let InvoiceRecipientsListContainer: any;
+  let UserDropdownContainer: any;
+  let AircraftDropdownContainer: any;
+  let AircraftsItemListContainer: any;
+  let ArrivalFinishContainer: any;
+  let UserImportFormContainer: any;
+  let YearlySummaryReportFormContainer: any;
+  let LandingsReportFormContainer: any;
+  let AirstatReportFormContainer: any;
+  let InvoicesReportFormContainer: any;
+
+  beforeAll(() => {
+    InvoiceRecipientsListContainer =
+      require('./InvoiceRecipientsListContainer').default;
+    UserDropdownContainer = require('./UserDropdownContainer').default;
+    AircraftDropdownContainer = require('./AircraftDropdownContainer').default;
+    AircraftsItemListContainer =
+      require('./AircraftsItemListContainer').default;
+    ArrivalFinishContainer = require('./ArrivalFinishContainer').default;
+    UserImportFormContainer = require('./UserImportFormContainer').default;
+    YearlySummaryReportFormContainer = require(
+      './YearlySummaryReportFormContainer'
+    ).default;
+    LandingsReportFormContainer = require(
+      './LandingsReportFormContainer'
+    ).default;
+    AirstatReportFormContainer = require('./AirstatReportFormContainer').default;
+    InvoicesReportFormContainer = require(
+      './InvoicesReportFormContainer'
+    ).default;
+  });
+
+  it('InvoiceRecipientsListContainer dispatches LOAD_INVOICE_RECIPIENT_SETTINGS on mount', () => {
+    const store = makeStore({
+      settings: { invoiceRecipients: { recipients: [] } },
+    });
+    render(wrap(store, <InvoiceRecipientsListContainer />));
+    expect(
+      store.actions.some(a => a.type === 'LOAD_INVOICE_RECIPIENT_SETTINGS')
+    ).toBe(true);
+  });
+
+  it('UserDropdownContainer dispatches LOAD_USERS on mount', () => {
+    const store = makeStore({ users: { data: {} } });
+    render(
+      wrap(
+        store,
+        <UserDropdownContainer
+          onChange={jest.fn()}
+          onFocus={jest.fn()}
+          onBlur={jest.fn()}
+        />
+      )
+    );
+    expect(store.actions.some(a => a.type === 'LOAD_USERS')).toBe(true);
+  });
+
+  it('AircraftDropdownContainer dispatches LOAD_AIRCRAFTS on mount', () => {
+    const store = makeStore({ aircrafts: { data: {} } });
+    render(
+      wrap(
+        store,
+        <AircraftDropdownContainer
+          onChange={jest.fn()}
+          onFocus={jest.fn()}
+          onBlur={jest.fn()}
+        />
+      )
+    );
+    expect(store.actions.some(a => a.type === 'LOAD_AIRCRAFTS')).toBe(true);
+  });
+
+  it('AircraftsItemListContainer dispatches LOAD_AIRCRAFT_SETTINGS on mount', () => {
+    const store = makeStore({
+      settings: { aircrafts: { club: {}, homeBase: {} } },
+      ui: { settings: { aircrafts: { newItem: {} } } },
+    });
+    render(wrap(store, <AircraftsItemListContainer type="club" />));
+    expect(
+      store.actions.some(a => a.type === 'LOAD_AIRCRAFT_SETTINGS')
+    ).toBe(true);
+  });
+
+  it('ArrivalFinishContainer dispatches LOAD_AIRCRAFT_SETTINGS and LOAD_USER_INVOICE_RECIPIENTS on mount', () => {
+    const store = makeStore({
+      settings: { aircrafts: {} },
+      invoiceRecipients: { recipients: undefined },
+      movements: {},
+      auth: { data: {} },
+      ui: { wizard: { values: {} } },
+    });
+    render(
+      wrap(
+        store,
+        <ArrivalFinishContainer
+          itemKey="mov-1"
+          immatriculation="HB-XYZ"
+          email="test@example.ch"
+          fees={{ landings: 1, goArounds: 0 }}
+          headingType="arrival"
+          finish={jest.fn()}
+        />
+      )
+    );
+    expect(
+      store.actions.some(a => a.type === 'LOAD_AIRCRAFT_SETTINGS')
+    ).toBe(true);
+    expect(
+      store.actions.some(a => a.type === 'LOAD_USER_INVOICE_RECIPIENTS')
+    ).toBe(true);
+  });
+
+  it('UserImportFormContainer dispatches INIT_IMPORT on mount', () => {
+    const store = makeStore({ imports: {} });
+    render(wrap(store, <UserImportFormContainer />));
+    const initAction = store.actions.find(a => a.type === 'INIT_IMPORT');
+    expect(initAction).toBeDefined();
+    expect(initAction.payload.name).toBe('users');
+  });
+
+  it('YearlySummaryReportFormContainer dispatches INIT_REPORT with yearlySummary', () => {
+    const store = makeStore({ reports: {} });
+    render(wrap(store, <YearlySummaryReportFormContainer />));
+    const initAction = store.actions.find(a => a.type === 'INIT_REPORT');
+    expect(initAction).toBeDefined();
+    expect(initAction.payload.name).toBe('yearlySummary');
+  });
+
+  it('LandingsReportFormContainer dispatches INIT_REPORT with landings', () => {
+    const store = makeStore({ reports: {} });
+    render(wrap(store, <LandingsReportFormContainer />));
+    const initAction = store.actions.find(a => a.type === 'INIT_REPORT');
+    expect(initAction).toBeDefined();
+    expect(initAction.payload.name).toBe('landings');
+  });
+
+  it('AirstatReportFormContainer dispatches INIT_REPORT with airstat', () => {
+    const store = makeStore({ reports: {} });
+    render(wrap(store, <AirstatReportFormContainer />));
+    const initAction = store.actions.find(a => a.type === 'INIT_REPORT');
+    expect(initAction).toBeDefined();
+    expect(initAction.payload.name).toBe('airstat');
+  });
+
+  it('InvoicesReportFormContainer dispatches INIT_REPORT with invoices', () => {
+    const store = makeStore({ reports: {} });
+    render(wrap(store, <InvoicesReportFormContainer />));
+    const initAction = store.actions.find(a => a.type === 'INIT_REPORT');
+    expect(initAction).toBeDefined();
+    expect(initAction.payload.name).toBe('invoices');
+  });
+});

--- a/src/containers/containers.spec.tsx
+++ b/src/containers/containers.spec.tsx
@@ -14,7 +14,7 @@ import { ThemeProvider } from 'styled-components';
   },
 };
 
-const theme = {
+const theme: any = {
   colors: { main: '#003863', background: '#fafafa', danger: '#e00f00' },
 };
 

--- a/src/containers/containers.spec.tsx
+++ b/src/containers/containers.spec.tsx
@@ -153,17 +153,18 @@ describe('container mount dispatches', () => {
     ).default;
   });
 
-  it('InvoiceRecipientsListContainer dispatches LOAD_INVOICE_RECIPIENT_SETTINGS on mount', () => {
+  const countOf = (store: MockStore, type: string) =>
+    store.actions.filter(a => a.type === type).length;
+
+  it('InvoiceRecipientsListContainer dispatches LOAD_INVOICE_RECIPIENT_SETTINGS exactly once on mount', () => {
     const store = makeStore({
       settings: { invoiceRecipients: { recipients: [] } },
     });
     render(wrap(store, <InvoiceRecipientsListContainer />));
-    expect(
-      store.actions.some(a => a.type === 'LOAD_INVOICE_RECIPIENT_SETTINGS')
-    ).toBe(true);
+    expect(countOf(store, 'LOAD_INVOICE_RECIPIENT_SETTINGS')).toBe(1);
   });
 
-  it('UserDropdownContainer dispatches LOAD_USERS on mount', () => {
+  it('UserDropdownContainer dispatches LOAD_USERS exactly once on mount', () => {
     const store = makeStore({ users: { data: {} } });
     render(
       wrap(
@@ -175,10 +176,10 @@ describe('container mount dispatches', () => {
         />
       )
     );
-    expect(store.actions.some(a => a.type === 'LOAD_USERS')).toBe(true);
+    expect(countOf(store, 'LOAD_USERS')).toBe(1);
   });
 
-  it('AircraftDropdownContainer dispatches LOAD_AIRCRAFTS on mount', () => {
+  it('AircraftDropdownContainer dispatches LOAD_AIRCRAFTS exactly once on mount', () => {
     const store = makeStore({ aircrafts: { data: {} } });
     render(
       wrap(
@@ -190,21 +191,19 @@ describe('container mount dispatches', () => {
         />
       )
     );
-    expect(store.actions.some(a => a.type === 'LOAD_AIRCRAFTS')).toBe(true);
+    expect(countOf(store, 'LOAD_AIRCRAFTS')).toBe(1);
   });
 
-  it('AircraftsItemListContainer dispatches LOAD_AIRCRAFT_SETTINGS on mount', () => {
+  it('AircraftsItemListContainer dispatches LOAD_AIRCRAFT_SETTINGS exactly once on mount', () => {
     const store = makeStore({
       settings: { aircrafts: { club: {}, homeBase: {} } },
       ui: { settings: { aircrafts: { newItem: {} } } },
     });
     render(wrap(store, <AircraftsItemListContainer type="club" />));
-    expect(
-      store.actions.some(a => a.type === 'LOAD_AIRCRAFT_SETTINGS')
-    ).toBe(true);
+    expect(countOf(store, 'LOAD_AIRCRAFT_SETTINGS')).toBe(1);
   });
 
-  it('ArrivalFinishContainer dispatches LOAD_AIRCRAFT_SETTINGS and LOAD_USER_INVOICE_RECIPIENTS on mount', () => {
+  it('ArrivalFinishContainer dispatches LOAD_AIRCRAFT_SETTINGS and LOAD_USER_INVOICE_RECIPIENTS exactly once on mount', () => {
     const store = makeStore({
       settings: { aircrafts: {} },
       invoiceRecipients: { recipients: undefined },
@@ -225,51 +224,58 @@ describe('container mount dispatches', () => {
         />
       )
     );
-    expect(
-      store.actions.some(a => a.type === 'LOAD_AIRCRAFT_SETTINGS')
-    ).toBe(true);
-    expect(
-      store.actions.some(a => a.type === 'LOAD_USER_INVOICE_RECIPIENTS')
-    ).toBe(true);
+    expect(countOf(store, 'LOAD_AIRCRAFT_SETTINGS')).toBe(1);
+    expect(countOf(store, 'LOAD_USER_INVOICE_RECIPIENTS')).toBe(1);
   });
 
-  it('UserImportFormContainer dispatches INIT_IMPORT on mount', () => {
+  it('UserImportFormContainer dispatches INIT_IMPORT exactly once with name=users', () => {
     const store = makeStore({ imports: {} });
     render(wrap(store, <UserImportFormContainer />));
-    const initAction = store.actions.find(a => a.type === 'INIT_IMPORT');
-    expect(initAction).toBeDefined();
-    expect(initAction.payload.name).toBe('users');
+    const inits = store.actions.filter(a => a.type === 'INIT_IMPORT');
+    expect(inits.length).toBe(1);
+    expect(inits[0].payload.name).toBe('users');
   });
 
-  it('YearlySummaryReportFormContainer dispatches INIT_REPORT with yearlySummary', () => {
+  it('YearlySummaryReportFormContainer dispatches INIT_REPORT exactly once with name=yearlySummary', () => {
     const store = makeStore({ reports: {} });
     render(wrap(store, <YearlySummaryReportFormContainer />));
-    const initAction = store.actions.find(a => a.type === 'INIT_REPORT');
-    expect(initAction).toBeDefined();
-    expect(initAction.payload.name).toBe('yearlySummary');
+    const inits = store.actions.filter(a => a.type === 'INIT_REPORT');
+    expect(inits.length).toBe(1);
+    expect(inits[0].payload.name).toBe('yearlySummary');
   });
 
-  it('LandingsReportFormContainer dispatches INIT_REPORT with landings', () => {
+  it('LandingsReportFormContainer dispatches INIT_REPORT exactly once with name=landings', () => {
     const store = makeStore({ reports: {} });
     render(wrap(store, <LandingsReportFormContainer />));
-    const initAction = store.actions.find(a => a.type === 'INIT_REPORT');
-    expect(initAction).toBeDefined();
-    expect(initAction.payload.name).toBe('landings');
+    const inits = store.actions.filter(a => a.type === 'INIT_REPORT');
+    expect(inits.length).toBe(1);
+    expect(inits[0].payload.name).toBe('landings');
   });
 
-  it('AirstatReportFormContainer dispatches INIT_REPORT with airstat', () => {
+  it('AirstatReportFormContainer dispatches INIT_REPORT exactly once with name=airstat', () => {
     const store = makeStore({ reports: {} });
     render(wrap(store, <AirstatReportFormContainer />));
-    const initAction = store.actions.find(a => a.type === 'INIT_REPORT');
-    expect(initAction).toBeDefined();
-    expect(initAction.payload.name).toBe('airstat');
+    const inits = store.actions.filter(a => a.type === 'INIT_REPORT');
+    expect(inits.length).toBe(1);
+    expect(inits[0].payload.name).toBe('airstat');
   });
 
-  it('InvoicesReportFormContainer dispatches INIT_REPORT with invoices', () => {
+  it('InvoicesReportFormContainer dispatches INIT_REPORT exactly once with name=invoices', () => {
     const store = makeStore({ reports: {} });
     render(wrap(store, <InvoicesReportFormContainer />));
-    const initAction = store.actions.find(a => a.type === 'INIT_REPORT');
-    expect(initAction).toBeDefined();
-    expect(initAction.payload.name).toBe('invoices');
+    const inits = store.actions.filter(a => a.type === 'INIT_REPORT');
+    expect(inits.length).toBe(1);
+    expect(inits[0].payload.name).toBe('invoices');
+  });
+
+  it('does not re-dispatch init actions when the container re-renders with same props', () => {
+    const store = makeStore({ reports: {} });
+    const { rerender } = render(
+      wrap(store, <LandingsReportFormContainer />)
+    );
+    const initialInitCount = countOf(store, 'INIT_REPORT');
+    expect(initialInitCount).toBe(1);
+    rerender(wrap(store, <LandingsReportFormContainer />));
+    expect(countOf(store, 'INIT_REPORT')).toBe(initialInitCount);
   });
 });


### PR DESCRIPTION
## Summary

Adds regression-coverage specs for all class components that are about
to be converted to function components as step 1 of the
modernization sequence (see issues in memory: route-touching classes
done, MovementWizard done, ~31 classes remaining).

Goal: lock in current behavior so the class → function conversions can
land as pure refactors without risking regressions.

### What's covered

All 31 remaining class components now have a spec (30 new files, 1 skipped).

**New spec files (19):**
- `App.spec.tsx` — scroll restore on PUSH/REPLACE, skip on POP, auth gating, profileEnabled flag
- `TimeField.spec.tsx` — parse, derive-from-props, onChange with fresh value
- `NumberBlock.spec.tsx` — edit state, blur commit, increment/decrement
- `MaskedInput.spec.tsx` — masking, tooltip show/hide, clear
- `HelpPage.spec.tsx` — box refs, scrollIntoView per question
- `AssociatedMovement.spec.tsx` — conditional loadMovement (mount + update)
- `MessageForm.spec.tsx` — unmount reset, dialogs, initial values
- `MovementList.spec.tsx` — 5 mount dispatches, loading gate, conditional children
- `InvoiceRecipientsList.spec.tsx` — clear-on-grow pattern
- `InvoiceRecipient.spec.tsx` — emails clear-on-grow, delete dialog
- `LockMovementsForm.spec.tsx` — mount dispatch, date change round-trip
- `AerodromeStatusForm.spec.tsx` — mount dispatch, rendering
- `AerodromeStatusPage.spec.tsx` — mount dispatch, loading/null states
- `MessageList.spec.tsx` — mount dispatch, selection toggle
- `StatusForm.spec.tsx` — render, change handlers, submit, disabled states
- `StatusList.spec.tsx` — active item, selection toggle
- `Fees.spec.tsx` — details expand/collapse, conditional rows
- `containers.spec.tsx` — 10 containers × mount dispatch exactly-once
  assertions + re-render guard

**Augmented specs (2):**
- `LoginInfo.spec.tsx` — re-open after outside click, listener cleanup,
  profileEnabled flag
- `DatePicker.spec.tsx` — prop mirror edges, locale, clear-button
  stopPropagation

**Skipped (1):**
- `VerticalHeaderLayout/Content.tsx` — single-line styled wrapper around
  children, no logic to regress

### Residual risks NOT catchable by specs

These become code-review concerns during the actual migration:

- **cWRP / getDerivedStateFromProps timing** — use derive-during-render
  pattern for TimeField and DatePicker, not \`useState + useEffect\`,
  to preserve single-frame update semantics.
- **PureComponent → React.memo** — perf, not correctness. Cypress smoke
  on the movements list will reveal if broken.
- **stopPropagation in other click handlers** — reviewed per-file
  during each conversion.

## Test plan

- [x] \`npm test\` — 2093 / 2093 pass (was 2013 before this branch)
- [x] \`npm run typecheck\` — clean
- [ ] After merge, migration PRs (class → function) run against this net