### PR TITLE
Convert 4 mount-dispatch components to function components

### DIFF
--- a/src/components/AerodromeStatusForm/AerodromeStatusForm.tsx
+++ b/src/components/AerodromeStatusForm/AerodromeStatusForm.tsx
@@ -1,37 +1,35 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
 import StatusList from "./StatusList"
 import StatusForm from "./StatusForm"
 import StatusShape from "./StatusShape"
 
-class AerodromeStatusForm extends React.Component<any, any> {
+const AerodromeStatusForm = (props: any) => {
+  useEffect(() => {
+    props.loadAerodromeStatus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  componentWillMount() {
-    this.props.loadAerodromeStatus();
-  }
+  const {data, disabled, dirty, latest, selected, updateAerodromeStatus, saveAerodromeStatus, selectAerodromeStatus} = props;
 
-  render() {
-    const {data, disabled, dirty, latest, selected, updateAerodromeStatus, saveAerodromeStatus, selectAerodromeStatus} = this.props;
-
-    return (
-      <React.Fragment>
-        <StatusForm
-          data={data}
-          disabled={disabled}
-          dirty={dirty}
-          updateAerodromeStatus={updateAerodromeStatus}
-          saveAerodromeStatus={saveAerodromeStatus}
-        />
-        {latest.array.length > 0 && (
-          <StatusList
-            items={latest}
-            selected={selected}
-            selectStatus={selectAerodromeStatus}
-          />)}
-      </React.Fragment>
-    );
-  }
-}
+  return (
+    <React.Fragment>
+      <StatusForm
+        data={data}
+        disabled={disabled}
+        dirty={dirty}
+        updateAerodromeStatus={updateAerodromeStatus}
+        saveAerodromeStatus={saveAerodromeStatus}
+      />
+      {latest.array.length > 0 && (
+        <StatusList
+          items={latest}
+          selected={selected}
+          selectStatus={selectAerodromeStatus}
+        />)}
+    </React.Fragment>
+  );
+};
 
 (AerodromeStatusForm as any).propTypes = {
   data: PropTypes.shape({

--- a/src/components/AerodromeStatusPage/AerodromeStatusPage.tsx
+++ b/src/components/AerodromeStatusPage/AerodromeStatusPage.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Logo from '../Logo';
@@ -7,7 +7,7 @@ import MaterialIcon from '../MaterialIcon'
 import {getLabel} from '../AerodromeStatusForm/StatusOptions'
 import dates from '../../util/dates'
 import newLineToBr from '../../util/newLineToBr'
-import {withTranslation} from 'react-i18next'
+import {useTranslation} from 'react-i18next'
 
 const StyledLogo = styled(Logo)`
   width: 200px;
@@ -45,34 +45,33 @@ const StyledAuthor = styled.div`
   margin-top: 2em;
 `
 
-class AerodromeStatusPage extends Component<any, any> {
+const AerodromeStatusPage = (props: any) => {
+  const { t } = useTranslation();
+  const { status } = props;
 
-  componentDidMount() {
-    this.props.watchCurrentAerodromeStatus()
+  useEffect(() => {
+    props.watchCurrentAerodromeStatus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (status === undefined) {
+    return <Centered><MaterialIcon icon="sync" rotate="left"/> {t('common.loading')}</Centered>;
+  }
+  if (status === null) {
+    return <Centered>{t('aerodromeStatus.unavailable')}</Centered>
   }
 
-  render() {
-    const {status, t} = this.props;
-
-    if (status === undefined) {
-      return <Centered><MaterialIcon icon="sync" rotate="left"/> {t('common.loading')}</Centered>;
-    }
-    if (status === null) {
-      return <Centered>{t('aerodromeStatus.unavailable')}</Centered>
-    }
-
-    return (
-      <StyledCentered>
-        <StyledLogo/>
-        <StyledContainer>
-          <StyledStatusName>{getLabel(status.status)}</StyledStatusName>
-          <div>{newLineToBr(status.details)}</div>
-          <StyledAuthor>{dates.formatDateTime(status.timestamp)}</StyledAuthor>
-        </StyledContainer>
-      </StyledCentered>
-    );
-  }
-}
+  return (
+    <StyledCentered>
+      <StyledLogo/>
+      <StyledContainer>
+        <StyledStatusName>{getLabel(status.status)}</StyledStatusName>
+        <div>{newLineToBr(status.details)}</div>
+        <StyledAuthor>{dates.formatDateTime(status.timestamp)}</StyledAuthor>
+      </StyledContainer>
+    </StyledCentered>
+  );
+};
 
 (AerodromeStatusPage as any).propTypes = {
   status: PropTypes.shape({
@@ -83,4 +82,4 @@ class AerodromeStatusPage extends Component<any, any> {
   watchCurrentAerodromeStatus: PropTypes.func.isRequired
 };
 
-export default withTranslation()(AerodromeStatusPage);
+export default AerodromeStatusPage;

--- a/src/components/LockMovementsForm/LockMovementsForm.tsx
+++ b/src/components/LockMovementsForm/LockMovementsForm.tsx
@@ -1,43 +1,41 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { withTranslation } from 'react-i18next';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import LabeledComponent from './StyledLabeledComponent';
 import LabeledBox from '../LabeledBox';
 import DatePicker from '../DatePicker';
 import moment from 'moment';
 
-class LockMovementsForm extends Component<any, any> {
+const LockMovementsForm = (props: any) => {
+  const { t } = useTranslation();
+  const { lockDate } = props;
 
-  componentWillMount() {
-    this.props.loadLockDate();
-  }
+  useEffect(() => {
+    props.loadLockDate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  render() {
-    const { lockDate } = this.props;
-    const { t } = this.props;
+  const datePicker = (
+    <DatePicker
+      value={lockDate.date ? moment(lockDate.date).format('YYYY-MM-DD') : null}
+      onChange={(e: any) => {
+        const ms = e.value ? new Date(e.value).getTime() : null;
+        props.setLockDate(ms);
+      }}
+      clearable={true}
+      dataCy="lock-date"
+    />
+  );
 
-    const datePicker = (
-      <DatePicker
-        value={lockDate.date ? moment(lockDate.date).format('YYYY-MM-DD') : null}
-        onChange={(e) => {
-          const ms = e.value ? new Date(e.value).getTime() : null;
-          this.props.setLockDate(ms);
-        }}
-        clearable={true}
-        dataCy="lock-date"
-      />
-    );
-
-    return (
-      <LabeledBox label={t('lockMovements.heading')} className="LockMovementsForm">
-        <div>
-          <p>{t('lockMovements.description')}</p>
-          <LabeledComponent label={t('lockMovements.lockDate')} component={datePicker}/>
-        </div>
-      </LabeledBox>
-    );
-  }
-}
+  return (
+    <LabeledBox label={t('lockMovements.heading')} className="LockMovementsForm">
+      <div>
+        <p>{t('lockMovements.description')}</p>
+        <LabeledComponent label={t('lockMovements.lockDate')} component={datePicker}/>
+      </div>
+    </LabeledBox>
+  );
+};
 
 (LockMovementsForm as any).propTypes = {
   lockDate: PropTypes.object.isRequired,
@@ -45,4 +43,4 @@ class LockMovementsForm extends Component<any, any> {
   setLockDate: PropTypes.func.isRequired,
 };
 
-export default withTranslation()(LockMovementsForm);
+export default LockMovementsForm;

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
-import { withTranslation } from 'react-i18next';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import MessageShape from './MessageShape';
 import MessagesWrapper from './MessagesWrapper';
 import Message from './Message';
@@ -8,41 +8,40 @@ import MessageHeader from './MessageHeader';
 import MessageContent from './MessageContent';
 import Empty from './Empty';
 
-class MessageList extends Component<any, any> {
+const MessageList = (props: any) => {
+  const { t } = useTranslation();
 
-  componentWillMount() {
-    this.props.loadMessages();
+  useEffect(() => {
+    props.loadMessages();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleMessageClick = (key: string) => {
+    props.selectMessage(props.messages.selected === key ? null : key);
+  };
+
+  if (props.messages.data.array.length === 0) {
+    return <Empty>{t('message.noMessages')}</Empty>;
   }
 
-  render() {
-    const { t } = this.props;
-    if (this.props.messages.data.array.length === 0) {
-      return <Empty>{t('message.noMessages')}</Empty>;
-    }
-
-    return (
-      <MessagesWrapper>
-        {this.props.messages.data.array.map((item, index) => {
-          const isSelected = this.props.messages.selected === item.key;
-          return (
-            <Message
-              key={index}
-              $selected={isSelected}
-              onClick={this.handleMessageClick.bind(this, item.key)}
-            >
-              <MessageHeader item={item} selected={isSelected}/>
-              {isSelected && <MessageContent item={item}/>}
-            </Message>
-          );
-        })}
-      </MessagesWrapper>
-    );
-  }
-
-  handleMessageClick(key) {
-    this.props.selectMessage(this.props.messages.selected === key ? null : key);
-  }
-}
+  return (
+    <MessagesWrapper>
+      {props.messages.data.array.map((item: any, index: number) => {
+        const isSelected = props.messages.selected === item.key;
+        return (
+          <Message
+            key={index}
+            $selected={isSelected}
+            onClick={() => handleMessageClick(item.key)}
+          >
+            <MessageHeader item={item} selected={isSelected}/>
+            {isSelected && <MessageContent item={item}/>}
+          </Message>
+        );
+      })}
+    </MessagesWrapper>
+  );
+};
 
 (MessageList as any).propTypes = {
   messages: PropTypes.shape({
@@ -55,4 +54,4 @@ class MessageList extends Component<any, any> {
   selectMessage: PropTypes.func.isRequired,
 };
 
-export default withTranslation()(MessageList);
+export default MessageList;


### PR DESCRIPTION
## Summary

Part 3 of the class → function migration. Converts 4 components that
share the same shape: \`componentWillMount\` → \`useEffect(() => init(), [])\`.

### Files converted

- \`AerodromeStatusForm.tsx\` → \`loadAerodromeStatus\`
- \`AerodromeStatusPage.tsx\` → \`watchCurrentAerodromeStatus\` (was
  already \`componentDidMount\` — converted for consistency with hook form)
- \`MessageList.tsx\` → \`loadMessages\`
- \`LockMovementsForm.tsx\` → \`loadLockDate\`

Three of these also dropped \`withTranslation\` for \`useTranslation\`
(AerodromeStatusForm never used it).

### Class count

12 class components before → **8 after**.

## Test plan

- [x] \`npm test\` — 2093 / 2093 pass
- [x] \`npm run typecheck\` — clean
- [x] \`npm start --project=lszm\` — dev server compiles, serves HTTP 200
- [ ] Manual smoke: admin → aerodrome status form, messages page,
      admin → lock movements, /aerodrome-status public page