### PR TITLE
Upgrade nodemailer from 6 to 8

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,7 +12,7 @@
         "firebase-admin": "^13.0.0",
         "firebase-functions": "^6.0.0",
         "moment": "^2.22.2",
-        "nodemailer": "^6.9.0",
+        "nodemailer": "^8.0.7",
         "request-promise": "^4.2.6",
         "soap": "^1.6.0"
       },
@@ -7000,9 +7000,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "firebase-admin": "^13.0.0",
     "firebase-functions": "^6.0.0",
     "moment": "^2.22.2",
-    "nodemailer": "^6.9.0",
+    "nodemailer": "^8.0.7",
     "request-promise": "^4.2.6",
     "soap": "^1.6.0"
   },


### PR DESCRIPTION
## Summary
- Bump `nodemailer` in `functions/` from `^6.9.0` to `^8.0.7`.
- No code changes: the only call site (`functions/auth/sendSignInEmail.js`) uses plain SMTP `createTransport({ host, port, secure, auth })` and standard `sendMail({ from, to, subject, text, html })` — both signatures are unchanged across v6/v7/v8.
- Reviewed breaking changes: v7 SES SDK overhaul (N/A — no SES use) and v8 `NoAuth` → `ENOAUTH` error code rename (N/A — not referenced in code).

## Test plan
- [x] `cd functions && npm test` — all 293 tests pass
- [ ] Verify SMTP sign-in email still delivers in deployed environment after merge