### PR TITLE
Drop node-fetch dependency in favor of Node 20 native fetch

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,7 +12,6 @@
         "firebase-admin": "^12.0.0",
         "firebase-functions": "^4.7.0",
         "moment": "^2.22.2",
-        "node-fetch": "^2.6.7",
         "nodemailer": "^6.9.0",
         "request-promise": "^4.2.6",
         "soap": "^1.6.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,6 @@
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^4.7.0",
     "moment": "^2.22.2",
-    "node-fetch": "^2.6.7",
     "nodemailer": "^6.9.0",
     "request-promise": "^4.2.6",
     "soap": "^1.6.0"

--- a/functions/updateAerodromes.js
+++ b/functions/updateAerodromes.js
@@ -1,6 +1,5 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
-const fetch = require('node-fetch');
 
 const AERODROMES_URL = 'https://raw.githubusercontent.com/odch/aerodromes/refs/heads/main/aerodromes.json';
 const SCHEDULE = '0 3 * * 3'; // Every Wednesday at 3 AM

--- a/functions/updateAerodromes.spec.js
+++ b/functions/updateAerodromes.spec.js
@@ -37,8 +37,8 @@ jest.mock('firebase-admin', () => ({
   )
 }));
 
-jest.mock('node-fetch');
-const fetch = require('node-fetch');
+const fetch = jest.fn();
+global.fetch = fetch;
 
 require('./updateAerodromes');
 

--- a/functions/updateAircraftList.js
+++ b/functions/updateAircraftList.js
@@ -1,6 +1,5 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
-const fetch = require('node-fetch');
 
 // Note: this map must be kept in sync with the list in `aircraftCategories.js`.
 const aircraftCategoryMap = {

--- a/functions/updateAircraftList.spec.js
+++ b/functions/updateAircraftList.spec.js
@@ -40,8 +40,8 @@ jest.mock('firebase-admin', () => ({
   )
 }));
 
-jest.mock('node-fetch');
-const fetch = require('node-fetch');
+const fetch = jest.fn();
+global.fetch = fetch;
 
 // Load module after mocks are set up - this triggers onRun registration
 require('./updateAircraftList');


### PR DESCRIPTION
## Summary

Cloud Functions run on Node 20 (per `CLAUDE.md`), which exposes `fetch` globally. Drop the direct `node-fetch` dep and use the native binding.

## Changes

- `updateAerodromes.js` / `updateAircraftList.js`: remove `const fetch = require('node-fetch');` — the global works in its place with no code changes inside the files.
- `updateAerodromes.spec.js` / `updateAircraftList.spec.js`: switch from `jest.mock('node-fetch')` + `require('node-fetch')` to a `global.fetch = jest.fn()` stub. Same `fetch.mockResolvedValue(...)` API at call sites — no test body changes.
- `functions/package.json`: drop the direct `node-fetch` dep.

`node-fetch` still appears in `functions/node_modules` as a transitive dep of `firebase-admin` / `google-gax` / etc., but we no longer depend on it directly. That can go away naturally as those upstream packages finish migrating to native fetch.

## Test plan

- [x] `npm run test:functions` — 33 suites / 284 tests pass
- [x] `npm run typecheck` — clean (unaffected)
- [ ] CI verifies on GitHub