### PR TITLE
Convert 9 trivial class components to function components

### DIFF
--- a/src/components/AerodromeStatusForm/StatusForm.tsx
+++ b/src/components/AerodromeStatusForm/StatusForm.tsx
@@ -5,7 +5,7 @@ import Button from '../Button'
 import LabeledComponent from '../LabeledComponent';
 import TextArea from '../TextArea';
 import AerodromeStatusDropdown from './AerodromeStatusDropdown'
-import { withTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 
 const StyledForm = styled.form`
   padding: 1em
@@ -14,52 +14,54 @@ const StyledForm = styled.form`
 const StyledLabeledComponent = styled(LabeledComponent)`
   width: 50%;
   margin-bottom: 1.5em;
-  
+
   @media (max-width: 768px) {
     width: 100%;
   }
 `;
 
-class StatusForm extends React.Component<any, any> {
+const StatusForm = (props: any) => {
+  const { t } = useTranslation();
+  const { data, disabled, dirty } = props;
 
-  handleSubmit(e) {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    this.props.saveAerodromeStatus(this.props.data);
-  }
+    props.saveAerodromeStatus(data);
+  };
 
-  handleStatusChange(status) {
-    this.props.updateAerodromeStatus(status, this.props.data.details);
-  }
+  const handleStatusChange = (status: string) => {
+    props.updateAerodromeStatus(status, data.details);
+  };
 
-  handleDetailsChange(e) {
-    this.props.updateAerodromeStatus(this.props.data.status, e.target.value);
-  }
+  const handleDetailsChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    props.updateAerodromeStatus(data.status, e.target.value);
+  };
 
-  render() {
-    const {data, disabled, dirty, t} = this.props;
+  const statusDropdown = (
+    <AerodromeStatusDropdown value={data.status} onChange={handleStatusChange}/>
+  );
+  const detailsTextArea = (
+    <TextArea value={data.details} rows={6} onChange={handleDetailsChange}/>
+  );
 
-    const statusDropdown = <AerodromeStatusDropdown value={data.status} onChange={this.handleStatusChange.bind(this)}/>;
-    const detailsTextArea = <TextArea value={data.details} rows={6} onChange={this.handleDetailsChange.bind(this)}/>;
-
-    return (
-      <StyledForm
-        className="AerodromeStatusForm"
-        onSubmit={this.handleSubmit.bind(this)}
-      >
-        <fieldset disabled={disabled}>
-          <StyledLabeledComponent label={t('common.status')} component={statusDropdown}/>
-          <StyledLabeledComponent label={t('common.details')} component={detailsTextArea}/>
-          <Button
-            type="submit"
-            label={t('common.save')}
-            icon="save"
-            disabled={disabled || !dirty}
-            primary/>
-        </fieldset>
-      </StyledForm>
-    );
-  }
-}
+  return (
+    <StyledForm
+      className="AerodromeStatusForm"
+      onSubmit={handleSubmit}
+    >
+      <fieldset disabled={disabled}>
+        <StyledLabeledComponent label={t('common.status')} component={statusDropdown}/>
+        <StyledLabeledComponent label={t('common.details')} component={detailsTextArea}/>
+        <Button
+          type="submit"
+          label={t('common.save')}
+          icon="save"
+          disabled={disabled || !dirty}
+          primary/>
+      </fieldset>
+    </StyledForm>
+  );
+};
 
 (StatusForm as any).propTypes = {
   data: PropTypes.shape({
@@ -72,4 +74,4 @@ class StatusForm extends React.Component<any, any> {
   saveAerodromeStatus: PropTypes.func.isRequired
 };
 
-export default withTranslation()(StatusForm);
+export default StatusForm;

--- a/src/components/AerodromeStatusForm/StatusList.tsx
+++ b/src/components/AerodromeStatusForm/StatusList.tsx
@@ -1,42 +1,40 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React from 'react';
 import StatusShape from './StatusShape';
 import Status from './Status';
 import StatusHeader from './StatusHeader';
 import StatusContent from './StatusContent';
 
-class StatusList extends Component<any, any> {
+const StatusList = (props: any) => {
+  const { items, selected, selectStatus } = props;
 
-  handleStatusClick(key) {
-    this.props.selectStatus(this.props.selected === key ? null : key);
-  }
+  const handleStatusClick = (key: string) => {
+    selectStatus(selected === key ? null : key);
+  };
 
-  render() {
-    const {items, selected} = this.props;
-    return (
-      <div>
-        {items.array.map((item, index) => {
-          const active = index === 0
-          const isSelected = active || selected === item.key;
-          return (
-            <Status
-              key={index}
-              $selected={isSelected}
-            >
-              <StatusHeader
-                item={item}
-                selected={isSelected}
-                active={active}
-                onClick={this.handleStatusClick.bind(this, item.key)}
-              />
-              {isSelected && <StatusContent item={item}/>}
-            </Status>
-          );
-        })}
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      {items.array.map((item: any, index: number) => {
+        const active = index === 0;
+        const isSelected = active || selected === item.key;
+        return (
+          <Status
+            key={index}
+            $selected={isSelected}
+          >
+            <StatusHeader
+              item={item}
+              selected={isSelected}
+              active={active}
+              onClick={() => handleStatusClick(item.key)}
+            />
+            {isSelected && <StatusContent item={item}/>}
+          </Status>
+        );
+      })}
+    </div>
+  );
+};
 
 (StatusList as any).propTypes = {
   items: PropTypes.shape({

--- a/src/components/HelpPage/HelpPage.tsx
+++ b/src/components/HelpPage/HelpPage.tsx
@@ -1,46 +1,43 @@
-import React, {Component} from 'react';
+import React, { useRef } from 'react';
 import LabeledBox from '../LabeledBox';
 import JumpNavigation from '../JumpNavigation';
 import VerticalHeaderLayout from '../VerticalHeaderLayout';
 import getQuestions from './questions';
 import QuestionsList from './QuestionsList';
 import Content from './Content';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
-class HelpPage extends Component<any, any> {
-  boxes: any[];
+const HelpPage = () => {
+  const { t } = useTranslation();
+  const boxes = useRef<(HTMLElement | null)[]>([]);
+  const questions = getQuestions(t);
 
-  constructor(props) {
-    super(props);
-    this.boxes = [];
-  }
-
-  render() {
-    const { t } = this.props;
-    const questions = getQuestions(t);
-    return (
-      <VerticalHeaderLayout>
-        <Content>
-          <JumpNavigation/>
-          <QuestionsList questions={questions} onClick={this.handleItemClick.bind(this)}/>
-          {questions.map((question, index) => (
-            <LabeledBox key={index} ref={box => this.boxes[index] = box} label={(index + 1) + '. ' + question.question}>
-              <div>
-                {question.answer}
-              </div>
-            </LabeledBox>
-          ))}
-        </Content>
-      </VerticalHeaderLayout>
-    );
-  }
-
-  handleItemClick(index) {
-    const domNode = this.boxes[index];
+  const handleItemClick = (index: number) => {
+    const domNode = boxes.current[index];
     if (domNode) {
       domNode.scrollIntoView();
     }
-  }
-}
+  };
 
-export default withTranslation()(HelpPage);
+  return (
+    <VerticalHeaderLayout>
+      <Content>
+        <JumpNavigation/>
+        <QuestionsList questions={questions} onClick={handleItemClick}/>
+        {questions.map((question, index) => (
+          <LabeledBox
+            key={index}
+            ref={box => { boxes.current[index] = box; }}
+            label={(index + 1) + '. ' + question.question}
+          >
+            <div>
+              {question.answer}
+            </div>
+          </LabeledBox>
+        ))}
+      </Content>
+    </VerticalHeaderLayout>
+  );
+};
+
+export default HelpPage;

--- a/src/components/MaskedInput/MaskedInput.tsx
+++ b/src/components/MaskedInput/MaskedInput.tsx
@@ -1,5 +1,5 @@
-import React, {Component} from 'react'
-import { withTranslation } from 'react-i18next'
+import React, { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import {maskEmail, maskPhone, maskText} from '../../util/masking'
 import MaterialIcon from '../MaterialIcon'
 import Input from '../Input'
@@ -27,77 +27,56 @@ const ClearButton = styled.button`
   right: 5px;
 `;
 
-class MaskedInput extends Component<any, any> {
-  inputRef: any;
+const MaskedInput = (props: any) => {
+  const { t } = useTranslation();
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
-  constructor(props) {
-    super(props)
+  const refInputDom = (input: HTMLInputElement | null) => {
+    inputRef.current = input;
+  };
 
-    this.state = {
-      tooltipVisible: false
-    }
-
-    this.refInputDom = this.refInputDom.bind(this)
-    this.handleClear = this.handleClear.bind(this)
-    this.handleMouseEnter = this.handleMouseEnter.bind(this)
-    this.handleMouseLeave = this.handleMouseLeave.bind(this)
-  }
-
-  refInputDom(input) {
-    this.inputRef = input
-  }
-
-  handleClear() {
-    this.props.input.onChange(null)
+  const handleClear = () => {
+    props.input.onChange(null);
     window.requestAnimationFrame(() => {
-      if (this.inputRef) {
-        this.inputRef.focus()
+      if (inputRef.current) {
+        inputRef.current.focus();
       }
     });
-  }
+  };
 
-  handleMouseEnter() {
-    this.setState({
-      tooltipVisible: true
-    })
-  }
-
-  handleMouseLeave() {
-    this.setState({
-      tooltipVisible: false
-    })
-  }
-
-  render() {
-    if (this.props.input.value && !this.props.meta.active) {
-      return (
-        <StyledMaskedComponent data-cy={this.props.input.name} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
-          <MaskedContent>{
-            this.props.type === 'email'
-              ? maskEmail(this.props.input.value)
-              : this.props.type === 'tel'
-                ? maskPhone(this.props.input.value)
-                : maskText(this.props.input.value)
-          }</MaskedContent>
-          <ClearButton onClick={this.handleClear} type="button">
-            <MaterialIcon icon="clear"/>
-          </ClearButton>
-          {this.state.tooltipVisible && <Tooltip>{this.props.t('maskedInput.tooltip')}</Tooltip>}
-        </StyledMaskedComponent>
-      )
-    }
-
+  if (props.input.value && !props.meta.active) {
     return (
-      <Input
-        {...this.props.input}
-        name={this.props.name}
-        type={this.props.type}
-        readOnly={this.props.readOnly}
-        data-cy={this.props.input.name}
-        ref={this.refInputDom}
-      />
+      <StyledMaskedComponent
+        data-cy={props.input.name}
+        onMouseEnter={() => setTooltipVisible(true)}
+        onMouseLeave={() => setTooltipVisible(false)}
+      >
+        <MaskedContent>{
+          props.type === 'email'
+            ? maskEmail(props.input.value)
+            : props.type === 'tel'
+              ? maskPhone(props.input.value)
+              : maskText(props.input.value)
+        }</MaskedContent>
+        <ClearButton onClick={handleClear} type="button">
+          <MaterialIcon icon="clear"/>
+        </ClearButton>
+        {tooltipVisible && <Tooltip>{t('maskedInput.tooltip')}</Tooltip>}
+      </StyledMaskedComponent>
     );
   }
-}
 
-export default withTranslation()(MaskedInput);
+  return (
+    <Input
+      {...props.input}
+      name={props.name}
+      type={props.type}
+      readOnly={props.readOnly}
+      data-cy={props.input.name}
+      ref={refInputDom}
+    />
+  );
+};
+
+export default MaskedInput;

--- a/src/components/MessageForm/MessageForm.tsx
+++ b/src/components/MessageForm/MessageForm.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import { withTranslation } from 'react-i18next';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import {Field, Form} from 'react-final-form'
 import H1 from '../H1';
 import Button from '../Button';
@@ -9,67 +9,68 @@ import {renderInputField, renderPhoneField, renderTextArea} from './renderField'
 import Intro from './Intro';
 import Dialog from './Dialog';
 
-class MessageForm extends React.Component<any, any> {
+const MessageForm = (props: any) => {
+  const { t } = useTranslation();
 
-  componentWillUnmount() {
-    this.props.resetMessageForm();
-  }
+  useEffect(() => {
+    return () => {
+      props.resetMessageForm();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  render() {
-    const { t } = this.props;
-    return (
-      <Form validate={validate} onSubmit={this.props.onSubmit} initialValues={this.props.initialValues}>
-        {({handleSubmit}) => (
-          <form className="MessageForm" onSubmit={handleSubmit}>
-            <H1>{t('message.heading')}</H1>
-            <Intro>
-              {t('message.intro')}
-            </Intro>
-            <div>
-              <Field
-                name="name"
-                type="text"
-                component={renderInputField}
-                label={t('message.name')}
-              />
-              <Field
-                name="email"
-                type="email"
-                component={renderInputField}
-                label={t('message.email')}
-              />
-              <Field
-                name="phone"
-                component={renderPhoneField}
-                label={t('message.phone')}
-              />
-              <Field
-                name="message"
-                component={renderTextArea}
-                label={t('message.message')}
-              />
-            </div>
-            <Button type="submit" icon="send" label={t('message.send')} primary dataCy="send"/>
-            {this.props.sent && (
-              <Dialog
-                heading={t('message.successHeading')}
-                message={t('message.successMessage')}
-                onClose={this.props.confirmSaveMessageSuccess}
-              />
-            )}
-            {this.props.commitFailed && (
-              <Dialog
-                heading={t('message.errorHeading')}
-                message={t('message.errorMessage')}
-                onClose={this.props.resetMessageForm}
-              />
-            )}
-          </form>
-        )}
-      </Form>
-    );
-  }
-}
+  return (
+    <Form validate={validate} onSubmit={props.onSubmit} initialValues={props.initialValues}>
+      {({handleSubmit}) => (
+        <form className="MessageForm" onSubmit={handleSubmit}>
+          <H1>{t('message.heading')}</H1>
+          <Intro>
+            {t('message.intro')}
+          </Intro>
+          <div>
+            <Field
+              name="name"
+              type="text"
+              component={renderInputField}
+              label={t('message.name')}
+            />
+            <Field
+              name="email"
+              type="email"
+              component={renderInputField}
+              label={t('message.email')}
+            />
+            <Field
+              name="phone"
+              component={renderPhoneField}
+              label={t('message.phone')}
+            />
+            <Field
+              name="message"
+              component={renderTextArea}
+              label={t('message.message')}
+            />
+          </div>
+          <Button type="submit" icon="send" label={t('message.send')} primary dataCy="send"/>
+          {props.sent && (
+            <Dialog
+              heading={t('message.successHeading')}
+              message={t('message.successMessage')}
+              onClose={props.confirmSaveMessageSuccess}
+            />
+          )}
+          {props.commitFailed && (
+            <Dialog
+              heading={t('message.errorHeading')}
+              message={t('message.errorMessage')}
+              onClose={props.resetMessageForm}
+            />
+          )}
+        </form>
+      )}
+    </Form>
+  );
+};
 
 (MessageForm as any).propTypes = {
   sent: PropTypes.bool.isRequired,
@@ -80,4 +81,4 @@ class MessageForm extends React.Component<any, any> {
   initialValues: PropTypes.object,
 };
 
-export default withTranslation()(MessageForm);
+export default MessageForm;

--- a/src/components/StartPage/LoginInfo.tsx
+++ b/src/components/StartPage/LoginInfo.tsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import MaterialIcon from '../MaterialIcon';
 import {Link} from 'react-router-dom'
-import { withTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 
 const StyledWrapper = styled.div`
   position: relative
@@ -84,7 +84,7 @@ const StyledMenu = styled.div`
   box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 3px 0px, rgba(0, 0, 0, 0.06) 0px 1px 2px 0px;
 `
 
-const getUsername = (authData, t) => {
+const getUsername = (authData: any, t: (key: string) => string) => {
   if (authData.email) {
     return authData.email
   }
@@ -97,84 +97,60 @@ const getUsername = (authData, t) => {
   return authData.uid
 }
 
-class LoginInfo extends React.Component<any, any> {
-  menuRef: any;
+const LoginInfo = (props: any) => {
+  const { t } = useTranslation();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
 
-  constructor(props) {
-    super(props)
-
-    this.handleUserNameClick = this.handleUserNameClick.bind(this)
-    this.handleClickOutside = this.handleClickOutside.bind(this)
-    this.setMenuRef = this.setMenuRef.bind(this);
-
-    this.state = {
-      menuOpen: false
-    }
-  }
-
-  handleUserNameClick(e) {
-    e.stopPropagation();
-    this.setState(prevState => ({ menuOpen: !prevState.menuOpen }), () => {
-      if (this.state.menuOpen) {
-        document.addEventListener('click', this.handleClickOutside);
-      } else {
-        document.removeEventListener('click', this.handleClickOutside);
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
       }
-    });
-  }
+    };
 
-  handleClickOutside(event) {
-    if (this.menuRef && !this.menuRef.contains(event.target)) {
-      this.setState({ menuOpen: false });
-      document.removeEventListener('click', this.handleClickOutside);
+    if (menuOpen) {
+      document.addEventListener('click', handleClickOutside);
     }
-  }
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, [menuOpen]);
 
-  componentWillUnmount() {
-    document.removeEventListener('click', this.handleClickOutside);
-  }
+  const handleUserNameClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setMenuOpen(prev => !prev);
+  };
 
-  setMenuRef(node) {
-    this.menuRef = node;
-  }
-
-  render() {
-    const props = this.props;
-    const { t } = props;
-
-    if (props.auth.authenticated === true && typeof props.auth.data.uid === 'string') {
-      return (
-        <StyledWrapper className={props.className} data-cy="login-info">
-          <StyledUserNameWrapper onClick={this.handleUserNameClick}>
-            <MaterialIcon icon="account_box"/>
-            <UserName>{getUsername(props.auth.data, t)}</UserName>
-          </StyledUserNameWrapper>
-          {this.state.menuOpen && props.auth.data.links !== false && this.renderMenu()}
-        </StyledWrapper>
-      );
-    }
-
+  const renderMenu = () => {
+    const auth = props.auth.data;
     return (
-      <div className={props.className}>
-        <Button onClick={props.showLogin}>{t('common.login')}</Button>
-      </div>
-    );
-  }
-
-  renderMenu() {
-    const auth = this.props.auth.data;
-    const { t } = this.props;
-    return (
-      <StyledMenu ref={this.setMenuRef}>
+      <StyledMenu ref={menuRef}>
         <StyledMenuUsername>{getUsername(auth, t)}</StyledMenuUsername>
         {(typeof __CONF__ === 'undefined' || __CONF__.profileEnabled !== false) && auth && auth.guest !== true && auth.kiosk !== true && auth.uid !== 'ipauth' && (
           <StyledMenuLink to="/profile" data-cy="profile">{t('login.profile')}</StyledMenuLink>
         )}
-        <StyledMenuButton onClick={this.props.logout} data-cy="logout">{t('login.logout')}</StyledMenuButton>
+        <StyledMenuButton onClick={props.logout} data-cy="logout">{t('login.logout')}</StyledMenuButton>
       </StyledMenu>
-    )
+    );
+  };
+
+  if (props.auth.authenticated === true && typeof props.auth.data.uid === 'string') {
+    return (
+      <StyledWrapper className={props.className} data-cy="login-info">
+        <StyledUserNameWrapper onClick={handleUserNameClick}>
+          <MaterialIcon icon="account_box"/>
+          <UserName>{getUsername(props.auth.data, t)}</UserName>
+        </StyledUserNameWrapper>
+        {menuOpen && props.auth.data.links !== false && renderMenu()}
+      </StyledWrapper>
+    );
   }
-}
+
+  return (
+    <div className={props.className}>
+      <Button onClick={props.showLogin}>{t('common.login')}</Button>
+    </div>
+  );
+};
 
 (LoginInfo as any).propTypes = {
   className: PropTypes.string,
@@ -189,4 +165,4 @@ class LoginInfo extends React.Component<any, any> {
   showLogin: PropTypes.func.isRequired,
 };
 
-export default withTranslation()(LoginInfo);
+export default LoginInfo;

--- a/src/components/TimeField/NumberBlock.tsx
+++ b/src/components/TimeField/NumberBlock.tsx
@@ -1,88 +1,15 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import NumberBlockWrapper from './NumberBlockWrapper';
 import Button from './Button';
 import Input from './Input';
 
-class NumberBlock extends React.Component<any, any> {
+const formatTwoDigit = (number: number) => ('0' + number).slice(-2);
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      editingValue: null,
-    }
-  }
+const NumberBlock = (props: any) => {
+  const [editingValue, setEditingValue] = useState<string | null>(null);
 
-  render() {
-    return (
-      <NumberBlockWrapper>
-        <Button
-          type="button"
-          onMouseDown={this.handleIncrement.bind(this)}
-          data-cy={`${this.props.dataCy}-increment`}
-        >+</Button>
-        <Input
-          type="text"
-          value={this.state.editingValue !== null ? this.state.editingValue : this.formatTwoDigit(this.props.value)}
-          onFocus={this.handleFocus.bind(this)}
-          onChange={this.handleChange.bind(this)}
-          onBlur={this.handleBlur.bind(this)}
-          maxLength={2}
-          data-cy={`${this.props.dataCy}-input`}
-        />
-        <Button
-          type="button"
-          onMouseDown={this.handleDecrement.bind(this)}
-          data-cy={`${this.props.dataCy}-decrement`}
-        >-</Button>
-      </NumberBlockWrapper>
-    );
-  }
-
-  handleFocus(e) {
-    e.target.select();
-    this.setState({
-      editingValue: e.target.value
-    });
-  }
-
-  handleChange(e) {
-    if (/^\d{0,2}$/.test(e.target.value)) {
-      this.setState({
-        editingValue: e.target.value,
-      });
-    }
-  }
-
-  handleBlur() {
-    const value = /^\d{1,2}$/.test(this.state.editingValue)
-      ? parseInt(this.state.editingValue, 10)
-      : 0;
-    this.setState({
-      editingValue: null,
-    });
-    this.props.onChange(value);
-  }
-
-  handleIncrement(e) {
-    this.execWhilePressed(e.target, () => {
-      const value = this.props.value + 1;
-      this.props.onChange(value);
-    });
-  }
-
-  handleDecrement(e) {
-    this.execWhilePressed(e.target, () => {
-      const value = this.props.value - 1;
-      this.props.onChange(value);
-    });
-  }
-
-  formatTwoDigit(number) {
-    return ('0' + number).slice(-2);
-  }
-
-  execWhilePressed(element, func) {
+  const execWhilePressed = (element: HTMLElement, func: () => void) => {
     func();
 
     const interval = window.setInterval(func, 150);
@@ -93,8 +20,63 @@ class NumberBlock extends React.Component<any, any> {
 
     element.addEventListener('mouseup', clearFunc);
     element.addEventListener('mouseout', clearFunc);
-  }
-}
+  };
+
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    e.target.select();
+    setEditingValue(e.target.value);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (/^\d{0,2}$/.test(e.target.value)) {
+      setEditingValue(e.target.value);
+    }
+  };
+
+  const handleBlur = () => {
+    const value = /^\d{1,2}$/.test(editingValue ?? '')
+      ? parseInt(editingValue as string, 10)
+      : 0;
+    setEditingValue(null);
+    props.onChange(value);
+  };
+
+  const handleIncrement = (e: React.MouseEvent<HTMLButtonElement>) => {
+    execWhilePressed(e.target as HTMLElement, () => {
+      props.onChange(props.value + 1);
+    });
+  };
+
+  const handleDecrement = (e: React.MouseEvent<HTMLButtonElement>) => {
+    execWhilePressed(e.target as HTMLElement, () => {
+      props.onChange(props.value - 1);
+    });
+  };
+
+  return (
+    <NumberBlockWrapper>
+      <Button
+        type="button"
+        onMouseDown={handleIncrement}
+        data-cy={`${props.dataCy}-increment`}
+      >+</Button>
+      <Input
+        type="text"
+        value={editingValue !== null ? editingValue : formatTwoDigit(props.value)}
+        onFocus={handleFocus}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        maxLength={2}
+        data-cy={`${props.dataCy}-input`}
+      />
+      <Button
+        type="button"
+        onMouseDown={handleDecrement}
+        data-cy={`${props.dataCy}-decrement`}
+      >-</Button>
+    </NumberBlockWrapper>
+  );
+};
 
 (NumberBlock as any).propTypes = {
   value: PropTypes.number.isRequired,

--- a/src/components/VerticalHeaderLayout/Content.tsx
+++ b/src/components/VerticalHeaderLayout/Content.tsx
@@ -10,12 +10,9 @@ const Wrapper = styled.div`
   }
 `;
 
-class Content extends React.PureComponent<any, any> {
-
-  render() {
-    return <Wrapper>{this.props.children}</Wrapper>;
-  }
-}
+const Content = ({ children }: { children: React.ReactNode }) => (
+  <Wrapper>{children}</Wrapper>
+);
 
 (Content as any).propTypes = {
   children: PropTypes.element.isRequired

--- a/src/components/wizards/ArrivalWizard/Finish/Fees.tsx
+++ b/src/components/wizards/ArrivalWizard/Finish/Fees.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components'
 import formatMoney from '../../../../util/formatMoney'
 import MaterialIcon from '../../../MaterialIcon'
-import { withTranslation, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 
 const ExpandableDetails = styled.div`
   padding: 0.5em 0;
@@ -110,43 +110,34 @@ const FeesDetails = ({fees}) => {
   );
 }
 
-class Fees extends React.Component<any, any> {
+const Fees = ({ fees }: { fees: any }) => {
+  const { t } = useTranslation();
+  const [detailsExpanded, setDetailsExpanded] = useState(false);
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      detailsExpanded: false
-    }
-  }
+  return (
+    <div>
+      <DetailsContainer>
+        <ExpandableDetails>
+          <Amount>
+            {t('arrival.fees.landingFee', {amount: formatMoney(fees.totalGross)})}
+          </Amount>
+          <DetailsTrigger onClick={() => setDetailsExpanded(!detailsExpanded)}>
+            <div>
+              <MaterialIcon icon={detailsExpanded ? 'expand_less' : 'expand_more'}/>
+            </div>
+            <div>
+              {detailsExpanded
+                ? t('arrival.fees.hideDetails')
+                : t('arrival.fees.showDetails')}
+            </div>
+          </DetailsTrigger>
+          {detailsExpanded && (
+            <FeesDetails fees={fees}/>
+          )}
+        </ExpandableDetails>
+      </DetailsContainer>
+    </div>
+  );
+};
 
-  render() {
-    const {fees, t} = this.props;
-
-    return (
-      <div>
-        <DetailsContainer>
-          <ExpandableDetails>
-            <Amount>
-              {t('arrival.fees.landingFee', {amount: formatMoney(fees.totalGross)})}
-            </Amount>
-            <DetailsTrigger onClick={() => this.setState({detailsExpanded: !this.state.detailsExpanded})}>
-              <div>
-                <MaterialIcon icon={this.state.detailsExpanded ? 'expand_less' : 'expand_more'}/>
-              </div>
-              <div>
-                {this.state.detailsExpanded
-                  ? t('arrival.fees.hideDetails')
-                  : t('arrival.fees.showDetails')}
-              </div>
-            </DetailsTrigger>
-            {this.state.detailsExpanded && (
-              <FeesDetails fees={fees}/>
-            )}
-          </ExpandableDetails>
-        </DetailsContainer>
-      </div>
-    );
-  }
-}
-
-export default withTranslation()(Fees)
+export default Fees;


### PR DESCRIPTION
## Summary

Part 1 of the class → function migration. Converts the 9 lowest-risk
class components: render-only, simple state, and unmount cleanup.
All changes are mechanical — no logic changes, no new abstractions.

### Files converted

| File | Shape |
|------|-------|
| \`VerticalHeaderLayout/Content.tsx\` | PureComponent → FC |
| \`AerodromeStatusForm/StatusForm.tsx\` | class + withTranslation → FC + useTranslation |
| \`AerodromeStatusForm/StatusList.tsx\` | class → FC |
| \`wizards/ArrivalWizard/Finish/Fees.tsx\` | class + useState for detailsExpanded |
| \`TimeField/NumberBlock.tsx\` | class → FC + useState for editingValue |
| \`MaskedInput/MaskedInput.tsx\` | class → FC + useState (tooltip) + useRef (input) |
| \`HelpPage/HelpPage.tsx\` | class → FC + useRef for boxes array |
| \`MessageForm/MessageForm.tsx\` | class → FC + useEffect cleanup for unmount reset |
| \`StartPage/LoginInfo.tsx\` | class → FC + useState (menu) + keyed useEffect (document click listener) + useRef (menu) |

### Side effect

All 9 files were also migrated off the \`withTranslation\` HOC onto the
\`useTranslation\` hook. That's 9 of the 24 \`withTranslation\` usages
retired — no separate effort needed.

### Class count

31 class components before → **22 after**.

## Test plan

- [x] \`npm test\` — 2093 / 2093 pass (same count as before — the specs
      landed in #719 pin current behavior)
- [x] \`npm run typecheck\` — clean
- [x] \`npm start --project=lszm\` — dev server compiles, serves HTTP 200
- [ ] Manual smoke: login, open help page, status form, messages form