### PR TITLE
Upgrade firebase-functions from 4 to 6

### DIFF
--- a/functions/anonymizeMovements.js
+++ b/functions/anonymizeMovements.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
 const SCHEDULE = '0 2 * * *'; // Every day at 2 AM

--- a/functions/anonymizeMovements.spec.js
+++ b/functions/anonymizeMovements.spec.js
@@ -19,7 +19,7 @@ jest.mock('firebase-admin', () => ({
   initializeApp: jest.fn(),
 }));
 
-jest.mock('firebase-functions', () => ({
+jest.mock('firebase-functions/v1', () => ({
   region: jest.fn().mockReturnThis(),
   pubsub: {
     schedule: jest.fn().mockReturnValue({

--- a/functions/api/basicAuth.js
+++ b/functions/api/basicAuth.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 
 const config = functions.config();
 

--- a/functions/api/basicAuth.spec.js
+++ b/functions/api/basicAuth.spec.js
@@ -18,7 +18,7 @@ describe('functions/api/basicAuth', () => {
 
     beforeEach(() => {
       jest.resetModules();
-      jest.mock('firebase-functions', () => ({
+      jest.mock('firebase-functions/v1', () => ({
         config: jest.fn(() => ({})),
       }));
       basicAuth = require('./basicAuth');
@@ -39,7 +39,7 @@ describe('functions/api/basicAuth', () => {
 
     beforeEach(() => {
       jest.resetModules();
-      jest.mock('firebase-functions', () => ({
+      jest.mock('firebase-functions/v1', () => ({
         config: jest.fn(() => ({ api: { serviceuser: { password: 'pass' } } })),
       }));
       basicAuth = require('./basicAuth');
@@ -59,7 +59,7 @@ describe('functions/api/basicAuth', () => {
 
     beforeEach(() => {
       jest.resetModules();
-      jest.mock('firebase-functions', () => ({
+      jest.mock('firebase-functions/v1', () => ({
         config: jest.fn(() => ({ api: { serviceuser: { username: 'user' } } })),
       }));
       basicAuth = require('./basicAuth');
@@ -79,7 +79,7 @@ describe('functions/api/basicAuth', () => {
 
     beforeEach(() => {
       jest.resetModules();
-      jest.mock('firebase-functions', () => ({
+      jest.mock('firebase-functions/v1', () => ({
         config: jest.fn(() => ({
           api: { serviceuser: { username: 'admin', password: 's3cret' } },
         })),

--- a/functions/api/index.js
+++ b/functions/api/index.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 const express = require('express')
 const cors = require('cors')({origin: true, credentials: true})

--- a/functions/associatedMovements/setAssociatedMovementsTriggers.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 const utils = require('./utils')
 

--- a/functions/associatedMovements/setAssociatedMovementsTriggers.spec.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.spec.js
@@ -2,7 +2,7 @@
 
 const mockCapturedHandlers = {};
 
-jest.mock('firebase-functions', () => {
+jest.mock('firebase-functions/v1', () => {
   const makeDbRef = (path) => ({
     onCreate: jest.fn(handler => {
       mockCapturedHandlers[`onCreate:${path}`] = handler;

--- a/functions/auth/cleanupExpiredSignInCodes.js
+++ b/functions/auth/cleanupExpiredSignInCodes.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
 const MAX_ATTEMPTS = 5;

--- a/functions/auth/cleanupExpiredSignInCodes.spec.js
+++ b/functions/auth/cleanupExpiredSignInCodes.spec.js
@@ -34,7 +34,7 @@ describe('functions', () => {
       mockFunctions.region = jest.fn(() => mockFunctions);
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
 
       require('./cleanupExpiredSignInCodes');
     });

--- a/functions/auth/cleanupExpiredWebauthnChallenges.js
+++ b/functions/auth/cleanupExpiredWebauthnChallenges.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
 exports.cleanupExpiredWebauthnChallenges = functions

--- a/functions/auth/cleanupExpiredWebauthnChallenges.spec.js
+++ b/functions/auth/cleanupExpiredWebauthnChallenges.spec.js
@@ -34,7 +34,7 @@ describe('functions', () => {
       mockFunctions.region = jest.fn(() => mockFunctions);
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
 
       require('./cleanupExpiredWebauthnChallenges');
     });

--- a/functions/auth/createTestEmailToken.js
+++ b/functions/auth/createTestEmailToken.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const cors = require('cors')({origin: true});
 

--- a/functions/auth/generateAuthenticationOptions.js
+++ b/functions/auth/generateAuthenticationOptions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
 const { generateAuthenticationOptions } = require('@simplewebauthn/server');

--- a/functions/auth/generateAuthenticationOptions.spec.js
+++ b/functions/auth/generateAuthenticationOptions.spec.js
@@ -46,7 +46,7 @@ describe('functions', () => {
       });
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
       jest.mock('cors', () => () => mockCors);
       jest.mock('@simplewebauthn/server', () => ({
         generateAuthenticationOptions: mockGenerateAuthenticationOptions,

--- a/functions/auth/generateRegistrationOptions.js
+++ b/functions/auth/generateRegistrationOptions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
 const { generateRegistrationOptions } = require('@simplewebauthn/server');

--- a/functions/auth/generateRegistrationOptions.spec.js
+++ b/functions/auth/generateRegistrationOptions.spec.js
@@ -49,7 +49,7 @@ describe('functions', () => {
       });
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
       jest.mock('cors', () => () => mockCors);
       jest.mock('@simplewebauthn/server', () => ({
         generateRegistrationOptions: mockGenerateRegistrationOptions,

--- a/functions/auth/generateSignInCode.js
+++ b/functions/auth/generateSignInCode.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const crypto = require('crypto');
 const cors = require('cors')({origin: true});

--- a/functions/auth/generateSignInCode.spec.js
+++ b/functions/auth/generateSignInCode.spec.js
@@ -32,7 +32,7 @@ describe('functions', () => {
       mockSendSignInEmail = jest.fn().mockResolvedValue('msg123');
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
       jest.mock('cors', () => () => mockCors);
       jest.mock('./sendSignInEmail', () => ({ sendSignInEmail: mockSendSignInEmail }));
 

--- a/functions/auth/generateSignInLink.js
+++ b/functions/auth/generateSignInLink.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const cors = require('cors')({origin: true});
 

--- a/functions/auth/generateSignInLink.spec.js
+++ b/functions/auth/generateSignInLink.spec.js
@@ -25,7 +25,7 @@ describe('functions', () => {
       mockFunctions.region = jest.fn(() => mockFunctions);
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
       jest.mock('cors', () => () => mockCors);
 
       require('./generateSignInLink');

--- a/functions/auth/index.js
+++ b/functions/auth/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const cors = require('cors')({
   origin: true,

--- a/functions/auth/modes/flightnet/index.js
+++ b/functions/auth/modes/flightnet/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const flightnet = require('./flightnet');
 const requestHelper = require('../../util/requestHelper');
 

--- a/functions/auth/modes/flightnet/index.spec.js
+++ b/functions/auth/modes/flightnet/index.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-jest.mock('firebase-functions', () => ({
+jest.mock('firebase-functions/v1', () => ({
   config: jest.fn(() => ({}))
 }));
 

--- a/functions/auth/modes/ip/index.js
+++ b/functions/auth/modes/ip/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const requestHelper = require('../../util/requestHelper');
 
 let ips = [];

--- a/functions/auth/removePasskey.js
+++ b/functions/auth/removePasskey.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
 const {

--- a/functions/auth/removePasskey.spec.js
+++ b/functions/auth/removePasskey.spec.js
@@ -31,7 +31,7 @@ describe('functions', () => {
       mockVerifyRecentAuth = jest.fn();
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
       jest.mock('cors', () => () => mockCors);
       jest.mock('./webauthnHelpers', () => {
         class AuthError extends Error {

--- a/functions/auth/verifyAuthentication.js
+++ b/functions/auth/verifyAuthentication.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
 const { verifyAuthenticationResponse } = require('@simplewebauthn/server');

--- a/functions/auth/verifyAuthentication.spec.js
+++ b/functions/auth/verifyAuthentication.spec.js
@@ -49,7 +49,7 @@ describe('functions', () => {
       });
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
       jest.mock('cors', () => () => mockCors);
       jest.mock('@simplewebauthn/server', () => ({
         verifyAuthenticationResponse: mockVerifyAuthenticationResponse,

--- a/functions/auth/verifyRegistration.js
+++ b/functions/auth/verifyRegistration.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
 const { verifyRegistrationResponse } = require('@simplewebauthn/server');

--- a/functions/auth/verifyRegistration.spec.js
+++ b/functions/auth/verifyRegistration.spec.js
@@ -43,7 +43,7 @@ describe('functions', () => {
       });
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
       jest.mock('cors', () => () => mockCors);
       jest.mock('@simplewebauthn/server', () => ({
         verifyRegistrationResponse: mockVerifyRegistrationResponse,

--- a/functions/auth/verifySignInCode.js
+++ b/functions/auth/verifySignInCode.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const crypto = require('crypto');
 const cors = require('cors')({origin: true});

--- a/functions/auth/verifySignInCode.spec.js
+++ b/functions/auth/verifySignInCode.spec.js
@@ -50,7 +50,7 @@ describe('functions', () => {
       };
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
       jest.mock('cors', () => () => mockCors);
 
       require('./verifySignInCode');

--- a/functions/auth/webauthnHelpers.js
+++ b/functions/auth/webauthnHelpers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const crypto = require('crypto');
 

--- a/functions/auth/webauthnHelpers.spec.js
+++ b/functions/auth/webauthnHelpers.spec.js
@@ -37,7 +37,7 @@ describe('functions', () => {
       };
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
 
       helpers = require('./webauthnHelpers');
     });

--- a/functions/cleanupMessages.js
+++ b/functions/cleanupMessages.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
 const SCHEDULE = '0 2 * * *'; // Every day at 2 AM

--- a/functions/cleanupMessages.spec.js
+++ b/functions/cleanupMessages.spec.js
@@ -17,7 +17,7 @@ jest.mock('firebase-admin', () => ({
   initializeApp: jest.fn(),
 }));
 
-jest.mock('firebase-functions', () => ({
+jest.mock('firebase-functions/v1', () => ({
   region: jest.fn().mockReturnThis(),
   pubsub: {
     schedule: jest.fn().mockReturnValue({

--- a/functions/enrichMovements.js
+++ b/functions/enrichMovements.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
 const getEnrichedData = (aerodromeSnapshot, icaoCode) => {

--- a/functions/enrichMovements.spec.js
+++ b/functions/enrichMovements.spec.js
@@ -3,7 +3,7 @@
 // Capture handlers registered by the module
 const mockCapturedHandlers = {};
 
-jest.mock('firebase-functions', () => {
+jest.mock('firebase-functions/v1', () => {
   const makeRef = (handlers) => (path) => ({
     onCreate: jest.fn(handler => {
       const key = `onCreate:${path}`;

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
 const config = functions.config()

--- a/functions/invoiceRecipients/invoiceRecipientsTrigger.js
+++ b/functions/invoiceRecipients/invoiceRecipientsTrigger.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 
 const instance = functions.config().rtdb.instance

--- a/functions/invoiceRecipients/invoiceRecipientsTrigger.spec.js
+++ b/functions/invoiceRecipients/invoiceRecipientsTrigger.spec.js
@@ -2,7 +2,7 @@
 
 let capturedHandler;
 
-jest.mock('firebase-functions', () => {
+jest.mock('firebase-functions/v1', () => {
   const mock = {
     config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
     database: {
@@ -30,7 +30,7 @@ describe('functions/invoiceRecipients/invoiceRecipientsTrigger', () => {
     jest.clearAllMocks();
     capturedHandler = null;
 
-    jest.mock('firebase-functions', () => {
+    jest.mock('firebase-functions/v1', () => {
       const mock = {
         config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
         database: {

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -1,0 +1,10 @@
+// Jest 24 predates Node's `exports` field support in package.json.
+// firebase-functions@6 exposes gen1 APIs only via its `./v1` export
+// subpath, which jest-resolve cannot follow without an explicit map.
+// Remove this mapping once jest is upgraded to 28+.
+module.exports = {
+  moduleNameMapper: {
+    '^firebase-functions/v1$':
+      '<rootDir>/node_modules/firebase-functions/lib/v1/index.js',
+  },
+};

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,7 +10,7 @@
         "@simplewebauthn/server": "^10.0.1",
         "cors": "^2.8.4",
         "firebase-admin": "^12.0.0",
-        "firebase-functions": "^4.7.0",
+        "firebase-functions": "^6.0.0",
         "moment": "^2.22.2",
         "nodemailer": "^6.9.0",
         "request-promise": "^4.2.6",
@@ -1162,20 +1162,21 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/serve-static": "*"
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
-      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1234,6 +1235,12 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -1303,12 +1310,23 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -3637,15 +3655,15 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-4.9.0.tgz",
-      "integrity": "sha512-IqxOEsVAWGcRv9KRGzWQR5mOFuNsil3vsfkRPPiaV1U/ATC27/jbahh4z8I4rW8Xqa6cQE5xqnw0ueyMH7i7Ag==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.6.0.tgz",
+      "integrity": "sha512-wwfo6JF+N7HUExVs5gUFgkgVGHDEog9O+qtouh7IuJWk8TBQ+KwXEgRiXbatSj7EbTu3/yYnHuzh3XExbfF6wQ==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
-        "@types/express": "4.17.3",
+        "@types/express": "^4.17.21",
         "cors": "^2.8.5",
-        "express": "^4.17.1",
+        "express": "^4.21.0",
         "protobufjs": "^7.2.2"
       },
       "bin": {
@@ -3655,7 +3673,7 @@
         "node": ">=14.10.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^10.0.0 || ^11.0.0 || ^12.0.0"
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
       }
     },
     "node_modules/follow-redirects": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "@simplewebauthn/server": "^10.0.1",
     "cors": "^2.8.4",
     "firebase-admin": "^12.0.0",
-    "firebase-functions": "^4.7.0",
+    "firebase-functions": "^6.0.0",
     "moment": "^2.22.2",
     "nodemailer": "^6.9.0",
     "request-promise": "^4.2.6",

--- a/functions/updateAerodromes.js
+++ b/functions/updateAerodromes.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
 const AERODROMES_URL = 'https://raw.githubusercontent.com/odch/aerodromes/refs/heads/main/aerodromes.json';

--- a/functions/updateAerodromes.spec.js
+++ b/functions/updateAerodromes.spec.js
@@ -2,7 +2,7 @@
 
 let capturedOnRun;
 
-jest.mock('firebase-functions', () => {
+jest.mock('firebase-functions/v1', () => {
   const mock = {
     pubsub: {
       schedule: jest.fn(() => ({

--- a/functions/updateAircraftList.js
+++ b/functions/updateAircraftList.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
 // Note: this map must be kept in sync with the list in `aircraftCategories.js`.

--- a/functions/updateAircraftList.spec.js
+++ b/functions/updateAircraftList.spec.js
@@ -2,7 +2,7 @@
 
 let capturedOnRun;
 
-jest.mock('firebase-functions', () => ({
+jest.mock('firebase-functions/v1', () => ({
   region: jest.fn(() => ({
     pubsub: {
       schedule: jest.fn(() => ({

--- a/functions/updateArrivalPaymentStatus.js
+++ b/functions/updateArrivalPaymentStatus.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
 const instance = functions.config().rtdb.instance;

--- a/functions/updateArrivalPaymentStatus.spec.js
+++ b/functions/updateArrivalPaymentStatus.spec.js
@@ -26,7 +26,7 @@ describe('functions', () => {
       };
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions', () => mockFunctions);
+      jest.mock('firebase-functions/v1', () => mockFunctions);
 
       require('./updateArrivalPaymentStatus');
     });

--- a/functions/webhook/index.js
+++ b/functions/webhook/index.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 const request = require('request-promise');
 


### PR DESCRIPTION
## Summary

Bumps `firebase-functions` from `^4.7.0` (resolved 4.9.0) to `^6.0.0` (installs 6.6.0). This unblocks the upcoming `firebase-admin` 12 → 13 upgrade, which requires a firebase-functions version that accepts firebase-admin v13 as a peer — v6 is the first major that does.

## What changes

Starting in v5, firebase-functions' default package entrypoint flipped from gen1 to gen2. Our entire codebase uses **gen1** APIs — `functions.region(...)`, `.pubsub.schedule(...)`, `.https.onRequest(...)`, `.database.ref(...)`, `.logger.*`, `.config()`. These remain available under the `firebase-functions/v1` subpath.

The code change is a mechanical import-path rewrite across 48 source and spec files:

\`\`\`
require('firebase-functions')   →   require('firebase-functions/v1')
jest.mock('firebase-functions', …)  →  jest.mock('firebase-functions/v1', …)
\`\`\`

No API calls were rewritten; the gen1 surface is byte-for-byte the same.

## Why v6 and not v7

v7 removes `functions.config()`. We use it in three places (`index.js`, `updateArrivalPaymentStatus.js`, `enrichMovements.js`). Migrating to `firebase-functions/params` is a separate follow-up that deserves its own PR. Staying on v6 keeps `config()` available (deprecated but functional).

## Jest workaround — `functions/jest.config.js`

Jest 24 (our current version) predates Node's `exports` field support in `package.json`, so `jest.mock('firebase-functions/v1', ...)` fails with "Cannot find module". Added a `moduleNameMapper` that bridges the subpath to its actual file location:

\`\`\`js
moduleNameMapper: {
  '^firebase-functions/v1$':
    '<rootDir>/node_modules/firebase-functions/lib/v1/index.js',
}
\`\`\`

This affects jest only (production Node 22 resolves `exports` natively). The mapping can be removed once jest is upgraded to 28+.

## Regression risk & mitigation

Release-note review of v5, v6 (no v7):
- **v5.0.0**: internal only — multi-DB Firestore support, removed firebase-admin v10 compat. No gen1 surface changes.
- **v6.0.0**: entrypoint flip (handled by our import migration) + `@deprecated` annotation on `functions.config()` (type-level only; no runtime change).

The gen1 surface is intentionally preserved under `/v1` for exactly this scenario. Nothing in our `functions.{region,pubsub,https,database,logger,config}` usage shows up as a breaking change in any 5.x or 6.x release notes.

**What I can't prove from release notes**: subtle deployment-metadata or transitive-dep regressions. Required smoke test below is the real safety net.

## Test plan

- [x] `npm run test:functions` — 284/284 pass
- [x] Runtime shape check — all six gen1 APIs we use (`region`, `logger`, `config`, `https.onRequest`, `pubsub.schedule`, `database.ref`) are present with expected types under `firebase-functions/v1`
- [ ] **Required before merge**: deploy to `lszm` (test aerodrome) and exercise each trigger type:
  - HTTPS: sign-in via the web app — watch for `onRequest` handler errors
  - Scheduled: force-invoke `scheduledAerodromesUpdate` or `anonymizeMovements` from the Firebase console
  - Database trigger: create/update a movement so `enrichMovements` fires
  - Module load: deploy output itself will fail fast if any function can't initialize

Watch logs for: module-load errors, missing `.region`/`.pubsub`/`.https` methods, unexpected `config()` shapes, or deprecation noise louder than background.

**Rollback**: single-line revert of `functions/package.json` + `git checkout functions/` restores v4 behavior.

## Rollout (post-merge)

1. Deploy to `lszm` first
2. Observe 24–48h across at least one scheduled-function cycle
3. If clean, roll to other aerodromes (`lszt`, `lspv`, `lsze`, `lszk`, `lszo`)

## Unblocks

- `firebase-admin` 12 → 13 becomes a trivial follow-up (pure version bump)
- v6 → v7 can be planned once `config()` → `params` migration is done

## Out of scope

- gen1 → gen2 migration (not deprecated yet; significant rewrite)
- `functions.config()` → `firebase-functions/params` (deprecated in v6, removed in v7)
- jest 24 → 28+ (would let us drop the moduleNameMapper; own PR)
- Other outdated deps in `functions/` (admin, @simplewebauthn, nodemailer)