### PR TITLE
Convert AutoLoad HOC to function component

### DIFF
--- a/src/util/AutoLoad.spec.tsx
+++ b/src/util/AutoLoad.spec.tsx
@@ -178,5 +178,107 @@ describe('util', () => {
       );
       expect(() => unmount()).not.toThrow();
     });
+
+    it('does not call loadItems on mount', () => {
+      const AutoLoadList = AutoLoad(SimpleList);
+      render(
+        <Wrapper>
+          <AutoLoadList items={['a']} loadItems={loadItems} />
+        </Wrapper>
+      );
+      expect(loadItems).not.toHaveBeenCalled();
+    });
+
+    it('calls loadItems exactly once per items-growth rerender', () => {
+      const AutoLoadList = AutoLoad(SimpleList);
+      const { rerender } = render(
+        <Wrapper>
+          <AutoLoadList items={['a']} loadItems={loadItems} />
+        </Wrapper>
+      );
+      expect(loadItems).not.toHaveBeenCalled();
+
+      act(() => {
+        rerender(
+          <Wrapper>
+            <AutoLoadList items={['a', 'b']} loadItems={loadItems} />
+          </Wrapper>
+        );
+      });
+      expect(loadItems).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls the latest loadItems on scroll when the prop changes across renders', () => {
+      const AutoLoadList = AutoLoad(SimpleList);
+      const firstLoad = jest.fn();
+      const secondLoad = jest.fn();
+      const { rerender } = render(
+        <Wrapper>
+          <AutoLoadList items={['a']} loadItems={firstLoad} />
+        </Wrapper>
+      );
+      rerender(
+        <Wrapper>
+          <AutoLoadList items={['a']} loadItems={secondLoad} />
+        </Wrapper>
+      );
+
+      const scrollEvent = new Event('scroll');
+      Object.defineProperty(scrollEvent, 'target', { value: document });
+      window.dispatchEvent(scrollEvent);
+
+      expect(firstLoad).not.toHaveBeenCalled();
+      expect(secondLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it('respects autoLoadDisabled changes across renders', () => {
+      const AutoLoadList = AutoLoad(SimpleList);
+      const { rerender } = render(
+        <Wrapper>
+          <AutoLoadList
+            items={['a']}
+            loadItems={loadItems}
+            autoLoadDisabled={false}
+          />
+        </Wrapper>
+      );
+      rerender(
+        <Wrapper>
+          <AutoLoadList
+            items={['a']}
+            loadItems={loadItems}
+            autoLoadDisabled={true}
+          />
+        </Wrapper>
+      );
+
+      const scrollEvent = new Event('scroll');
+      Object.defineProperty(scrollEvent, 'target', { value: document });
+      window.dispatchEvent(scrollEvent);
+
+      expect(loadItems).not.toHaveBeenCalled();
+    });
+
+    it('calls loadItems on scroll of a scrollable ancestor element', () => {
+      const AutoLoadList = AutoLoad(SimpleList);
+      render(
+        <div style={{ overflow: 'auto' }} data-testid="scroll-parent">
+          <Wrapper>
+            <AutoLoadList items={['a']} loadItems={loadItems} />
+          </Wrapper>
+        </div>
+      );
+
+      const scrollParent = document.querySelector(
+        '[data-testid="scroll-parent"]'
+      )!;
+      const scrollEvent = new Event('scroll');
+      Object.defineProperty(scrollEvent, 'target', { value: scrollParent });
+      scrollParent.dispatchEvent(scrollEvent);
+
+      // In jsdom offsetHeight, scrollTop, scrollHeight all default to 0,
+      // so isEndReached on a non-document element returns true (0+0===0).
+      expect(loadItems).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/util/AutoLoad.tsx
+++ b/src/util/AutoLoad.tsx
@@ -1,87 +1,77 @@
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { useEffect, useRef } from 'react';
 import isElementInViewport from '../util/isElementInViewport';
 
-const DEFAULT_BOTTOM_THRESHOLD = 50
+const DEFAULT_BOTTOM_THRESHOLD = 50;
 
-export const AutoLoad = (List: any) => class extends Component<any, any> {
+export const AutoLoad = (List: any) => {
+  const AutoLoadWrapper: React.FC<any> = (props) => {
+    const elementRef = useRef<HTMLDivElement | null>(null);
+    const bottomMarkerRef = useRef<HTMLDivElement | null>(null);
+    const prevItemsLengthRef = useRef(props.items.length);
 
-  element: any;
-  bottomMarker: any;
+    const latestPropsRef = useRef(props);
+    latestPropsRef.current = props;
 
-  constructor(props) {
-    super(props);
-    this.handleScroll = this.handleScroll.bind(this);
-  }
+    useEffect(() => {
+      const findScrollableElement = (): EventTarget => {
+        let element: any = elementRef.current;
+        while (element && element !== document) {
+          const style = window.getComputedStyle(element);
+          const overflow = style.getPropertyValue('overflow');
+          if (overflow === 'auto' || overflow === 'scroll') return element;
+          element = element.parentNode;
+        }
+        return window;
+      };
 
-  componentDidMount() {
-    const scrollableElement = this.findScrollableElement();
-    if (scrollableElement) {
-      scrollableElement.addEventListener('scroll', this.handleScroll);
-    }
-  }
+      const getBottomThreshold = () =>
+        typeof latestPropsRef.current.bottomThreshold === 'number'
+          ? latestPropsRef.current.bottomThreshold
+          : DEFAULT_BOTTOM_THRESHOLD;
 
-  componentWillUnmount() {
-    const scrollableElement = this.findScrollableElement();
-    if (scrollableElement) {
-      scrollableElement.removeEventListener('scroll', this.handleScroll);
-    }
-  }
+      const isEndReached = (el: any) => {
+        if (el === document) {
+          const scrollY = window.scrollY || window.pageYOffset;
+          return (
+            window.innerHeight + scrollY + getBottomThreshold() >=
+            document.body.offsetHeight
+          );
+        }
+        return el.offsetHeight + el.scrollTop === el.scrollHeight;
+      };
 
-  componentDidUpdate(prevProps) {
-    if (this.props.items.length > prevProps.items.length
-      && this.bottomMarker && isElementInViewport(this.bottomMarker)) {
-      this.props.loadItems();
-    }
-  }
+      const handleScroll = (e: Event) => {
+        if (
+          isEndReached(e.target) &&
+          !latestPropsRef.current.autoLoadDisabled
+        ) {
+          latestPropsRef.current.loadItems();
+        }
+      };
 
-  findScrollableElement() {
-    let element = this.element;
-    do {
-      const style = window.getComputedStyle(element);
-      const overflow = style.getPropertyValue('overflow');
-      if (overflow === 'auto' || overflow === 'scroll') {
-        return element;
+      const scrollable = findScrollableElement();
+      scrollable.addEventListener('scroll', handleScroll);
+      return () => scrollable.removeEventListener('scroll', handleScroll);
+    }, []);
+
+    useEffect(() => {
+      if (
+        props.items.length > prevItemsLengthRef.current &&
+        bottomMarkerRef.current &&
+        isElementInViewport(bottomMarkerRef.current)
+      ) {
+        props.loadItems();
       }
-      element = element.parentNode;
-    } while (element && element !== document);
-    return window;
-  }
+      prevItemsLengthRef.current = props.items.length;
+    }, [props.items.length]);
 
-  handleScroll(e) {
-    if (this.isEndReached(e.target) && !this.props.autoLoadDisabled) {
-      this.props.loadItems();
-    }
-  }
-
-  isEndReached(element) {
-    if (element === document) {
-      const scrollY = window.scrollY || window.pageYOffset;
-      return (window.innerHeight + scrollY + this.getBottomThreshold()) >= document.body.offsetHeight;
-    }
-    return element.offsetHeight + element.scrollTop === element.scrollHeight;
-  }
-
-  getBottomThreshold() {
-    return typeof this.props.bottomThreshold === 'number'
-      ? this.props.bottomThreshold
-      : DEFAULT_BOTTOM_THRESHOLD
-  }
-
-  render() {
     return (
-      <div className={this.props.className} ref={(element) => this.element = element}>
-        <List {...this.props}/>
-        <div ref={element => this.bottomMarker = element}></div>
+      <div className={props.className} ref={elementRef}>
+        <List {...props} />
+        <div ref={bottomMarkerRef}></div>
       </div>
     );
-  }
-};
+  };
 
-AutoLoad.propTypes = {
-  loadItems: PropTypes.func.isRequired,
-  items: PropTypes.array.isRequired,
-  bottomThreshold: PropTypes.number,
-  className: PropTypes.string,
-  autoLoadDisabled: PropTypes.bool,
+  return AutoLoadWrapper;
 };


### PR DESCRIPTION
## Summary

- Migrates `src/util/AutoLoad.tsx` — the last remaining class component in `src/` — to a function component with hooks.
- HOC signature (`AutoLoad(List)`) is preserved, so the single call site (`MovementList`) and the existing spec suite don't need to change.
- Strengthens the spec suite with migration-specific tests and brings coverage of `AutoLoad.tsx` to 100% (stmts/branches/funcs/lines).

## Notes

The scroll handler reads props through a `latestPropsRef` updated every render. This avoids both stale-closure bugs on `loadItems` / `autoLoadDisabled` / `bottomThreshold`, and noisy re-attachment of the DOM scroll listener on every render.

`componentDidUpdate`'s "load more when items grow and bottom marker is visible" semantics are replicated with a `prevItemsLengthRef` initialized to `items.length`, so the `useEffect` is a no-op on mount and fires only on actual growth.

Typed as `React.FC<any>` to match the original `Component<any, any>` — a narrower interface collided with `connect`'s inferred prop types at the `MovementListContainer` call site.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 191 suites / 2100 tests pass (up from 2095; 5 new AutoLoad tests)
- [x] Coverage on `AutoLoad.tsx`: 100% stmts / 100% branches / 100% funcs / 100% lines
- [ ] Manual: `npm start --project=lszm`, scroll the movements list to the bottom, confirm additional movements load; confirm `autoLoadDisabled` still suppresses auto-loading