### PR TITLE
Type AircraftDropdown Option props

### DIFF
--- a/src/components/AircraftDropdown/Option.tsx
+++ b/src/components/AircraftDropdown/Option.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -16,17 +15,17 @@ const Type = styled.div<{ $focussed?: boolean }>`
   color: ${props => props.$focussed ? props.theme.colors.main : `#888`};
 `;
 
-const Option = props => (
+interface Props {
+  immatriculation: string;
+  type: string;
+  focussed?: boolean;
+}
+
+const Option = (props: Props) => (
   <Wrapper>
     <Immatriculation $focussed={props.focussed}>{props.immatriculation}</Immatriculation>
     <Type $focussed={props.focussed}>{props.type}</Type>
   </Wrapper>
 );
-
-Option.propTypes = {
-  immatriculation: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
-  focussed: PropTypes.bool
-};
 
 export default Option;


### PR DESCRIPTION
## Summary

First in a per-component migration from PropTypes to TypeScript `interface Props`. Converts `src/components/AircraftDropdown/Option.tsx` — a small, leaf, self-contained component — and sets the pattern for the remaining ~97 PropTypes-using files.

## The pattern

- Write a TS \`interface Props\` matching the component's actual prop shape.
- Type the signature: \`(props: Props)\` or destructure with \`: Props\`.
- Drop the \`import PropTypes from 'prop-types'\` and the \`.propTypes = {}\` block.

Where the existing PropTypes schema is out of date vs the real call sites, each PR updates the interface to reflect reality (often tightening types the component actually relies on).

## Why per-component

Mechanical batch conversion was attempted and abandoned (~100 files touched, ~100 typecheck errors surfaced from stale PropTypes schemas that didn't match actual Redux state or call-site data). Per-component migration:

- Each PR stays small and reviewable.
- Props interfaces are thought through once, properly, based on the actual usage — not a literal translation of a schema that may be wrong.
- \`prop-types\` remains as a runtime safety net during the transition.
- The \`prop-types\` dependency drops at the end, once the last component lands.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 191 suites / 2100 tests pass
- [ ] CI verifies on GitHub

## Follow-up

~97 more components to migrate. Good next candidates (small, self-contained leaves): other \`*/Option.tsx\` files, \`MonthDropdown\`, \`SingleSelect/Item\`, etc.