### PR TITLE
Push homebased aircraft to customs app

### DIFF
--- a/functions/homebasedAircraft/homebasedAircraftTrigger.js
+++ b/functions/homebasedAircraft/homebasedAircraftTrigger.js
@@ -1,0 +1,52 @@
+const functions = require('firebase-functions/v1')
+const admin = require('firebase-admin')
+
+const instance = functions.config().rtdb.instance
+
+function buildBody(snapshot) {
+  const homeBase = (snapshot && snapshot.homeBase) || {}
+  const club = (snapshot && snapshot.club) || {}
+  const registrations = Array.from(new Set([...Object.keys(homeBase), ...Object.keys(club)]))
+  return registrations.map(registration => ({ registration }))
+}
+
+module.exports.updateCustomsHomebasedAircraftOnUpdate =
+  functions.region('europe-west1').database.instance(instance).ref('/settings/aircrafts')
+    .onWrite(async (change, context) => {
+      const beforeBody = buildBody(change.before.val())
+      const afterBody = buildBody(change.after.val())
+      const jsonBody = JSON.stringify(afterBody)
+
+      if (JSON.stringify(beforeBody) === jsonBody) {
+        console.log('No change detected.')
+        return
+      }
+
+      const snapshot = await admin.database().ref('/settings/customsDeclarationApp').once('value')
+      const customsSettings = snapshot.val()
+
+      if (!customsSettings || !customsSettings.baseUrl) {
+        console.log('No customs declaration settings in /settings/customsDeclarationApp. Aborting...')
+        return
+      }
+
+      const url = `${customsSettings.baseUrl}/api/homebased-aircraft?ad=${customsSettings.aerodrome}`
+
+      const response = await fetch(url, {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${customsSettings.accessToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: jsonBody
+      })
+
+      if (response.ok) {
+        console.log('Successfully updated homebased aircraft of the customs app')
+      } else {
+        console.log('Failed to update the homebased aircraft of the customs app', response)
+
+        const responseBody = await response.text().catch(() => '')
+        console.log('Response body', responseBody)
+      }
+    })

--- a/functions/homebasedAircraft/homebasedAircraftTrigger.spec.js
+++ b/functions/homebasedAircraft/homebasedAircraftTrigger.spec.js
@@ -1,0 +1,247 @@
+'use strict';
+
+let capturedHandler;
+
+jest.mock('firebase-functions/v1', () => {
+  const mock = {
+    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
+    database: {
+      instance: jest.fn(() => ({
+        ref: jest.fn(() => ({
+          onWrite: jest.fn(handler => { capturedHandler = handler; }),
+        })),
+      })),
+    },
+  };
+  mock.region = jest.fn(() => mock);
+  return mock;
+});
+
+const mockAdminDbRef = jest.fn();
+jest.mock('firebase-admin', () => ({
+  database: jest.fn(() => ({ ref: mockAdminDbRef })),
+}));
+
+global.fetch = jest.fn();
+
+describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    capturedHandler = null;
+
+    jest.mock('firebase-functions/v1', () => {
+      const mock = {
+        config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
+        database: {
+          instance: jest.fn(() => ({
+            ref: jest.fn(() => ({
+              onWrite: jest.fn(handler => { capturedHandler = handler; }),
+            })),
+          })),
+        },
+      };
+      mock.region = jest.fn(() => mock);
+      return mock;
+    });
+
+    jest.mock('firebase-admin', () => ({
+      database: jest.fn(() => ({ ref: mockAdminDbRef })),
+    }));
+
+    require('./homebasedAircraftTrigger');
+  });
+
+  const makeChange = (before, after) => ({
+    before: { val: () => before },
+    after: { val: () => after },
+  });
+
+  it('does nothing when before and after are equal', async () => {
+    const value = { homeBase: { HBXYZ: true }, club: { HBABC: true } };
+    const change = makeChange(value, value);
+    await capturedHandler(change, {});
+    expect(mockAdminDbRef).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when only an unrelated sibling subtree changed', async () => {
+    const change = makeChange(
+      { homeBase: { HBXYZ: true }, club: { HBABC: true }, other: 1 },
+      { homeBase: { HBXYZ: true }, club: { HBABC: true }, other: 2 }
+    );
+    await capturedHandler(change, {});
+    expect(mockAdminDbRef).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no customs declaration settings exist', async () => {
+    mockAdminDbRef.mockReturnValue({
+      once: jest.fn().mockResolvedValue({ val: () => null }),
+    });
+    const change = makeChange(
+      { homeBase: { HBXYZ: true } },
+      { homeBase: { HBABC: true } }
+    );
+    await capturedHandler(change, {});
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when customs settings have no baseUrl', async () => {
+    mockAdminDbRef.mockReturnValue({
+      once: jest.fn().mockResolvedValue({ val: () => ({ aerodrome: 'LSZT' }) }),
+    });
+    const change = makeChange(
+      { homeBase: { HBXYZ: true } },
+      { homeBase: { HBABC: true } }
+    );
+    await capturedHandler(change, {});
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('sends PUT with union of homeBase and club registrations', async () => {
+    mockAdminDbRef.mockReturnValue({
+      once: jest.fn().mockResolvedValue({
+        val: () => ({
+          baseUrl: 'https://customs.example.com',
+          aerodrome: 'LSZT',
+          accessToken: 'tok123',
+        }),
+      }),
+    });
+
+    global.fetch.mockResolvedValue({ ok: true });
+
+    const after = {
+      homeBase: { HBXYZ: true, HBABC: true },
+      club: { HBABC: true, HBCLU: true },
+    };
+    const change = makeChange({ homeBase: { HBOLD: true } }, after);
+    await capturedHandler(change, {});
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://customs.example.com/api/homebased-aircraft?ad=LSZT',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer tok123',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify([
+          { registration: 'HBXYZ' },
+          { registration: 'HBABC' },
+          { registration: 'HBCLU' },
+        ]),
+      })
+    );
+  });
+
+  it('handles missing homeBase or club subkey', async () => {
+    mockAdminDbRef.mockReturnValue({
+      once: jest.fn().mockResolvedValue({
+        val: () => ({
+          baseUrl: 'https://customs.example.com',
+          aerodrome: 'LSZT',
+          accessToken: 'tok123',
+        }),
+      }),
+    });
+
+    global.fetch.mockResolvedValue({ ok: true });
+
+    const change = makeChange(
+      { homeBase: { HBOLD: true }, club: { HBCLU: true } },
+      { club: { HBCLU: true, HBNEW: true } }
+    );
+    await capturedHandler(change, {});
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify([
+          { registration: 'HBCLU' },
+          { registration: 'HBNEW' },
+        ]),
+      })
+    );
+  });
+
+  it('handles null after value by sending empty array', async () => {
+    mockAdminDbRef.mockReturnValue({
+      once: jest.fn().mockResolvedValue({
+        val: () => ({
+          baseUrl: 'https://customs.example.com',
+          aerodrome: 'LSZT',
+          accessToken: 'tok123',
+        }),
+      }),
+    });
+
+    global.fetch.mockResolvedValue({ ok: true });
+
+    const change = makeChange({ homeBase: { HBOLD: true } }, null);
+    await capturedHandler(change, {});
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ body: JSON.stringify([]) })
+    );
+  });
+
+  it('logs error when fetch response is not ok', async () => {
+    mockAdminDbRef.mockReturnValue({
+      once: jest.fn().mockResolvedValue({
+        val: () => ({
+          baseUrl: 'https://customs.example.com',
+          aerodrome: 'LSZT',
+          accessToken: 'tok123',
+        }),
+      }),
+    });
+
+    global.fetch.mockResolvedValue({
+      ok: false,
+      text: jest.fn().mockResolvedValue('Not authorized'),
+    });
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const change = makeChange(
+      { homeBase: { HBOLD: true } },
+      { homeBase: { HBNEW: true } }
+    );
+    await capturedHandler(change, {});
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to update the homebased aircraft of the customs app',
+      expect.anything()
+    );
+    expect(consoleSpy).toHaveBeenCalledWith('Response body', 'Not authorized');
+    consoleSpy.mockRestore();
+  });
+
+  it('tolerates non-text error responses without throwing', async () => {
+    mockAdminDbRef.mockReturnValue({
+      once: jest.fn().mockResolvedValue({
+        val: () => ({
+          baseUrl: 'https://customs.example.com',
+          aerodrome: 'LSZT',
+          accessToken: 'tok123',
+        }),
+      }),
+    });
+
+    global.fetch.mockResolvedValue({
+      ok: false,
+      text: jest.fn().mockRejectedValue(new Error('stream error')),
+    });
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const change = makeChange(
+      { homeBase: { HBOLD: true } },
+      { homeBase: { HBNEW: true } }
+    );
+    await expect(capturedHandler(change, {})).resolves.toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalledWith('Response body', '');
+    consoleSpy.mockRestore();
+  });
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -32,6 +32,7 @@ const api = require('./api');
 const webhook = require('./webhook');
 const associatedMovementsTriggers = require('./associatedMovements/setAssociatedMovementsTriggers');
 const invoiceRecipientsTrigger = require('./invoiceRecipients/invoiceRecipientsTrigger');
+const homebasedAircraftTrigger = require('./homebasedAircraft/homebasedAircraftTrigger');
 const updateArrivalPaymentStatus = require('./updateArrivalPaymentStatus');
 const { scheduledAnonymizeMovements } = require('./anonymizeMovements');
 const { scheduledCleanupMessages } = require('./cleanupMessages');
@@ -60,6 +61,7 @@ exports.scheduledAircraftListUpdate = scheduledAircraftListUpdate;
 exports.setAssociatedMovementOnDeletedDeparture = associatedMovementsTriggers.setAssociatedMovementOnDeletedDeparture;
 exports.setAssociatedMovementOnDeletedArrival = associatedMovementsTriggers.setAssociatedMovementOnDeletedArrival;
 exports.updateCustomsInvoiceRecipientsOnUpdate = invoiceRecipientsTrigger.updateCustomsInvoiceRecipientsOnUpdate;
+exports.updateCustomsHomebasedAircraftOnUpdate = homebasedAircraftTrigger.updateCustomsHomebasedAircraftOnUpdate;
 
 exports.enrichDepartureOnCreate = enrichMovements.enrichDepartureOnCreate;
 exports.enrichDepartureOnUpdate = enrichMovements.enrichDepartureOnUpdate;


### PR DESCRIPTION
## Summary
- New RTDB trigger on `/settings/aircrafts` that PUTs the union of `homeBase` and `club` registrations to the customs app's new `/api/homebased-aircraft` endpoint.
- Mirrors the existing invoice-recipients push: same Bearer auth from `/settings/customsDeclarationApp`, wipe-and-replace semantics on the customs side.
- Enables the customs app to skip the customs fee for homebased aircraft when its `freeForHomebased` flag is on.

## Notes
- No-op check compares the *computed* payload (not the raw subtree), so unrelated sibling writes under `/settings/aircrafts` don't trigger redundant pushes.
- Error path uses `response.text().catch(() => '')` so non-text / stream errors don't escape the handler.
- Pre-existing `invoiceRecipientsTrigger` was used as the reference pattern.

## Test plan
- [x] `npm run test:functions` — 293 tests pass
- [x] 100% coverage on the new trigger (9 specs: equal payload, unrelated sibling, missing settings, no `baseUrl`, union with overlap, missing subkey, null `after`, fetch error, non-text error response)
- [ ] Deploy to staging and verify a write to `/settings/aircrafts/homeBase/<reg>` results in a successful `PUT` against the customs app