### PR TITLE
Reset WebKit appearance on form inputs for iOS Safari

### DIFF
--- a/src/style/global-style.ts
+++ b/src/style/global-style.ts
@@ -37,6 +37,15 @@ const GlobalStyle = createGlobalStyle`
     color: #000;
     text-decoration: none;
   }
+
+  input:not([type="checkbox"]):not([type="radio"]):not([type="file"]):not([type="range"]):not([type="color"]),
+  textarea,
+  select {
+    -webkit-appearance: none;
+    appearance: none;
+    border-radius: 0;
+    box-sizing: border-box;
+  }
 `;
 
 export default GlobalStyle


### PR DESCRIPTION
## Summary

- Strip WebKit's default `-webkit-appearance` and `border-radius` from
  `input`, `textarea`, and `select` so iOS Safari stops rendering a
  rounded-corner artifact on inputs that use `border-bottom` only.
- Switch those elements to `box-sizing: border-box` so `width: 100%`
  honors the parent and doesn't overflow once UA padding is added.
- Checkbox / radio / file / range / color inputs are excluded so their
  native rendering is preserved.

The bug was visible on iPhone Safari and Brave (both use WebKit on
iOS) on the departure wizard's `Typ` and `Maximales Abfluggewicht`
fields, plus any other native input/textarea in the app. It does not
reproduce in DevTools mobile-sim mode because that uses Blink, not
WebKit.

## Test plan

- [x] iPhone Safari: departure wizard inputs render with a flat
      underline and stay within the viewport
- [ ] OTP digit inputs still render with their custom 8px radius
- [ ] Checkbox in `AirstatReportForm` and `FileInput` still use native
      rendering
- [ ] Desktop Brave/Chrome: no visual regression
- [x] `npm test` passes
- [x] `npm run typecheck` passes