### PR TITLE
Align LSPL landing fees with 2024 fee schedule

### DIFF
--- a/src/util/landingFeeStrategies/lspl.spec.ts
+++ b/src/util/landingFeeStrategies/lspl.spec.ts
@@ -1,0 +1,142 @@
+import lspl from './lspl'
+import {AircraftOrigin} from '../landingFees'
+
+describe('util', () => {
+  describe('landingFeeStrategies', () => {
+    describe('lspl', () => {
+      describe('getLandingFee ', () => {
+        describe.each([
+          // homebase plane / motorglider / self-launching glider — flat 7
+          [0, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 7],
+          [1000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 7],
+          [2000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 7],
+          [50000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 7],
+          [1000, 'private', AircraftOrigin.CLUB, 'Flugzeug', 7],
+          [1000, 'private', AircraftOrigin.HOME_BASE, 'Motorsegler', 7],
+          [1000, 'private', AircraftOrigin.HOME_BASE, 'Eigenbauflugzeug', 7],
+
+          // homebase + instruction — also flat 7 (no special instruction rule)
+          [1000, 'instruction', AircraftOrigin.HOME_BASE, 'Flugzeug', 7],
+          [1000, 'instruction', AircraftOrigin.CLUB, 'Flugzeug', 7],
+          [2000, 'instruction', AircraftOrigin.HOME_BASE, 'Flugzeug', 7],
+
+          // homebase glider self-launch / winch — flat 7
+          [0, 'glider_private_self', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 7],
+          [0, 'glider_private_winch', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 7],
+          [0, 'glider_instruction_self', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 7],
+          [0, 'glider_instruction_winch', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 7],
+
+          // homebase helicopter — flat 7 (extending homebase rule)
+          [0, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 7],
+          [2000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 7],
+          [1000, 'instruction', AircraftOrigin.HOME_BASE, 'Eigenbauhubschrauber', 7],
+
+          // non-homebase plane / motorglider / glider — MTOW scale (gross 20 / 25)
+          [0, 'private', AircraftOrigin.OTHER, 'Flugzeug', 18.5],
+          [500, 'private', AircraftOrigin.OTHER, 'Flugzeug', 18.5],
+          [1000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 18.5],
+          [1001, 'private', AircraftOrigin.OTHER, 'Flugzeug', 23.13],
+          [2000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 23.13],
+          [50000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 23.13],
+          [50001, 'private', AircraftOrigin.OTHER, 'Flugzeug', undefined],
+          [800, 'private', AircraftOrigin.OTHER, 'Motorsegler', 18.5],
+          [1500, 'private', AircraftOrigin.OTHER, 'Motorsegler', 23.13],
+          [0, 'glider_private_self', AircraftOrigin.OTHER, 'Segelflugzeug', 18.5],
+          [0, 'glider_private_winch', AircraftOrigin.OTHER, 'Segelflugzeug', 18.5],
+
+          // non-homebase external instruction — same MTOW scale (no special rule)
+          [800, 'instruction', AircraftOrigin.OTHER, 'Flugzeug', 18.5],
+          [2000, 'instruction', AircraftOrigin.OTHER, 'Flugzeug', 23.13],
+
+          // non-homebase helicopter — uses MTOW scale like planes
+          [800, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 18.5],
+          [1500, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 23.13],
+          [50000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 23.13],
+          [50001, 'private', AircraftOrigin.OTHER, 'Hubschrauber', undefined],
+          [1000, 'private', AircraftOrigin.OTHER, 'Eigenbauhubschrauber', 18.5],
+
+          // aerotow tug — flat 8 regardless of MTOW or origin
+          [800, 'aerotow', AircraftOrigin.HOME_BASE, 'Flugzeug', 8],
+          [800, 'aerotow', AircraftOrigin.CLUB, 'Flugzeug', 8],
+          [800, 'aerotow', AircraftOrigin.OTHER, 'Flugzeug', 8],
+          [2000, 'aerotow', AircraftOrigin.OTHER, 'Flugzeug', 8],
+
+          // aerotowed glider — no fee (covered by tug)
+          [0, 'glider_private_aerotow', AircraftOrigin.HOME_BASE, 'Segelflugzeug', undefined],
+          [0, 'glider_private_aerotow', AircraftOrigin.OTHER, 'Segelflugzeug', undefined],
+          [0, 'glider_instruction_aerotow', AircraftOrigin.HOME_BASE, 'Segelflugzeug', undefined],
+          [0, 'glider_instruction_aerotow', AircraftOrigin.OTHER, 'Segelflugzeug', undefined],
+
+          // hot air balloon — flat 20 (gross) per movement, regardless of origin / flight type
+          [0, 'private', AircraftOrigin.OTHER, 'Ballon (Heissluft)', 18.5],
+          [0, 'private', AircraftOrigin.HOME_BASE, 'Ballon (Heissluft)', 18.5],
+          [0, 'private', AircraftOrigin.OTHER, 'Ballon (Gas)', 18.5],
+          [0, 'private', AircraftOrigin.OTHER, 'Luftschiff (Heissluft)', 18.5],
+        ])(
+          'getLandingFee(%i, %s, %s, %s)',
+          (mtow, flightType, aircraftOrigin, aircraftCategory, expected) => {
+            test(`returns ${expected}`, () => {
+              const landingFee = lspl.getLandingFee(mtow, flightType, aircraftOrigin, aircraftCategory)
+              if (expected === undefined) {
+                expect(landingFee).toBe(undefined)
+              } else {
+                expect(landingFee!.fee).toBe(expected)
+              }
+            })
+          }
+        )
+      })
+
+      describe('getGoAroundFee', () => {
+        it('always returns undefined', () => {
+          expect(lspl.getGoAroundFee(0, 'private', AircraftOrigin.OTHER, 'Flugzeug')).toBeUndefined()
+          expect(lspl.getGoAroundFee(1000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug')).toBeUndefined()
+          expect(lspl.getGoAroundFee(800, 'aerotow', AircraftOrigin.HOME_BASE, 'Flugzeug')).toBeUndefined()
+          expect(lspl.getGoAroundFee(0, 'glider_private_aerotow', AircraftOrigin.HOME_BASE, 'Segelflugzeug')).toBeUndefined()
+          expect(lspl.getGoAroundFee(0, 'private', AircraftOrigin.OTHER, 'Ballon (Heissluft)')).toBeUndefined()
+        })
+      })
+
+      describe('getVatRate ', () => {
+        describe.each([
+          // homebase → 0
+          ['private', AircraftOrigin.HOME_BASE, 'Flugzeug', 0],
+          ['private', AircraftOrigin.CLUB, 'Flugzeug', 0],
+          ['instruction', AircraftOrigin.HOME_BASE, 'Flugzeug', 0],
+          ['instruction', AircraftOrigin.CLUB, 'Flugzeug', 0],
+          ['private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 0],
+          ['private', AircraftOrigin.HOME_BASE, 'Motorsegler', 0],
+          ['glider_private_self', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 0],
+          ['glider_private_winch', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 0],
+
+          // aerotow (any origin) → 0 (member tow service)
+          ['aerotow', AircraftOrigin.HOME_BASE, 'Flugzeug', 0],
+          ['aerotow', AircraftOrigin.OTHER, 'Flugzeug', 0],
+          ['glider_private_aerotow', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 0],
+          ['glider_instruction_aerotow', AircraftOrigin.OTHER, 'Segelflugzeug', 0],
+
+          // non-homebase → 8.1
+          ['private', AircraftOrigin.OTHER, 'Flugzeug', 8.1],
+          ['instruction', AircraftOrigin.OTHER, 'Flugzeug', 8.1],
+          ['private', AircraftOrigin.OTHER, 'Hubschrauber', 8.1],
+          ['private', AircraftOrigin.OTHER, 'Motorsegler', 8.1],
+          ['glider_private_self', AircraftOrigin.OTHER, 'Segelflugzeug', 8.1],
+          ['glider_private_winch', AircraftOrigin.OTHER, 'Segelflugzeug', 8.1],
+
+          // balloon → 8.1 regardless of origin
+          ['private', AircraftOrigin.OTHER, 'Ballon (Heissluft)', 8.1],
+          ['private', AircraftOrigin.HOME_BASE, 'Ballon (Heissluft)', 8.1],
+          ['private', AircraftOrigin.OTHER, 'Ballon (Gas)', 8.1],
+          ['private', AircraftOrigin.OTHER, 'Luftschiff (Heissluft)', 8.1],
+        ])(
+          'getVatRate(%s, %s, %s)',
+          (flightType, aircraftOrigin, aircraftCategory, expected) => {
+            test(`returns ${expected}`, () => {
+              expect(lspl.getVatRate(flightType, aircraftOrigin, aircraftCategory)).toBe(expected)
+            })
+          }
+        )
+      })
+    })
+  })
+})

--- a/src/util/landingFeeStrategies/lspl.ts
+++ b/src/util/landingFeeStrategies/lspl.ts
@@ -1,11 +1,19 @@
 import {AircraftOrigin} from '../landingFees'
 import data from './lspl_data.json'
-import {isHelicopter} from '../aircraftCategories'
 import {getMtowFee} from './utils'
+
+const BALLOON_CATEGORIES = ['Ballon (Heissluft)', 'Ballon (Gas)', 'Luftschiff (Heissluft)']
+const GLIDER_AEROTOW_RE = /^glider_(instruction|private)_aerotow$/
+
+const isBalloon = (aircraftCategory: string) => BALLOON_CATEGORIES.includes(aircraftCategory)
+const isAerotowTug = (flightType: string) => flightType === 'aerotow'
+const isAerotowedGlider = (flightType: string) => GLIDER_AEROTOW_RE.test(flightType)
+const isHomebaseOrigin = (aircraftOrigin: any) =>
+  aircraftOrigin === AircraftOrigin.HOME_BASE || aircraftOrigin === AircraftOrigin.CLUB
 
 const getLandingFee = (mtow: number, flightType: string, aircraftOrigin: any, aircraftCategory: string) => {
   const fee = getFee(mtow, flightType, aircraftOrigin, aircraftCategory)
-  if (fee) {
+  if (typeof fee === 'number') {
     return {fee}
   }
   return undefined
@@ -15,29 +23,35 @@ const getGoAroundFee = (mtow: number, flightType: string, aircraftOrigin: any, a
   undefined
 
 const getFee = (mtow: number, flightType: string, aircraftOrigin: any, aircraftCategory: string) => {
-  const isHomebase = aircraftOrigin === AircraftOrigin.HOME_BASE || aircraftOrigin === AircraftOrigin.CLUB
-  const isInstruction = flightType === 'instruction'
-  const isHeli = isHelicopter(aircraftCategory)
-
-  if (isHeli) {
-    return getMtowFee(data.fees.helicopter, mtow)
+  if (isBalloon(aircraftCategory)) {
+    return data.fees.balloon
   }
 
-  if (isInstruction) {
-    if (isHomebase) {
-      return data.fees.instruction_homebase
-    }
-    return data.fees.instruction_external
+  if (isAerotowTug(flightType)) {
+    return data.fees.aerotow
+  }
+
+  if (isAerotowedGlider(flightType)) {
+    return undefined
+  }
+
+  if (isHomebaseOrigin(aircraftOrigin)) {
+    return data.fees.plane_homebase
   }
 
   return getMtowFee(data.fees.plane, mtow)
 }
 
 const getVatRate = (flightType: string, aircraftOrigin: any, aircraftCategory: string) => {
-  const isHomebase = aircraftOrigin === AircraftOrigin.HOME_BASE || aircraftOrigin === AircraftOrigin.CLUB
-  const isInstruction = flightType === 'instruction'
+  if (isBalloon(aircraftCategory)) {
+    return 8.1
+  }
 
-  if (isHomebase && isInstruction) {
+  if (isAerotowTug(flightType) || isAerotowedGlider(flightType)) {
+    return 0
+  }
+
+  if (isHomebaseOrigin(aircraftOrigin)) {
     return 0
   }
 

--- a/src/util/landingFeeStrategies/lspl_data.json
+++ b/src/util/landingFeeStrategies/lspl_data.json
@@ -4,10 +4,8 @@
       { "max_weight": 1000, "fee": 18.5 },
       { "max_weight": 50000, "fee": 23.13 }
     ],
-    "instruction_homebase": 18.5,
-    "instruction_external": 18.5,
-    "helicopter": [
-      { "max_weight": 50000, "fee": 23.13 }
-    ]
+    "plane_homebase": 7,
+    "aerotow": 8,
+    "balloon": 18.5
   }
 }


### PR DESCRIPTION
## Summary

Aligns the LSPL landing fee strategy with the Aero-Club Regionalverband Langenthal published fee schedule (Gebühren und Mitgliederbeiträge 2024).

**Fee changes (gross / VAT):**

| Category | Gross | VAT |
|---|---|---|
| Homebase (all categories incl. instruction) | 7 CHF | 0 % |
| Aerotow tug (towed glider has no separate fee) | 8 CHF | 0 % |
| Non-homebase ≤ 1000 kg | 20 CHF | 8.1 % |
| Non-homebase > 1000 kg | 25 CHF | 8.1 % |
| Hot-air balloon (per landing) | 20 CHF | 8.1 % |

**Behavior changes:**
- Add homebase 7 CHF flat fee with 0% VAT under the Swiss member-services exemption (Art. 21 Abs. 2 Ziff. 13 MWSTG).
- Add Schleppzug (aerotow) handling: tug pays 8 CHF, towed glider gets no separate fee — mirrors the existing lszm pattern.
- Add Heissluftballon handling (`Ballon (Heissluft)`, `Ballon (Gas)`, `Luftschiff (Heissluft)`).
- Drop the separate single-tier helicopter table; helicopters now use the plane MTOW scale.
- Drop stale flat instruction fees that were not in the PDF.

**Airla maintenance flights:** no fee-strategy change. Charged regularly; the 0-CHF arrangement is handled by selecting `Airla` as the invoice recipient.

## Open questions for the club (before merging)

1. Confirm with accountant: 0 % VAT on all homebase movements (member-services exemption).
2. Confirm homebase helicopter and winch-glider get the same 7 CHF (PDF doesn't explicitly say).
3. Verify `Airla` is set up as an invoice recipient in LSPL Firebase data.
4. Balloon: PDF says "pro Start und Landung" but Flightbox only charges landings — is the start portion handled manually, or should this be addressed?
5. Cross-check with a recent invoice to validate the new amounts match current practice.

## Test plan

- [x] `npm test -- src/util/landingFeeStrategies/lspl.spec.ts` (70/70 pass, 100% coverage on lspl.ts)
- [x] `npm run typecheck` (no errors)
- [x] Broader landing-fee tests (273/273 pass)
- [ ] Manual smoke test in dev (`npm start --project=lspl`): walk a movement wizard for each scenario in the matrix above and confirm the displayed gross + VAT match.
- [ ] Confirm open questions above with the club before merge.