### PR TITLE
Preserve Content PureComponent behavior with React.memo

### DIFF
--- a/src/components/VerticalHeaderLayout/Content.tsx
+++ b/src/components/VerticalHeaderLayout/Content.tsx
@@ -10,9 +10,11 @@ const Wrapper = styled.div`
   }
 `;
 
-const Content = ({ children }: { children: React.ReactNode }) => (
+const Content = React.memo(({ children }: { children: React.ReactNode }) => (
   <Wrapper>{children}</Wrapper>
-);
+));
+
+(Content as any).displayName = 'Content';
 
 (Content as any).propTypes = {
   children: PropTypes.element.isRequired


### PR DESCRIPTION
## Summary

Follow-up from the class→function migration review: the initial
conversion of \`VerticalHeaderLayout/Content.tsx\` (in PR #720)
converted the \`React.PureComponent\` to a plain function component
without a \`React.memo\` wrapper. That drops the shallow-equal
skip-on-same-props behavior.

In practice the impact is near-zero — Content is a trivial wrapper,
and parents almost always pass new-JSX children each render so the
shallow check wouldn't skip anyway. But strictly speaking, this is
a behavioral change vs master.

Wrapping in \`React.memo\` restores the exact pattern of the
pre-migration \`PureComponent\`.

## Test plan

- [x] \`npm test\` — 2095 / 2095 pass
- [x] \`npm run typecheck\` — clean