### PR TITLE
Convert 3 cDU-pattern components to function components

### DIFF
--- a/src/components/InvoiceRecipientsList/InvoiceRecipient.tsx
+++ b/src/components/InvoiceRecipientsList/InvoiceRecipient.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import { withTranslation } from 'react-i18next';
+import React, { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import MaterialIcon from '../MaterialIcon';
 import ItemList from '../ItemList'
@@ -36,79 +36,66 @@ const ButtonContainer = styled.div`
   text-align: right
 `
 
-class InvoiceRecipient extends React.Component<any, any> {
+const InvoiceRecipient = (props: any) => {
+  const { t } = useTranslation();
+  const { recipient, expanded, onRemove, onAddEmail, onRemoveEmail, onExpandedChange } = props;
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      newEmail: '',
-      recipientDeleteDialogOpen: false
+  const [newEmail, setNewEmail] = useState('');
+  const [recipientDeleteDialogOpen, setRecipientDeleteDialogOpen] = useState(false);
+
+  const currentEmails = recipient.emails || [];
+  const prevEmailsLengthRef = useRef(currentEmails.length);
+
+  useEffect(() => {
+    if (prevEmailsLengthRef.current < currentEmails.length) {
+      setNewEmail('');
     }
-  }
+    prevEmailsLengthRef.current = currentEmails.length;
+  }, [currentEmails.length]);
 
-  componentDidUpdate(prevProps) {
-    // Check if a new email was successfully added
-    const prevEmails = prevProps.recipient.emails || []
-    const currentEmails = this.props.recipient.emails || []
-    if (prevEmails.length < currentEmails.length) {
-      this.setState({newEmail: ''});
-    }
-  }
+  const sortedEmails = [...currentEmails].sort((a: string, b: string) =>
+    a.toLowerCase().localeCompare(b.toLowerCase())
+  );
 
-  render() {
-    const { t } = this.props;
-    const {recipient, expanded, onRemove, onAddEmail, onRemoveEmail, onExpandedChange} = this.props
-
-    const sortedEmails = [...(recipient.emails || [])].sort((a, b) =>
-      a.toLowerCase().localeCompare(b.toLowerCase())
-    )
-
-    return (
-      <>
-        <Wrapper>
-          <Header onClick={() => onExpandedChange(!expanded)}>
-            <Name>
-              <MaterialIcon icon={expanded ? "keyboard_arrow_up" : "keyboard_arrow_down"}/>
-              <div>{recipient.name}</div>
-            </Name>
-          </Header>
-          {expanded && (
-            <Details>
-              <ItemList items={sortedEmails}
-                        placeholder={t('invoiceRecipients.authorizedLogin')}
-                        newItem={this.state.newEmail}
-                        newItemInputType="email"
-                        changeNewItem={value => {
-                          this.setState({
-                            newEmail: value
-                          })
-                        }}
-                        addItem={onAddEmail}
-                        removeItem={onRemoveEmail}/>
-              <ButtonContainer>
-                <Button label={t('invoiceRecipients.delete')} icon="delete" danger onClick={() => {
-                  this.setState({
-                    recipientDeleteDialogOpen: true
-                  })
-                }}/>
-              </ButtonContainer>
-            </Details>
-          )}
-        </Wrapper>
-        {this.state.recipientDeleteDialogOpen && (
-          <DeleteDialog
-            question={t('invoiceRecipients.deleteConfirm', {name: recipient.name})}
-            onConfirm={() => onRemove()}
-            onCancel={() => {
-              this.setState({
-                recipientDeleteDialogOpen: false
-              })
-            }}/>
+  return (
+    <>
+      <Wrapper>
+        <Header onClick={() => onExpandedChange(!expanded)}>
+          <Name>
+            <MaterialIcon icon={expanded ? "keyboard_arrow_up" : "keyboard_arrow_down"}/>
+            <div>{recipient.name}</div>
+          </Name>
+        </Header>
+        {expanded && (
+          <Details>
+            <ItemList items={sortedEmails}
+                      placeholder={t('invoiceRecipients.authorizedLogin')}
+                      newItem={newEmail}
+                      newItemInputType="email"
+                      changeNewItem={(value: string) => setNewEmail(value)}
+                      addItem={onAddEmail}
+                      removeItem={onRemoveEmail}/>
+            <ButtonContainer>
+              <Button
+                label={t('invoiceRecipients.delete')}
+                icon="delete"
+                danger
+                onClick={() => setRecipientDeleteDialogOpen(true)}
+              />
+            </ButtonContainer>
+          </Details>
         )}
-      </>
-    )
-  }
-}
+      </Wrapper>
+      {recipientDeleteDialogOpen && (
+        <DeleteDialog
+          question={t('invoiceRecipients.deleteConfirm', {name: recipient.name})}
+          onConfirm={() => onRemove()}
+          onCancel={() => setRecipientDeleteDialogOpen(false)}
+        />
+      )}
+    </>
+  );
+};
 
 (InvoiceRecipient as any).propTypes = {
   recipient: PropTypes.shape({
@@ -121,4 +108,4 @@ class InvoiceRecipient extends React.Component<any, any> {
   onExpandedChange: PropTypes.func,
 };
 
-export default withTranslation()(InvoiceRecipient);
+export default InvoiceRecipient;

--- a/src/components/InvoiceRecipientsList/InvoiceRecipientsList.tsx
+++ b/src/components/InvoiceRecipientsList/InvoiceRecipientsList.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import MaterialIcon from '../MaterialIcon'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import InvoiceRecipient from './InvoiceRecipient'
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 const Form = styled.form`
     margin-bottom: 2em;
@@ -34,83 +34,74 @@ const AddButton = styled.button`
     }
 `;
 
-class InvoiceRecipientsList extends React.Component<any, any> {
+const InvoiceRecipientsList = (props: any) => {
+  const { t } = useTranslation();
+  const {
+    invoiceRecipients,
+    addInvoiceRecipient,
+    addInvoiceRecipientEmail,
+    removeInvoiceRecipient,
+    removeInvoiceRecipientEmail
+  } = props;
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      expandedRecipient: null,
-      newRecipientName: ''
+  const [expandedRecipient, setExpandedRecipient] = useState<string | null>(null);
+  const [newRecipientName, setNewRecipientName] = useState('');
+  const prevLengthRef = useRef(invoiceRecipients.length);
+
+  useEffect(() => {
+    if (prevLengthRef.current < invoiceRecipients.length) {
+      setNewRecipientName('');
     }
-  }
+    prevLengthRef.current = invoiceRecipients.length;
+  }, [invoiceRecipients.length]);
 
-  componentDidUpdate(prevProps) {
-    // Check if a new recipient was successfully added
-    if (prevProps.invoiceRecipients.length < this.props.invoiceRecipients.length) {
-      this.setState({newRecipientName: ''});
-    }
-  }
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    addInvoiceRecipient(newRecipientName);
+  };
 
-  render() {
-    const { t } = this.props;
-    const {
-      invoiceRecipients,
-      addInvoiceRecipient,
-      addInvoiceRecipientEmail,
-      removeInvoiceRecipient,
-      removeInvoiceRecipientEmail
-    } = this.props
+  const sortedRecipients = [...invoiceRecipients].sort((a: any, b: any) =>
+    a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+  );
 
-    const handleSubmit = e => {
-      e.preventDefault()
-      addInvoiceRecipient(this.state.newRecipientName)
-    }
-
-    const sortedRecipients = [...invoiceRecipients].sort((a, b) =>
-      a.name.toLowerCase().localeCompare(b.name.toLowerCase())
-    )
-
-    return (
+  return (
+    <div>
+      <Form onSubmit={handleSubmit}>
+        <InputContainer>
+          <Input
+            type="text"
+            value={newRecipientName}
+            placeholder={t('invoiceRecipients.nameLabel')}
+            onChange={e => setNewRecipientName(e.target.value)}
+          />
+        </InputContainer>
+        <AddButton
+          type="submit"
+          disabled={newRecipientName.length === 0}
+        >
+          <MaterialIcon icon="done"/>&nbsp;{t('invoiceRecipients.add')}
+        </AddButton>
+      </Form>
       <div>
-        <Form onSubmit={handleSubmit}>
-          <InputContainer>
-            <Input
-              type="text"
-              value={this.state.newRecipientName}
-              placeholder={t('invoiceRecipients.nameLabel')}
-              onChange={e => this.setState({
-                newRecipientName: e.target.value
-              })}
+        {sortedRecipients.map((recipient: any) => {
+          return (
+            <InvoiceRecipient
+              key={recipient.name}
+              recipient={recipient}
+              expanded={expandedRecipient === recipient.name}
+              onRemove={() => removeInvoiceRecipient(recipient.name)}
+              onAddEmail={(email: string) => addInvoiceRecipientEmail(recipient.name, email)}
+              onRemoveEmail={(email: string) => removeInvoiceRecipientEmail(recipient.name, email)}
+              onExpandedChange={(expanded: boolean) =>
+                setExpandedRecipient(expanded ? recipient.name : null)
+              }
             />
-          </InputContainer>
-          <AddButton
-            type="submit"
-            disabled={this.state.newRecipientName.length === 0}
-          >
-            <MaterialIcon icon="done"/>&nbsp;{t('invoiceRecipients.add')}
-          </AddButton>
-        </Form>
-        <div>
-          {sortedRecipients.map((recipient) => {
-            return (
-              <InvoiceRecipient
-                key={recipient.name}
-                recipient={recipient}
-                expanded={this.state.expandedRecipient === recipient.name}
-                onRemove={() => removeInvoiceRecipient(recipient.name)}
-                onAddEmail={email => addInvoiceRecipientEmail(recipient.name, email)}
-                onRemoveEmail={email => removeInvoiceRecipientEmail(recipient.name, email)}
-                onExpandedChange={expanded => this.setState({
-                  expandedRecipient: expanded ? recipient.name : null
-                })}
-              />
-            );
-          })}
-        </div>
+          );
+        })}
       </div>
-    )
-  }
-}
+    </div>
+  );
+};
 
 (InvoiceRecipientsList as any).propTypes = {
   invoiceRecipients: PropTypes.arrayOf(PropTypes.shape({
@@ -123,4 +114,4 @@ class InvoiceRecipientsList extends React.Component<any, any> {
   removeInvoiceRecipientEmail: PropTypes.func.isRequired,
 }
 
-export default withTranslation()(InvoiceRecipientsList)
+export default InvoiceRecipientsList;

--- a/src/components/MovementList/AssociatedMovement.tsx
+++ b/src/components/MovementList/AssociatedMovement.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import MaterialIcon from '../MaterialIcon';
 import MovementDetails from './MovementDetails';
 import Action from './Action';
@@ -30,15 +30,20 @@ const ActionContainer = styled.div`
   font-size: 1.2em;
 `;
 
-class AssociatedMovement extends React.PureComponent<any, any> {
+const AssociatedMovement = React.memo((props: any) => {
+  const { t } = useTranslation();
+  const {
+    movementType,
+    movementKey,
+    associatedMovement,
+    associatedMovementData,
+    loadMovement,
+    createMovementFromMovement,
+    isHomeBase,
+    isAdmin,
+  } = props;
 
-  constructor(props) {
-    super(props);
-    this.handleCreateMovement = this.handleCreateMovement.bind(this);
-  }
-
-  componentWillMount() {
-    const {associatedMovement, associatedMovementData, loadMovement} = this.props
+  useEffect(() => {
     if (
       associatedMovement &&
       ['departure', 'arrival'].includes(associatedMovement.type) &&
@@ -46,70 +51,58 @@ class AssociatedMovement extends React.PureComponent<any, any> {
     ) {
       loadMovement(associatedMovement.key, associatedMovement.type);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [associatedMovement, associatedMovementData]);
+
+  const handleCreateMovement = () => {
+    createMovementFromMovement(movementType, movementKey);
+  };
+
+  let label;
+  let text;
+
+  if (movementType === 'departure') {
+    label = t('movement.associated.arrivalLabel');
+    text = associatedMovementData
+      ? t('movement.associated.arrivalFound')
+      : associatedMovementData === null
+        ? t('movement.associated.arrivalNotFound')
+        : null;
+  } else {
+    label = t('movement.associated.departureLabel');
+    text = associatedMovementData
+      ? t('movement.associated.departureFound')
+      : associatedMovementData === null
+        ? t('movement.associated.departureNotFound')
+        : null;
   }
 
-  componentDidUpdate() {
-    const {associatedMovement, associatedMovementData, loadMovement} = this.props
-    if (
-      associatedMovement &&
-      ['departure', 'arrival'].includes(associatedMovement.type) &&
-      associatedMovementData === undefined
-    ) {
-      loadMovement(associatedMovement.key, associatedMovement.type);
-    }
-  }
+  return (
+    <Wrapper>
+      <div>
+        <Label>{label}</Label>
+        {text && <div>{text}</div>}
+        {associatedMovementData
+          ? <StyledDetails data={associatedMovementData} isHomeBase={isHomeBase} isAdmin={isAdmin}/>
+          : associatedMovementData === undefined
+            ? <MaterialIcon icon="sync" rotate="left"/>
+            : (
+              <ActionsContainer>
+                <ActionContainer>
+                  <Action
+                    label={ACTION_LABELS[movementType].label}
+                    icon={ACTION_LABELS[movementType].icon}
+                    onClick={handleCreateMovement}
+                  />
+                </ActionContainer>
+              </ActionsContainer>
+            )}
+      </div>
+    </Wrapper>
+  );
+});
 
-  render() {
-    const {movementType, associatedMovementData, t} = this.props;
-
-    let label;
-    let text;
-
-    if (movementType === 'departure') {
-      label = t('movement.associated.arrivalLabel');
-      text = associatedMovementData
-        ? t('movement.associated.arrivalFound')
-        : associatedMovementData === null
-          ? t('movement.associated.arrivalNotFound')
-          : null;
-    } else {
-      label = t('movement.associated.departureLabel');
-      text = associatedMovementData
-        ? t('movement.associated.departureFound')
-        : associatedMovementData === null
-          ? t('movement.associated.departureNotFound')
-          : null;
-    }
-
-    return (
-      <Wrapper>
-        <div>
-          <Label>{label}</Label>
-          {text && <div>{text}</div>}
-          {associatedMovementData
-            ? <StyledDetails data={associatedMovementData} isHomeBase={this.props.isHomeBase} isAdmin={this.props.isAdmin}/>
-            : associatedMovementData === undefined
-              ? <MaterialIcon icon="sync" rotate="left"/>
-              : (
-                <ActionsContainer>
-                  <ActionContainer>
-                    <Action
-                      label={ACTION_LABELS[movementType].label}
-                      icon={ACTION_LABELS[movementType].icon}
-                      onClick={this.handleCreateMovement}
-                    />
-                  </ActionContainer>
-                </ActionsContainer>
-              )}
-        </div>
-      </Wrapper>
-    )
-  }
-
-  handleCreateMovement() {
-    this.props.createMovementFromMovement(this.props.movementType, this.props.movementKey);
-  }
-}
+(AssociatedMovement as any).displayName = 'AssociatedMovement';
 
 (AssociatedMovement as any).propTypes = {
   movementType: PropTypes.oneOf(['departure', 'arrival']),
@@ -123,4 +116,4 @@ class AssociatedMovement extends React.PureComponent<any, any> {
   createMovementFromMovement: PropTypes.func.isRequired
 };
 
-export default withTranslation()(AssociatedMovement);
+export default AssociatedMovement;


### PR DESCRIPTION
## Summary

Part 4 of the class → function migration. Converts three components
that share the \`componentDidUpdate\`-with-prop-comparison pattern.
Each one is replaced by a keyed \`useEffect\` with a \`useRef\`
previous-length tracker (for clear-on-grow) or dependency-keyed check
(for conditional refetch).

### Files converted (one commit per file for bisect)

- \`InvoiceRecipientsList.tsx\` — clear \`newRecipientName\` when
  recipients count grows. Pattern: \`prevLengthRef\` + keyed \`useEffect\`.
- \`InvoiceRecipient.tsx\` — same pattern on \`emails.length\` growth.
- \`AssociatedMovement.tsx\` — \`componentWillMount\` + \`componentDidUpdate\`
  both fired \`loadMovement\` when data was undefined; collapses into
  one \`useEffect\` keyed on \`[associatedMovement, associatedMovementData]\`.
  Also wraps the FC in \`React.memo\` to preserve \`PureComponent\`'s
  render-skip behavior for the parent list.

All three also dropped \`withTranslation\` in favor of \`useTranslation\`.

### Class count

8 class components before → **5 after**.

## Test plan

- [x] \`npm test\` — 2093 / 2093 pass (specs for all three components
      cover clear-on-grow / no-clear-on-shrink / no-clear-on-same
      cases, plus AssociatedMovement's mount-vs-update refetch)
- [x] \`npm run typecheck\` — clean
- [x] \`npm start --project=lszm\` — dev server compiles, serves HTTP 200
- [ ] Manual smoke: admin → invoice recipients (add recipient, add
      email, delete), movement list with associated departure/arrival
      pairs (open arrival whose departure needs loading)