### PR TITLE
Add cash payments page to invoices report

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -576,6 +576,7 @@
   },
   "invoicesReport": {
     "onlinePayments": "Online-Zahlungen",
+    "cashPayments": "Bar-Zahlungen",
     "noRecipients": "Keine Rechnungsempfänger im ausgewählten Zeitraum ({{month}})",
     "landingFees": "Landetaxen",
     "customsFees": "Zollgebühren",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -576,6 +576,7 @@
   },
   "invoicesReport": {
     "onlinePayments": "Online payments",
+    "cashPayments": "Cash payments",
     "noRecipients": "No invoice recipients in the selected period ({{month}})",
     "landingFees": "Landing fees",
     "customsFees": "Customs fees",

--- a/src/util/InvoicesReport.spec.ts
+++ b/src/util/InvoicesReport.spec.ts
@@ -204,10 +204,22 @@ describe('util', () => {
         expect(groups[keys[0]]).toHaveLength(1);
       });
 
-      it('ignores arrivals with unsupported payment method (cash)', () => {
+      it('groups cash arrivals under CASH_RECIPIENT_NAME', () => {
         const report = makeReport(2023, 6);
         const localArrivals = [{
           paymentMethod: {method: 'cash'},
+        }];
+        const groups = report.groupArrivalsByRecipient(localArrivals);
+        const keys = Object.keys(groups);
+        expect(keys).toHaveLength(1);
+        expect(keys[0]).toBe('Bar-Zahlungen');
+        expect(groups[keys[0]]).toHaveLength(1);
+      });
+
+      it('ignores arrivals with unsupported payment method', () => {
+        const report = makeReport(2023, 6);
+        const localArrivals = [{
+          paymentMethod: {method: 'twint_external'},
         }];
         const groups = report.groupArrivalsByRecipient(localArrivals);
         expect(Object.keys(groups)).toHaveLength(0);
@@ -570,6 +582,47 @@ describe('util', () => {
         const content = report.buildContent(arrivalsSnapshot, [], []);
         const firstHeader = content[0];
         expect(firstHeader.text).toContain('Online-Zahlungen');
+      });
+
+      it('places CASH_RECIPIENT_NAME after Online-Zahlungen and before alphabetical recipients', () => {
+        const report = makeReport(2023, 6);
+        const arrivalsSnapshot = makeArrivalsSnapshot([
+          {
+            date: '2023-06-01', time: '10:00',
+            immatriculation: 'HB-AAA', mtow: 750, flightType: 'private',
+            firstname: 'A', lastname: 'A', email: 'a@example.com',
+            feeTotalNet: 10, feeVat: 1, feeRoundingDifference: 0, feeTotalGross: 11,
+            paymentMethod: {method: 'invoice', status: 'paid', invoiceRecipientName: 'AAA Company'},
+          },
+          {
+            date: '2023-06-02', time: '11:00',
+            immatriculation: 'HB-CASH', mtow: 750, flightType: 'private',
+            firstname: 'C', lastname: 'C', email: 'c@example.com',
+            feeTotalNet: 10, feeVat: 1, feeRoundingDifference: 0, feeTotalGross: 11,
+            paymentMethod: {method: 'cash'},
+          },
+        ]);
+        const content = report.buildContent(arrivalsSnapshot, [], []);
+        const headers = content.filter(item => item && item.style === 'header');
+        expect(headers[0].text).toContain('Online-Zahlungen');
+        expect(headers[1].text).toContain('Bar-Zahlungen');
+        expect(headers[2].text).toContain('AAA Company');
+      });
+
+      it('omits Bar-Zahlungen header when there are no cash arrivals', () => {
+        const report = makeReport(2023, 6);
+        const arrivalsSnapshot = makeArrivalsSnapshot([
+          {
+            date: '2023-06-01', time: '10:00',
+            immatriculation: 'HB-AAA', mtow: 750, flightType: 'private',
+            firstname: 'A', lastname: 'A', email: 'a@example.com',
+            feeTotalNet: 10, feeVat: 1, feeRoundingDifference: 0, feeTotalGross: 11,
+            paymentMethod: {method: 'invoice', status: 'paid', invoiceRecipientName: 'AAA Company'},
+          },
+        ]);
+        const content = report.buildContent(arrivalsSnapshot, [], []);
+        const headers = content.filter(item => item && item.style === 'header');
+        expect(headers.some(h => h.text && h.text.toString().includes('Bar-Zahlungen'))).toBe(false);
       });
 
       it('adds pageBreak=before for recipients after the first', () => {

--- a/src/util/InvoicesReport.ts
+++ b/src/util/InvoicesReport.ts
@@ -21,6 +21,10 @@ class InvoicesReport {
     return t('invoicesReport.onlinePayments');
   }
 
+  get cashRecipientName() {
+    return t('invoicesReport.cashPayments');
+  }
+
 
   year: number;
   month: number;
@@ -119,9 +123,15 @@ class InvoicesReport {
       ...Object.keys(customsRecipients)
     ]))
 
-    // sort names, but this.checkoutRecipientName should always be the first
-    recipientNames = recipientNames.filter(name => name !== this.checkoutRecipientName)
+    // sort names; checkoutRecipientName always first, cashRecipientName second (when present)
+    const hasCash = arrivalRecipients[this.cashRecipientName] !== undefined
+    recipientNames = recipientNames.filter(
+      name => name !== this.checkoutRecipientName && name !== this.cashRecipientName
+    )
     recipientNames.sort()
+    if (hasCash) {
+      recipientNames.unshift(this.cashRecipientName)
+    }
     recipientNames.unshift(this.checkoutRecipientName)
 
     const monthLabel = this.getMonthLabel()
@@ -169,7 +179,9 @@ class InvoicesReport {
         ? arrival.paymentMethod.invoiceRecipientName
         : arrival.paymentMethod.method === 'checkout'
           ? this.checkoutRecipientName
-          : undefined
+          : arrival.paymentMethod.method === 'cash'
+            ? this.cashRecipientName
+            : undefined
 
       if (invoiceRecipientName) {
         if (!recipients[invoiceRecipientName]) {


### PR DESCRIPTION
## Summary

The monthly invoices report dropped cash-paid arrivals silently — only `invoice` and `checkout` payment methods were routed. Adds a dedicated **Bar-Zahlungen** page that lists cash arrivals for the period.

## Changes

- `InvoicesReport.ts`:
  - New `cashRecipientName` getter (mirrors `checkoutRecipientName`).
  - `groupArrivalsByRecipient` now routes `paymentMethod.method === 'cash'` to the cash recipient.
  - `buildContent` ordering: **Online-Zahlungen → Bar-Zahlungen → alphabetical recipients**. The Bar-Zahlungen header is only emitted when the month actually contains cash arrivals.
- `de.json` / `en.json`: new key `invoicesReport.cashPayments` ("Bar-Zahlungen" / "Cash payments").
- `InvoicesReport.spec.ts`: flipped the previous "ignores cash" test to "groups cash under Bar-Zahlungen", added an "ignores unsupported payment method" test (using `twint_external`), and added two `buildContent` ordering tests.

Other payment methods (`twint_external`, `card_external`, …) remain out of scope and continue to be skipped.

## Test plan

- [x] `npm test` (2173/2173 pass)
- [x] `npm run typecheck` (clean)
- [x] Coverage on `InvoicesReport.ts`: 99.2 % stmts / 95.74 % branches / 100 % funcs (the single uncovered line is a pre-existing dead `noRecipients` branch, not regression)
- [ ] Manual smoke test: generate an invoices report for a month with mixed payment methods (cash + checkout + invoice) and confirm the page order and totals.