### PR TITLE
Convert TimeField and DatePicker to function components

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
-import { withTranslation } from 'react-i18next';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { de } from 'date-fns/locale/de';
 import { enGB } from 'date-fns/locale/en-GB';
 import ModalDialog from '../ModalDialog';
@@ -11,109 +11,83 @@ import DayPicker from './DayPicker';
 import ClearButton from './ClearButton';
 import Value from './Value';
 
-class DatePicker extends Component<any, any> {
+const DatePicker = (props: any) => {
+  const { i18n } = useTranslation();
+  const { clearable = false, readOnly, dataCy, onChange } = props;
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      showPicker: false,
-      value: props.value,
-    };
+  const [showPicker, setShowPicker] = useState(false);
+  const [state, setState] = useState(() => ({
+    value: props.value,
+    prevPropsValue: props.value,
+  }));
 
-    this.handleDayClick = this.handleDayClick.bind(this);
-    this.showPicker = this.showPicker.bind(this);
-    this.hidePicker = this.hidePicker.bind(this);
-    this.handleClear = this.handleClear.bind(this);
+  let currentValue = state.value;
+  if (props.value !== state.prevPropsValue) {
+    currentValue = props.value;
+    setState({ value: props.value, prevPropsValue: props.value });
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      value: nextProps.value,
-    });
-  }
-
-  render() {
-    if (this.props.readOnly === true) {
-      return (
-        <Wrapper readOnly>
-          <Value>
-            {this.state.value ? dates.formatDate(this.state.value) : '\u00a0'}
-          </Value>
-        </Wrapper>
-      );
+  const handleDayClick = (date: Date | null | undefined) => {
+    const dateString = date ? dates.localDate(date as any) : null;
+    setShowPicker(false);
+    setState({ value: dateString, prevPropsValue: props.value });
+    if (typeof onChange === 'function') {
+      onChange({ value: dateString });
     }
+  };
 
-    let dialog;
-    if (this.state.showPicker === true) {
-      const picker = this.renderPicker();
-      dialog = (
-        <ModalDialog content={picker} onBlur={this.hidePicker} fullWidthThreshold={0}/>
-      );
-    }
+  const handleClear = (e: React.MouseEvent) => {
+    e.stopPropagation(); // prevent call of outer div onClick handler
+    handleDayClick(null);
+  };
+
+  if (readOnly === true) {
     return (
-      <Wrapper>
-        <Value onClick={this.showPicker} data-cy={this.props.dataCy}>
-          {this.state.value ? this.renderValue() : '\u00a0'}
-          {this.props.clearable === true && this.state.value
-            ? <ClearButton onClick={this.handleClear} type="button">
-                <MaterialIcon icon="clear"/>
-            </ClearButton>
-            : null}
+      <Wrapper readOnly>
+        <Value>
+          {currentValue ? dates.formatDate(currentValue) : '\u00a0'}
         </Value>
-        {dialog}
       </Wrapper>
     );
   }
 
-  renderValue() {
-    return dates.formatDate(this.state.value);
-  }
-
-  renderPicker() {
-    const date = this.state.value ? new Date(this.state.value) : undefined;
-    const locale = this.props.i18n?.language === 'en' ? enGB : de;
+  const renderPicker = () => {
+    const date = currentValue ? new Date(currentValue) : undefined;
+    const locale = i18n?.language === 'en' ? enGB : de;
     return (
       <DayPicker
         mode="single"
         selected={date}
         defaultMonth={date}
-        onSelect={this.handleDayClick}
+        onSelect={handleDayClick}
         locale={locale}
         weekStartsOn={1}
       />
     );
-  }
+  };
 
-  handleDayClick(date) {
-    const dateString = date ? dates.localDate(date) : null;
-    this.setState({
-      showPicker: false,
-      value: dateString,
-    });
-    if (typeof this.props.onChange === 'function') {
-      this.props.onChange({
-        value: dateString,
-      });
-    }
-  }
+  const dialog = showPicker ? (
+    <ModalDialog
+      content={renderPicker()}
+      onBlur={() => setShowPicker(false)}
+      fullWidthThreshold={0}
+    />
+  ) : null;
 
-  handleClear(e) {
-    e.stopPropagation(); // prevent call of outer div onClick handler
-    this.handleDayClick(null);
-  }
-
-  showPicker() {
-    this.setState({
-      showPicker: true,
-    });
-  }
-
-  hidePicker() {
-    this.setState({
-      showPicker: false,
-    });
-  }
-}
+  return (
+    <Wrapper>
+      <Value onClick={() => setShowPicker(true)} data-cy={dataCy}>
+        {currentValue ? dates.formatDate(currentValue) : '\u00a0'}
+        {clearable === true && currentValue
+          ? <ClearButton onClick={handleClear} type="button">
+              <MaterialIcon icon="clear"/>
+          </ClearButton>
+          : null}
+      </Value>
+      {dialog}
+    </Wrapper>
+  );
+};
 
 (DatePicker as any).propTypes = {
   value: PropTypes.string,
@@ -122,8 +96,4 @@ class DatePicker extends Component<any, any> {
   readOnly: PropTypes.bool,
 };
 
-(DatePicker as any).defaultProps = {
-  clearable: false,
-};
-
-export default withTranslation()(DatePicker);
+export default DatePicker;

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -1,97 +1,79 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { parse, normalize } from '../../util/time';
 import Wrapper from './Wrapper';
 import NumberBlock from './NumberBlock';
 import update from 'immutability-helper';
 
-class TimeField extends Component<any, any> {
+const parseValue = (timeString: unknown) =>
+  parse(timeString) || { hours: 0, minutes: 0 };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      value: TimeField.parseValue(props.value),
+const formatTwoDigit = (n: number) => ('0' + n).slice(-2);
+
+const formatString = (time: { hours: number; minutes: number }) =>
+  formatTwoDigit(time.hours) + ':' + formatTwoDigit(time.minutes);
+
+const TimeField = (props: any) => {
+  const [state, setState] = useState(() => ({
+    value: parseValue(props.value),
+    prevPropsValue: props.value,
+  }));
+
+  let currentValue = state.value;
+  if (props.value !== state.prevPropsValue) {
+    currentValue = parseValue(props.value);
+    setState({
+      value: currentValue,
       prevPropsValue: props.value,
-    };
-  }
-
-  static getDerivedStateFromProps(props, state) {
-    if (props.value !== state.prevPropsValue) {
-      return {
-        value: TimeField.parseValue(props.value),
-        prevPropsValue: props.value,
-      };
-    }
-    return null;
-  }
-
-  static parseValue(timeString) {
-    return parse(timeString) || { hours: 0, minutes: 0 };
-  }
-
-  render() {
-    if (this.props.readOnly === true) {
-      return (
-        <div>
-          {this.formatString(this.state.value)}
-        </div>
-      );
-    }
-
-    return (
-      <Wrapper>
-        <NumberBlock
-          value={this.state.value.hours}
-          onChange={this.updateHours.bind(this)}
-          dataCy={`${this.props.dataCy}-hours`}
-        />
-        <span>:</span>
-        <NumberBlock
-          value={this.state.value.minutes}
-          onChange={this.updateMinutes.bind(this)}
-          dataCy={`${this.props.dataCy}-minutes`}
-        />
-      </Wrapper>
-    );
-  }
-
-  updateHours(hours) {
-    const newTime = update(this.state.value, {
-      hours: { $set: hours },
     });
-    this.setTime(newTime);
   }
 
-  updateMinutes(minutes) {
-    const newTime = update(this.state.value, {
-      minutes: { $set: minutes },
+  const setTime = (time: { hours: number; minutes: number }) => {
+    const normalized = normalize(time);
+    setState({
+      value: normalized,
+      prevPropsValue: props.value,
     });
-    this.setTime(newTime);
-  }
-
-  setTime(time) {
-    this.setState({
-      value: normalize(time),
-    }, this.fireChangeEvent);
-  }
-
-  fireChangeEvent() {
-    if (typeof this.props.onChange === 'function') {
-      const stringValue = this.formatString(this.state.value);
-      this.props.onChange({
+    if (typeof props.onChange === 'function') {
+      const stringValue = formatString(normalized);
+      props.onChange({
         value: stringValue !== '00:00' ? stringValue : null,
       });
     }
+  };
+
+  const updateHours = (hours: number) => {
+    setTime(update(currentValue, { hours: { $set: hours } }));
+  };
+
+  const updateMinutes = (minutes: number) => {
+    setTime(update(currentValue, { minutes: { $set: minutes } }));
+  };
+
+  if (props.readOnly === true) {
+    return (
+      <div>
+        {formatString(currentValue)}
+      </div>
+    );
   }
 
-  formatString(time) {
-    return this.formatTwoDigit(time.hours) + ':' + this.formatTwoDigit(time.minutes);
-  }
-
-  formatTwoDigit(number) {
-    return ('0' + number).slice(-2);
-  }
-}
+  return (
+    <Wrapper>
+      <NumberBlock
+        value={currentValue.hours}
+        onChange={updateHours}
+        dataCy={`${props.dataCy}-hours`}
+      />
+      <span>:</span>
+      <NumberBlock
+        value={currentValue.minutes}
+        onChange={updateMinutes}
+        dataCy={`${props.dataCy}-minutes`}
+      />
+    </Wrapper>
+  );
+};
 
 (TimeField as any).propTypes = {
   value: PropTypes.string,


### PR DESCRIPTION
## Summary

Part 5 of the class → function migration. Converts the two
\"mirror-prop-into-state\" components using the **derive-during-render
pattern**, NOT \`useState + useEffect\`.

This preserves the class behavior of \`getDerivedStateFromProps\` and
\`componentWillReceiveProps\` — state is updated in the same render
pass as the prop change, with no intermediate commit showing stale
state to the user.

### Pattern

\`\`\`tsx
const [state, setState] = useState(() => ({
  value: parseValue(props.value),
  prevPropsValue: props.value,
}));

let currentValue = state.value;
if (props.value !== state.prevPropsValue) {
  currentValue = parseValue(props.value);
  setState({ value: currentValue, prevPropsValue: props.value });
}
\`\`\`

React discards the current render and re-runs with the new state, so
there is no intermediate commit.

### Files converted (one commit per file)

- \`TimeField.tsx\` — was \`getDerivedStateFromProps\` mirroring the
  \`value\` prop through \`parseValue\`. Also moves \`parseValue\` and
  \`formatString\` helpers out of the class body.
- \`DatePicker.tsx\` — was \`componentWillReceiveProps\` mirroring
  \`value\`. Also drops \`withTranslation\` for \`useTranslation\`.
  Keeps \`e.stopPropagation()\` on the clear button (regression-tested
  by the spec from PR #719).

### Class count

5 class components before → **3 after**.

## Test plan

- [x] \`npm test\` — 2093 / 2093 pass (TimeField spec asserts prop
      mirror + fresh-value onChange; DatePicker spec asserts prop
      mirror + clear-button stopPropagation + locale)
- [x] \`npm run typecheck\` — clean
- [x] \`npm start --project=lszm\` — dev server compiles, serves HTTP 200
- [ ] Manual smoke: arrival/departure wizards (edit time fields,
      edit date field), settings → lock movements (date picker with
      clearable + null value)