### PR TITLE
Convert MovementList and Movement to function components

### DIFF
--- a/src/components/MovementList/Movement.tsx
+++ b/src/components/MovementList/Movement.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import dates from '../../util/dates';
 import MovementHeader from './MovementHeader';
 import MovementDetails from './MovementDetails';
@@ -42,140 +42,121 @@ const Footer = styled.div`
   }
 `;
 
-class Movement extends React.PureComponent<any, any> {
+const Movement = React.memo((props: any) => {
+  const { t } = useTranslation();
+  const { timeWithDate = true } = props;
 
-  constructor(props) {
-    super(props);
-    this.handleClick = this.handleClick.bind(this);
-    this.handleDeleteClick = this.handleDeleteClick.bind(this);
-    this.handleEditClick = this.handleEditClick.bind(this);
-    this.handleCustomsClick = this.handleCustomsClick.bind(this);
-  }
+  const handleClick = () => {
+    const selected = props.selected ? null : props.data.key;
+    props.onSelect(selected);
+  };
 
-  render() {
-    const props = this.props;
-    const { t } = this.props;
+  const handleDeleteClick = () => {
+    props.onDelete(props.data);
+  };
 
-    const isHomeBase = props.aircraftSettings.club[props.data.immatriculation] === true
-      || props.aircraftSettings.homeBase[props.data.immatriculation] === true;
+  const handleEditClick = () => {
+    props.onEdit(props.data.type, props.data.key);
+  };
 
-    return (
-      <Wrapper $selected={props.selected} data-id={props.data.key}>
-        <MovementHeader
-          onClick={this.handleClick}
-          selected={props.selected}
-          data={props.data}
-          timeWithDate={props.timeWithDate}
-          createMovementFromMovement={props.createMovementFromMovement}
-          locked={props.locked}
-          isHomeBase={isHomeBase}
-          isAdmin={props.isAdmin}
-        />
-        {props.selected && (
-          <div>
-            <StyledMovementDetails
-              data={props.data}
-              locked={props.locked}
-              isHomeBase={isHomeBase}
-              isAdmin={props.isAdmin}
-            />
-            {!props.locked && (
-              <Footer>
-                {this.shouldShowCustomsAction() && (
-                  <Action
-                    label={props.data.customsFormId ? t('movement.openCustoms') : t('movement.recordCustoms')}
-                    icon={props.customs.loading ? "sync" :"description"}
-                    rotateIcon={props.customs.loading ? 'left' : undefined}
-                    disabled={props.customs.loading}
-                    onClick={this.handleCustomsClick}
-                  />
-                )}
-                <Action
-                  label={t('movement.edit')}
-                  icon="edit"
-                  onClick={this.handleEditClick}
-                  dataCy="action-edit"
-                />
-                <Action
-                  label={t('movement.delete')}
-                  icon="delete"
-                  onClick={this.handleDeleteClick}
-                  dataCy="action-delete"
-                />
-              </Footer>
-            )}
-            <AssociatedMovement
-              movementType={props.data.type}
-              movementKey={props.data.key}
-              isHomeBase={isHomeBase}
-              associatedMovement={props.data.associatedMovement}
-              createMovementFromMovement={props.createMovementFromMovement}
-              loading={props.loading}
-              isAdmin={props.isAdmin}
-            />
-          </div>
-        )}
-      </Wrapper>
-    );
-  }
+  const handleCustomsClick = () => {
+    props.onStartCustoms(props.data);
+  };
 
-  handleClick() {
-    const selected = this.props.selected ? null : this.props.data.key;
-    this.props.onSelect(selected);
-  }
-
-  handleDeleteClick() {
-    this.props.onDelete(this.props.data);
-  }
-
-  handleEditClick() {
-    this.props.onEdit(this.props.data.type, this.props.data.key);
-  }
-
-  handleCustomsClick() {
-    this.props.onStartCustoms(this.props.data);
-  }
-
-  isForeignFlight() {
-    const { data, aerodromes } = this.props;
-
+  const isForeignFlight = () => {
+    const { data, aerodromes } = props;
     if (!aerodromes || !aerodromes.data) {
       return false;
     }
-
     const aerodrome = aerodromes.data.getByKey(data.location);
-
     if (!aerodrome) {
       return false;
     }
-
     return aerodrome.country !== 'CH';
-  }
+  };
 
-  isFutureFlightTime() {
-    const { data } = this.props;
+  const isFutureFlightTime = () => {
+    const { data } = props;
     const flightTimestamp = dates.localToIsoUtc(data.date, data.time);
     const now = new Date().toISOString();
     return flightTimestamp > now;
-  }
+  };
 
-  shouldShowCustomsAction() {
-    const { data, customs } = this.props;
-
-    // Only show customs actions if the customs declaration app is available (checked via Cloud Functions)
+  const shouldShowCustomsAction = () => {
+    const { data, customs } = props;
     if (customs && customs.available !== true) {
       return false;
     }
-
-    // Show "Zollanmeldung öffnen" if customsFormId exists (regardless of timing)
     if (data.customsFormId) {
       return true;
     }
+    return isForeignFlight() && isFutureFlightTime();
+  };
 
-    // Show "Zollanmeldung erfassen" for foreign flights that are in the future
-    return this.isForeignFlight() && this.isFutureFlightTime();
-  }
-}
+  const isHomeBase = props.aircraftSettings.club[props.data.immatriculation] === true
+    || props.aircraftSettings.homeBase[props.data.immatriculation] === true;
+
+  return (
+    <Wrapper $selected={props.selected} data-id={props.data.key}>
+      <MovementHeader
+        onClick={handleClick}
+        selected={props.selected}
+        data={props.data}
+        timeWithDate={timeWithDate}
+        createMovementFromMovement={props.createMovementFromMovement}
+        locked={props.locked}
+        isHomeBase={isHomeBase}
+        isAdmin={props.isAdmin}
+      />
+      {props.selected && (
+        <div>
+          <StyledMovementDetails
+            data={props.data}
+            locked={props.locked}
+            isHomeBase={isHomeBase}
+            isAdmin={props.isAdmin}
+          />
+          {!props.locked && (
+            <Footer>
+              {shouldShowCustomsAction() && (
+                <Action
+                  label={props.data.customsFormId ? t('movement.openCustoms') : t('movement.recordCustoms')}
+                  icon={props.customs.loading ? "sync" : "description"}
+                  rotateIcon={props.customs.loading ? 'left' : undefined}
+                  disabled={props.customs.loading}
+                  onClick={handleCustomsClick}
+                />
+              )}
+              <Action
+                label={t('movement.edit')}
+                icon="edit"
+                onClick={handleEditClick}
+                dataCy="action-edit"
+              />
+              <Action
+                label={t('movement.delete')}
+                icon="delete"
+                onClick={handleDeleteClick}
+                dataCy="action-delete"
+              />
+            </Footer>
+          )}
+          <AssociatedMovement
+            movementType={props.data.type}
+            movementKey={props.data.key}
+            isHomeBase={isHomeBase}
+            associatedMovement={props.data.associatedMovement}
+            createMovementFromMovement={props.createMovementFromMovement}
+            loading={props.loading}
+            isAdmin={props.isAdmin}
+          />
+        </div>
+      )}
+    </Wrapper>
+  );
+});
+
+(Movement as any).displayName = 'Movement';
 
 (Movement as any).propTypes = {
   data: PropTypes.object.isRequired,
@@ -201,8 +182,4 @@ class Movement extends React.PureComponent<any, any> {
   loading: PropTypes.bool.isRequired
 };
 
-(Movement as any).defaultProps = {
-  timeWithDate: true,
-};
-
-export default withTranslation()(Movement);
+export default Movement;

--- a/src/components/MovementList/MovementList.tsx
+++ b/src/components/MovementList/MovementList.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import { withTranslation } from 'react-i18next';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import Predicates from './Predicates';
 import MovementGroup from './MovementGroup';
 import LoadingInfo from './LoadingInfo';
@@ -30,115 +30,115 @@ const olderPredicate = Predicates.and(
  * this month
  * older
  */
-class MovementList extends React.PureComponent<any, any> {
+const MovementList = (props: any) => {
+  const { t } = useTranslation();
 
-  componentWillMount() {
-    this.props.loadAircraftSettings();
-    this.props.loadAerodromes();
-    this.props.checkCustomsAvailability();
-    this.props.onSelect(null);
-    this.props.loadItems(true);
+  useEffect(() => {
+    props.loadAircraftSettings();
+    props.loadAerodromes();
+    props.checkCustomsAvailability();
+    props.onSelect(null);
+    props.loadItems(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (props.lockDate.loading === true
+    || !props.aircraftSettings.club
+    || !props.aircraftSettings.homeBase) {
+    return <LoadingInfo/>;
   }
 
-  render() {
-    const { t } = this.props;
-    if (this.props.lockDate.loading === true
-      || !this.props.aircraftSettings.club
-      || !this.props.aircraftSettings.homeBase) {
-      return <LoadingInfo/>;
-    }
+  const confirmationDialog = props.deleteConfirmation ? (
+    <MovementDeleteConfirmationDialog
+      item={props.deleteConfirmation}
+      confirm={props.deleteItem}
+      hide={props.hideDeleteConfirmationDialog}
+    />
+  ) : null;
 
-    const confirmationDialog = this.props.deleteConfirmation ?
-      (<MovementDeleteConfirmationDialog
-        item={this.props.deleteConfirmation}
-        confirm={this.props.deleteItem}
-        hide={this.props.hideDeleteConfirmationDialog}
-      />) : null;
-
-    return (
-      <div>
-        {this.props.isAdmin === true && <MovementFilter/>}
-        <MovementGroup
-          label={t('movement.groups.tomorrow')}
-          items={this.props.items}
-          selected={this.props.selected}
-          onSelect={this.props.onSelect}
-          predicate={afterTodayPredicate}
-          onEdit={this.props.onEdit}
-          timeWithDate={true}
-          createMovementFromMovement={this.props.createMovementFromMovement}
-          onDelete={this.props.showDeleteConfirmationDialog}
-          lockDate={this.props.lockDate.date}
-          aircraftSettings={this.props.aircraftSettings}
-          loading={this.props.loading}
-          isAdmin={this.props.isAdmin}
-        />
-        <MovementGroup
-          label={t('movement.groups.today')}
-          items={this.props.items}
-          selected={this.props.selected}
-          onSelect={this.props.onSelect}
-          predicate={todayPredicate}
-          onEdit={this.props.onEdit}
-          timeWithDate={false}
-          createMovementFromMovement={this.props.createMovementFromMovement}
-          onDelete={this.props.showDeleteConfirmationDialog}
-          lockDate={this.props.lockDate.date}
-          aircraftSettings={this.props.aircraftSettings}
-          loading={this.props.loading}
-          isAdmin={this.props.isAdmin}
-        />
-        <MovementGroup
-          label={t('movement.groups.yesterday')}
-          items={this.props.items}
-          selected={this.props.selected}
-          onSelect={this.props.onSelect}
-          predicate={yesterdayPredicate}
-          onEdit={this.props.onEdit}
-          timeWithDate={false}
-          createMovementFromMovement={this.props.createMovementFromMovement}
-          onDelete={this.props.showDeleteConfirmationDialog}
-          lockDate={this.props.lockDate.date}
-          aircraftSettings={this.props.aircraftSettings}
-          loading={this.props.loading}
-          isAdmin={this.props.isAdmin}
-        />
-        <MovementGroup
-          label={t('movement.groups.thisMonth')}
-          items={this.props.items}
-          selected={this.props.selected}
-          onSelect={this.props.onSelect}
-          predicate={thisMonthPredicate}
-          onEdit={this.props.onEdit}
-          createMovementFromMovement={this.props.createMovementFromMovement}
-          onDelete={this.props.showDeleteConfirmationDialog}
-          lockDate={this.props.lockDate.date}
-          aircraftSettings={this.props.aircraftSettings}
-          loading={this.props.loading}
-          isAdmin={this.props.isAdmin}
-        />
-        <MovementGroup
-          label={t('movement.groups.older')}
-          items={this.props.items}
-          selected={this.props.selected}
-          onSelect={this.props.onSelect}
-          predicate={olderPredicate}
-          onEdit={this.props.onEdit}
-          createMovementFromMovement={this.props.createMovementFromMovement}
-          onDelete={this.props.showDeleteConfirmationDialog}
-          lockDate={this.props.lockDate.date}
-          aircraftSettings={this.props.aircraftSettings}
-          loading={this.props.loading}
-          isAdmin={this.props.isAdmin}
-        />
-        {this.props.loading && <LoadingInfo/>}
-        {this.props.loadingFailed && <LoadingFailureInfo/>}
-        {!this.props.loading && this.props.items.array.length === 0 && <NoMovementsInfo/>}
-        {confirmationDialog}
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      {props.isAdmin === true && <MovementFilter/>}
+      <MovementGroup
+        label={t('movement.groups.tomorrow')}
+        items={props.items}
+        selected={props.selected}
+        onSelect={props.onSelect}
+        predicate={afterTodayPredicate}
+        onEdit={props.onEdit}
+        timeWithDate={true}
+        createMovementFromMovement={props.createMovementFromMovement}
+        onDelete={props.showDeleteConfirmationDialog}
+        lockDate={props.lockDate.date}
+        aircraftSettings={props.aircraftSettings}
+        loading={props.loading}
+        isAdmin={props.isAdmin}
+      />
+      <MovementGroup
+        label={t('movement.groups.today')}
+        items={props.items}
+        selected={props.selected}
+        onSelect={props.onSelect}
+        predicate={todayPredicate}
+        onEdit={props.onEdit}
+        timeWithDate={false}
+        createMovementFromMovement={props.createMovementFromMovement}
+        onDelete={props.showDeleteConfirmationDialog}
+        lockDate={props.lockDate.date}
+        aircraftSettings={props.aircraftSettings}
+        loading={props.loading}
+        isAdmin={props.isAdmin}
+      />
+      <MovementGroup
+        label={t('movement.groups.yesterday')}
+        items={props.items}
+        selected={props.selected}
+        onSelect={props.onSelect}
+        predicate={yesterdayPredicate}
+        onEdit={props.onEdit}
+        timeWithDate={false}
+        createMovementFromMovement={props.createMovementFromMovement}
+        onDelete={props.showDeleteConfirmationDialog}
+        lockDate={props.lockDate.date}
+        aircraftSettings={props.aircraftSettings}
+        loading={props.loading}
+        isAdmin={props.isAdmin}
+      />
+      <MovementGroup
+        label={t('movement.groups.thisMonth')}
+        items={props.items}
+        selected={props.selected}
+        onSelect={props.onSelect}
+        predicate={thisMonthPredicate}
+        onEdit={props.onEdit}
+        createMovementFromMovement={props.createMovementFromMovement}
+        onDelete={props.showDeleteConfirmationDialog}
+        lockDate={props.lockDate.date}
+        aircraftSettings={props.aircraftSettings}
+        loading={props.loading}
+        isAdmin={props.isAdmin}
+      />
+      <MovementGroup
+        label={t('movement.groups.older')}
+        items={props.items}
+        selected={props.selected}
+        onSelect={props.onSelect}
+        predicate={olderPredicate}
+        onEdit={props.onEdit}
+        createMovementFromMovement={props.createMovementFromMovement}
+        onDelete={props.showDeleteConfirmationDialog}
+        lockDate={props.lockDate.date}
+        aircraftSettings={props.aircraftSettings}
+        loading={props.loading}
+        isAdmin={props.isAdmin}
+      />
+      {props.loading && <LoadingInfo/>}
+      {props.loadingFailed && <LoadingFailureInfo/>}
+      {!props.loading && props.items.array.length === 0 && <NoMovementsInfo/>}
+      {confirmationDialog}
+    </div>
+  );
+};
 
 (MovementList as any).propTypes = {
   loadItems: PropTypes.func.isRequired,
@@ -164,4 +164,4 @@ class MovementList extends React.PureComponent<any, any> {
   isAdmin: PropTypes.bool
 };
 
-export default withTranslation()(AutoLoad(MovementList));
+export default AutoLoad(MovementList);


### PR DESCRIPTION
## Summary

Part 6 of the class → function migration. Converts the perf-critical
pair that renders the main movements list.

### Files converted

- \`Movement.tsx\` — was \`PureComponent\` → wrapped in \`React.memo\`
  to preserve skip-on-same-props behavior. \`defaultProps\` for
  \`timeWithDate\` moved into destructuring default. Bound
  constructor methods → plain local arrows (children aren't
  memoized, so callback identity stability is not required). Helper
  methods (\`isForeignFlight\`, \`isFutureFlightTime\`,
  \`shouldShowCustomsAction\`) → local arrows that close over props.
- \`MovementList.tsx\` — was \`PureComponent\` with five
  \`componentWillMount\` dispatches → \`useEffect(() => {...}, [])\`.
  Export now \`AutoLoad(MovementList)\` directly (no
  \`withTranslation\` HOC wrapper needed because the component uses
  \`useTranslation\`). \`AutoLoad\` is still a class HOC in
  \`src/util/AutoLoad.tsx\` — deliberately out of scope for this PR.

Both also dropped \`withTranslation\` in favor of \`useTranslation\`.

### Class count

3 class components before → **1 after** (only \`App.tsx\` remains in
\`src/components/\` / \`src/containers/\`; \`AutoLoad\` is a class
HOC in \`src/util/\` but was never on the 31-file list).

### Perf preservation

The \`React.memo\` wrapper on \`Movement\` gives the same prop-level
skip behavior as the original \`PureComponent\`. The handlers passed
from \`Movement\` down to its children (\`MovementHeader\`,
\`MovementDetails\`, \`Action\`, \`AssociatedMovement\`) are plain
arrows rather than \`useCallback\` because none of those children
are memoized; ref stability would be unused overhead.

## Test plan

- [x] \`npm test\` — 2093 / 2093 pass (MovementList spec asserts all
      5 mount dispatches exactly-once + loading gate + conditional
      children; Movement spec asserts header/details/action
      rendering, click handling, customs visibility)
- [x] \`npm run typecheck\` — clean
- [x] \`npm start --project=lszm\` — dev server compiles, serves HTTP 200
- [ ] Manual smoke: /movements page (select/deselect movements,
      edit/delete actions, associated-movement expansion,
      scroll-triggered AutoLoad); admin filter toggle