### PR TITLE
Convert 10 mount-dispatch containers to function components

### DIFF
--- a/src/containers/AircraftDropdownContainer.tsx
+++ b/src/containers/AircraftDropdownContainer.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, { useEffect } from 'react';
 import {connect} from 'react-redux';
 import {loadAircrafts} from '../modules/aircrafts';
 import AircraftDropdown from '../components/AircraftDropdown';
@@ -14,29 +14,30 @@ interface OwnProps {
   dataCy?: string;
 }
 
-class AircraftDropdownContainer extends Component<OwnProps & {
+type Props = OwnProps & {
   aircrafts: object;
   loadAircrafts: () => void;
-}> {
-  componentWillMount() {
-    this.props.loadAircrafts();
-  }
+};
 
-  render() {
-    return (
-      <AircraftDropdown
-        aircrafts={this.props.aircrafts}
-        value={this.props.value ?? ''}
-        onChange={this.props.onChange}
-        onFocus={this.props.onFocus}
-        onBlur={this.props.onBlur}
-        readOnly={this.props.readOnly}
-        dataCy={this.props.dataCy}
-        clearable={this.props.clearable}
-      />
-    );
-  }
-}
+const AircraftDropdownContainer = (props: Props) => {
+  useEffect(() => {
+    props.loadAircrafts();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <AircraftDropdown
+      aircrafts={props.aircrafts}
+      value={props.value ?? ''}
+      onChange={props.onChange}
+      onFocus={props.onFocus}
+      onBlur={props.onBlur}
+      readOnly={props.readOnly}
+      dataCy={props.dataCy}
+      clearable={props.clearable}
+    />
+  );
+};
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
   aircrafts: state.aircrafts,

--- a/src/containers/AircraftsItemListContainer.tsx
+++ b/src/containers/AircraftsItemListContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {connect} from 'react-redux';
 import {changeNewItem} from '../modules/ui/settings/aircrafts';
 import {loadAircraftSettings, addAircraft, removeAircraft} from '../modules/settings/aircrafts';
@@ -9,30 +9,31 @@ interface OwnProps {
   type: string;
 }
 
-class AircraftsItemListContainer extends React.Component<OwnProps & {
+type Props = OwnProps & {
   items: string[];
   newItem: string;
   loadAircraftSettings: () => void;
   changeNewItem: (item: string) => void;
   addItem: (item: string) => void;
   removeItem: (item: string) => void;
-}> {
-  componentWillMount() {
-    this.props.loadAircraftSettings();
-  }
+};
 
-  render() {
-    return (
-      <ItemList
-        items={this.props.items}
-        newItem={this.props.newItem}
-        changeNewItem={this.props.changeNewItem}
-        addItem={this.props.addItem}
-        removeItem={this.props.removeItem}
-      />
-    );
-  }
-}
+const AircraftsItemListContainer = (props: Props) => {
+  useEffect(() => {
+    props.loadAircraftSettings();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <ItemList
+      items={props.items}
+      newItem={props.newItem}
+      changeNewItem={props.changeNewItem}
+      addItem={props.addItem}
+      removeItem={props.removeItem}
+    />
+  );
+};
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
   items: Object.keys((state.settings.aircrafts as any)[ownProps.type] || {}),

--- a/src/containers/AirstatReportFormContainer.tsx
+++ b/src/containers/AirstatReportFormContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {connect} from 'react-redux';
 import {initReport, setReportDate, setReportParameter, generateReport} from '../modules/reports';
 import AirstatReportForm from '../components/AirstatReportForm';
@@ -9,7 +9,7 @@ interface ReportDate {
   month?: number;
 }
 
-class AirstatReportFormContainer extends React.Component<{
+interface Props {
   initialized: boolean;
   date?: ReportDate;
   internal?: boolean;
@@ -20,26 +20,27 @@ class AirstatReportFormContainer extends React.Component<{
   setInternal: (internal: boolean) => void;
   setDelimiter: (delimiter: string) => void;
   generate: () => void;
-}> {
-  componentWillMount() {
-    this.props.initReport();
-  }
-
-  render() {
-    return (
-      <AirstatReportForm
-        disabled={!this.props.initialized || this.props.generationInProgress}
-        date={this.props.date}
-        internal={this.props.internal}
-        delimiter={this.props.delimiter}
-        setDate={this.props.setDate}
-        setInternal={this.props.setInternal}
-        setDelimiter={this.props.setDelimiter}
-        generate={this.props.generate}
-      />
-    );
-  }
 }
+
+const AirstatReportFormContainer = (props: Props) => {
+  useEffect(() => {
+    props.initReport();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <AirstatReportForm
+      disabled={!props.initialized || props.generationInProgress}
+      date={props.date}
+      internal={props.internal}
+      delimiter={props.delimiter}
+      setDate={props.setDate}
+      setInternal={props.setInternal}
+      setDelimiter={props.setDelimiter}
+      generate={props.generate}
+    />
+  );
+};
 
 const mapStateToProps = (state: RootState) => {
   let report = (state.reports as any).airstat;

--- a/src/containers/ArrivalFinishContainer.tsx
+++ b/src/containers/ArrivalFinishContainer.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, { useEffect } from 'react';
 import {connect} from 'react-redux';
 import {loadAircraftSettings} from '../modules/settings/aircrafts';
 import {loadUserInvoiceRecipients} from '../modules/invoiceRecipients';
@@ -25,7 +25,7 @@ interface Fees {
   totalGross?: number;
 }
 
-class ArrivalFinishContainer extends Component<{
+interface Props {
   aircraftSettings: {club?: object; homeBase?: object};
   invoiceRecipients?: string[];
   createMovementFromMovement: (key: string, type: string) => void;
@@ -41,66 +41,67 @@ class ArrivalFinishContainer extends Component<{
   auth: any;
   localUser: any;
   saveMovement: () => void;
-}> {
-  componentWillMount() {
-    this.props.loadAircraftSettings();
-    this.props.loadUserInvoiceRecipients();
-  }
-
-  render() {
-    const {
-      aircraftSettings,
-      invoiceRecipients,
-      email,
-      immatriculation,
-      fees,
-      createMovementFromMovement,
-      finish,
-      isUpdate,
-      headingType,
-      itemKey,
-      auth,
-      localUser,
-    } = this.props;
-
-    if (!aircraftSettings.club || !aircraftSettings.homeBase) {
-      return <FinishLoading />;
-    }
-
-    if (!invoiceRecipients) {
-      return <FinishLoading />;
-    }
-
-    const enabledPaymentMethods = getEnabledPaymentMethods(
-      objectToArray(__CONF__.paymentMethods),
-      auth.data,
-    )
-      .filter((method: string) => method === 'card' ? localUser : true)
-      .filter((method: string) => method === 'invoice' ? invoiceRecipients.length > 0 : true);
-
-    const isHomeBase =
-      (aircraftSettings.club as any)[immatriculation] === true ||
-      (aircraftSettings.homeBase as any)[immatriculation] === true;
-
-    const FinishAny = Finish as any;
-    return (
-      <FinishAny
-        createMovementFromMovement={createMovementFromMovement}
-        finish={finish}
-        isUpdate={isUpdate}
-        headingType={headingType}
-        email={email}
-        immatriculation={immatriculation}
-        isHomeBase={isHomeBase}
-        itemKey={itemKey}
-        fees={fees}
-        localUser={localUser}
-        enabledPaymentMethods={enabledPaymentMethods}
-        invoiceRecipientNames={invoiceRecipients}
-      />
-    );
-  }
 }
+
+const ArrivalFinishContainer = (props: Props) => {
+  useEffect(() => {
+    props.loadAircraftSettings();
+    props.loadUserInvoiceRecipients();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const {
+    aircraftSettings,
+    invoiceRecipients,
+    email,
+    immatriculation,
+    fees,
+    createMovementFromMovement,
+    finish,
+    isUpdate,
+    headingType,
+    itemKey,
+    auth,
+    localUser,
+  } = props;
+
+  if (!aircraftSettings.club || !aircraftSettings.homeBase) {
+    return <FinishLoading />;
+  }
+
+  if (!invoiceRecipients) {
+    return <FinishLoading />;
+  }
+
+  const enabledPaymentMethods = getEnabledPaymentMethods(
+    objectToArray(__CONF__.paymentMethods),
+    auth.data,
+  )
+    .filter((method: string) => method === 'card' ? localUser : true)
+    .filter((method: string) => method === 'invoice' ? invoiceRecipients.length > 0 : true);
+
+  const isHomeBase =
+    (aircraftSettings.club as any)[immatriculation] === true ||
+    (aircraftSettings.homeBase as any)[immatriculation] === true;
+
+  const FinishAny = Finish as any;
+  return (
+    <FinishAny
+      createMovementFromMovement={createMovementFromMovement}
+      finish={finish}
+      isUpdate={isUpdate}
+      headingType={headingType}
+      email={email}
+      immatriculation={immatriculation}
+      isHomeBase={isHomeBase}
+      itemKey={itemKey}
+      fees={fees}
+      localUser={localUser}
+      enabledPaymentMethods={enabledPaymentMethods}
+      invoiceRecipientNames={invoiceRecipients}
+    />
+  );
+};
 
 const mapStateToProps = (state: RootState, ownProps: any) => {
   const wizardValues = (state.ui.wizard as any).values || {};

--- a/src/containers/InvoiceRecipientsListContainer.tsx
+++ b/src/containers/InvoiceRecipientsListContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {connect} from 'react-redux';
 import {
   addInvoiceRecipient,
@@ -15,30 +15,31 @@ interface InvoiceRecipient {
   emails: string[];
 }
 
-class InvoiceRecipientsListContainer extends React.Component<{
+interface Props {
   invoiceRecipients: InvoiceRecipient[];
   loadInvoiceRecipientSettings: () => void;
   addInvoiceRecipient: (name: string) => void;
   addInvoiceRecipientEmail: (name: string, email: string) => void;
   removeInvoiceRecipient: (name: string) => void;
   removeInvoiceRecipientEmail: (name: string, email: string) => void;
-}> {
-  componentWillMount() {
-    this.props.loadInvoiceRecipientSettings();
-  }
-
-  render() {
-    return (
-      <InvoiceRecipientsList
-        invoiceRecipients={this.props.invoiceRecipients}
-        addInvoiceRecipient={this.props.addInvoiceRecipient}
-        addInvoiceRecipientEmail={this.props.addInvoiceRecipientEmail}
-        removeInvoiceRecipient={this.props.removeInvoiceRecipient}
-        removeInvoiceRecipientEmail={this.props.removeInvoiceRecipientEmail}
-      />
-    );
-  }
 }
+
+const InvoiceRecipientsListContainer = (props: Props) => {
+  useEffect(() => {
+    props.loadInvoiceRecipientSettings();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <InvoiceRecipientsList
+      invoiceRecipients={props.invoiceRecipients}
+      addInvoiceRecipient={props.addInvoiceRecipient}
+      addInvoiceRecipientEmail={props.addInvoiceRecipientEmail}
+      removeInvoiceRecipient={props.removeInvoiceRecipient}
+      removeInvoiceRecipientEmail={props.removeInvoiceRecipientEmail}
+    />
+  );
+};
 
 const mapStateToProps = (state: RootState) => ({
   invoiceRecipients: state.settings.invoiceRecipients.recipients || [],

--- a/src/containers/InvoicesReportFormContainer.tsx
+++ b/src/containers/InvoicesReportFormContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {connect} from 'react-redux';
 import {generateReport, initReport, setReportDate} from '../modules/reports';
 import ReportForm from '../components/ReportForm';
@@ -9,30 +9,31 @@ interface ReportDate {
   month?: number;
 }
 
-class InvoicesReportFormContainer extends React.Component<{
+interface Props {
   initialized: boolean;
   date?: ReportDate;
   generationInProgress?: boolean;
   initReport: () => void;
   setDate: (date: ReportDate) => void;
   generate: () => void;
-}> {
-  componentWillMount() {
-    this.props.initReport();
-  }
-
-  render() {
-    return (
-      <ReportForm
-        disabled={!this.props.initialized || this.props.generationInProgress}
-        date={this.props.date}
-        setDate={this.props.setDate}
-        generate={this.props.generate}
-        withDelimiter={false}
-      />
-    );
-  }
 }
+
+const InvoicesReportFormContainer = (props: Props) => {
+  useEffect(() => {
+    props.initReport();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <ReportForm
+      disabled={!props.initialized || props.generationInProgress}
+      date={props.date}
+      setDate={props.setDate}
+      generate={props.generate}
+      withDelimiter={false}
+    />
+  );
+};
 
 const mapStateToProps = (state: RootState) => {
   let report = (state.reports as any).invoices;

--- a/src/containers/LandingsReportFormContainer.tsx
+++ b/src/containers/LandingsReportFormContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {connect} from 'react-redux';
 import {initReport, setReportDate, generateReport, setReportParameter} from '../modules/reports';
 import ReportForm from '../components/ReportForm';
@@ -9,7 +9,7 @@ interface ReportDate {
   month?: number;
 }
 
-class LandingsReportFormContainer extends React.Component<{
+interface Props {
   initialized: boolean;
   date?: ReportDate;
   delimiter?: string;
@@ -18,24 +18,25 @@ class LandingsReportFormContainer extends React.Component<{
   setDate: (date: ReportDate) => void;
   setDelimiter: (delimiter: string) => void;
   generate: () => void;
-}> {
-  componentWillMount() {
-    this.props.initReport();
-  }
-
-  render() {
-    return (
-      <ReportForm
-        disabled={!this.props.initialized || this.props.generationInProgress}
-        date={this.props.date}
-        delimiter={this.props.delimiter}
-        setDate={this.props.setDate}
-        setDelimiter={this.props.setDelimiter}
-        generate={this.props.generate}
-      />
-    );
-  }
 }
+
+const LandingsReportFormContainer = (props: Props) => {
+  useEffect(() => {
+    props.initReport();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <ReportForm
+      disabled={!props.initialized || props.generationInProgress}
+      date={props.date}
+      delimiter={props.delimiter}
+      setDate={props.setDate}
+      setDelimiter={props.setDelimiter}
+      generate={props.generate}
+    />
+  );
+};
 
 const mapStateToProps = (state: RootState) => {
   let report = (state.reports as any).landings;

--- a/src/containers/UserDropdownContainer.tsx
+++ b/src/containers/UserDropdownContainer.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, { useEffect } from 'react';
 import {connect} from 'react-redux';
 import {loadUsers} from '../modules/users';
 import UserDropdown from '../components/UserDropdown';
@@ -13,28 +13,29 @@ interface OwnProps {
   dataCy?: string;
 }
 
-class UserDropdownContainer extends Component<OwnProps & {
+type Props = OwnProps & {
   users: object;
   loadUsers: () => void;
-}> {
-  componentWillMount() {
-    this.props.loadUsers();
-  }
+};
 
-  render() {
-    return (
-      <UserDropdown
-        users={this.props.users}
-        value={this.props.value ?? ''}
-        onChange={this.props.onChange}
-        onFocus={this.props.onFocus}
-        onBlur={this.props.onBlur}
-        readOnly={this.props.readOnly}
-        dataCy={this.props.dataCy}
-      />
-    );
-  }
-}
+const UserDropdownContainer = (props: Props) => {
+  useEffect(() => {
+    props.loadUsers();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <UserDropdown
+      users={props.users}
+      value={props.value ?? ''}
+      onChange={props.onChange}
+      onFocus={props.onFocus}
+      onBlur={props.onBlur}
+      readOnly={props.readOnly}
+      dataCy={props.dataCy}
+    />
+  );
+};
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
   users: state.users,

--- a/src/containers/UserImportFormContainer.tsx
+++ b/src/containers/UserImportFormContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {connect} from 'react-redux';
 import {initImport, selectImportFile, startImport} from '../modules/imports';
 import UserImportForm from '../components/UserImportForm';
@@ -6,7 +6,7 @@ import {RootState} from '../modules';
 
 const IMPORT_NAME = 'users';
 
-class UserImportFormContainer extends React.Component<{
+interface Props {
   initialized: boolean;
   inProgress: boolean;
   importDone: boolean;
@@ -15,26 +15,27 @@ class UserImportFormContainer extends React.Component<{
   initImport: () => void;
   selectFile: (file: File) => void;
   startImport: () => void;
-}> {
-  componentWillMount() {
-    this.props.initImport();
-  }
-
-  render() {
-    return (
-      <UserImportForm
-        disabled={!this.props.initialized}
-        selectedFile={this.props.selectedFile}
-        importInProgress={this.props.inProgress}
-        importDone={this.props.importDone}
-        importFailed={this.props.importFailed}
-        selectFile={this.props.selectFile}
-        startImport={this.props.startImport}
-        closeDoneDialog={this.props.initImport}
-      />
-    );
-  }
 }
+
+const UserImportFormContainer = (props: Props) => {
+  useEffect(() => {
+    props.initImport();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <UserImportForm
+      disabled={!props.initialized}
+      selectedFile={props.selectedFile}
+      importInProgress={props.inProgress}
+      importDone={props.importDone}
+      importFailed={props.importFailed}
+      selectFile={props.selectFile}
+      startImport={props.startImport}
+      closeDoneDialog={props.initImport}
+    />
+  );
+};
 
 const mapStateToProps = (state: RootState) => {
   let importObj = (state.imports as any)[IMPORT_NAME];

--- a/src/containers/YearlySummaryReportFormContainer.tsx
+++ b/src/containers/YearlySummaryReportFormContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {connect} from 'react-redux';
 import {initReport, setReportDate, generateReport, setReportParameter} from '../modules/reports';
 import YearlySummaryReportForm from '../components/YearlySummaryReportForm';
@@ -8,7 +8,7 @@ interface ReportDate {
   year?: number;
 }
 
-class YearlySummaryReportFormContainer extends React.Component<{
+interface Props {
   initialized: boolean;
   date?: ReportDate;
   delimiter?: string;
@@ -17,24 +17,25 @@ class YearlySummaryReportFormContainer extends React.Component<{
   setDate: (date: ReportDate) => void;
   setDelimiter: (delimiter: string) => void;
   generate: () => void;
-}> {
-  componentWillMount() {
-    this.props.initReport();
-  }
-
-  render() {
-    return (
-      <YearlySummaryReportForm
-        disabled={!this.props.initialized || this.props.generationInProgress}
-        date={this.props.date}
-        delimiter={this.props.delimiter}
-        setDate={this.props.setDate}
-        setDelimiter={this.props.setDelimiter}
-        generate={this.props.generate}
-      />
-    );
-  }
 }
+
+const YearlySummaryReportFormContainer = (props: Props) => {
+  useEffect(() => {
+    props.initReport();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <YearlySummaryReportForm
+      disabled={!props.initialized || props.generationInProgress}
+      date={props.date}
+      delimiter={props.delimiter}
+      setDate={props.setDate}
+      setDelimiter={props.setDelimiter}
+      generate={props.generate}
+    />
+  );
+};
 
 const mapStateToProps = (state: RootState) => {
   let report = (state.reports as any).yearlySummary;


### PR DESCRIPTION
## Summary

Part 2 of the class → function migration. Converts all 10 remaining
container classes that follow the same mechanical pattern:
\`componentWillMount\` → \`useEffect(() => { init(); }, [])\`.

All containers render a loading/disabled state when their slice of
redux state is absent, so the one-extra-render between mount and the
first post-dispatch commit produces no visible flicker — spec #720
already asserts this (containers render their mocked child with the
correct \`disabled\` / loading props on initial render).

### Files converted

Mount dispatch (5 containers):

- \`InvoiceRecipientsListContainer.tsx\` → \`loadInvoiceRecipientSettings\`
- \`UserDropdownContainer.tsx\` → \`loadUsers\`
- \`AircraftDropdownContainer.tsx\` → \`loadAircrafts\`
- \`AircraftsItemListContainer.tsx\` → \`loadAircraftSettings\`
- \`ArrivalFinishContainer.tsx\` → \`loadAircraftSettings\` + \`loadUserInvoiceRecipients\`

Report / import forms (5 containers):

- \`UserImportFormContainer.tsx\` → \`initImport('users')\`
- \`YearlySummaryReportFormContainer.tsx\` → \`initReport('yearlySummary')\`
- \`LandingsReportFormContainer.tsx\` → \`initReport('landings')\`
- \`AirstatReportFormContainer.tsx\` → \`initReport('airstat')\`
- \`InvoicesReportFormContainer.tsx\` → \`initReport('invoices')\`

### Class count

22 class components before → **12 after**.

## Test plan

- [x] \`npm test\` — 2093 / 2093 pass (containers.spec.tsx specifically
      asserts exactly-once dispatch on mount + no re-dispatch on
      re-render with same props)
- [x] \`npm run typecheck\` — clean
- [x] \`npm start --project=lszm\` — dev server compiles, serves HTTP 200
- [ ] Manual smoke: admin → invoice recipients, aircraft dropdowns in
      wizards, admin → reports (yearly summary, landings, airstat,
      invoices), admin → user import, arrival finish page