### PR TITLE
Migrate rtdb config to params (PR 1 of 4)

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -56,3 +56,6 @@ jobs:
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
       - run: firebase deploy --only functions
+        env:
+          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
+          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL }}

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -54,3 +54,6 @@ jobs:
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
       - run: firebase deploy --only functions
+        env:
+          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
+          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL }}

--- a/functions/associatedMovements/setAssociatedMovementsTriggers.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.js
@@ -174,7 +174,8 @@ const updateOnDelete = async (snap, type) => {
   }
 }
 
-const instance = functions.config().rtdb.instance;
+const { RTDB_INSTANCE } = require('../params');
+const instance = RTDB_INSTANCE.value();
 
 module.exports.setAssociatedMovementOnCreatedDeparture =
   functions.region('europe-west1').database.instance(instance).ref('/departures/{departureId}')

--- a/functions/associatedMovements/setAssociatedMovementsTriggers.spec.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.spec.js
@@ -16,7 +16,6 @@ jest.mock('firebase-functions/v1', () => {
   });
 
   const mock = {
-    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
     logger: {
       info: jest.fn(),
       warn: jest.fn(),

--- a/functions/enrichMovements.js
+++ b/functions/enrichMovements.js
@@ -93,7 +93,8 @@ async function enrichOnUpdate(change, movementType) {
   }
 }
 
-const instance = functions.config().rtdb.instance;
+const { RTDB_INSTANCE } = require('./params');
+const instance = RTDB_INSTANCE.value();
 
 const handleUpdate = (change, movementType) => {
   if (!change.before.exists() || !change.after.exists()) {

--- a/functions/enrichMovements.spec.js
+++ b/functions/enrichMovements.spec.js
@@ -16,7 +16,6 @@ jest.mock('firebase-functions/v1', () => {
   });
 
   const mock = {
-    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
     logger: {
       info: jest.fn(),
       warn: jest.fn(),

--- a/functions/homebasedAircraft/homebasedAircraftTrigger.js
+++ b/functions/homebasedAircraft/homebasedAircraftTrigger.js
@@ -1,7 +1,8 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
+const { RTDB_INSTANCE } = require('../params')
 
-const instance = functions.config().rtdb.instance
+const instance = RTDB_INSTANCE.value()
 
 function buildBody(snapshot) {
   const homeBase = (snapshot && snapshot.homeBase) || {}

--- a/functions/homebasedAircraft/homebasedAircraftTrigger.spec.js
+++ b/functions/homebasedAircraft/homebasedAircraftTrigger.spec.js
@@ -4,7 +4,6 @@ let capturedHandler;
 
 jest.mock('firebase-functions/v1', () => {
   const mock = {
-    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
     database: {
       instance: jest.fn(() => ({
         ref: jest.fn(() => ({
@@ -32,7 +31,6 @@ describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
 
     jest.mock('firebase-functions/v1', () => {
       const mock = {
-        config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
         database: {
           instance: jest.fn(() => ({
             ref: jest.fn(() => ({

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
+const { RTDB_URL, RTDB_INSTANCE } = require('./params');
 
-const config = functions.config()
-
-const dbUrl = config.rtdb.url
-const dbInstance = config.rtdb.instance;
+const dbUrl = RTDB_URL.value();
+const dbInstance = RTDB_INSTANCE.value();
 
 admin.initializeApp({
   databaseURL: dbUrl || `https://${dbInstance}.firebaseio.com`

--- a/functions/invoiceRecipients/invoiceRecipientsTrigger.js
+++ b/functions/invoiceRecipients/invoiceRecipientsTrigger.js
@@ -1,7 +1,8 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
+const { RTDB_INSTANCE } = require('../params')
 
-const instance = functions.config().rtdb.instance
+const instance = RTDB_INSTANCE.value()
 
 module.exports.updateCustomsInvoiceRecipientsOnUpdate =
   functions.region('europe-west1').database.instance(instance).ref('/settings/invoiceRecipients')

--- a/functions/invoiceRecipients/invoiceRecipientsTrigger.spec.js
+++ b/functions/invoiceRecipients/invoiceRecipientsTrigger.spec.js
@@ -4,7 +4,6 @@ let capturedHandler;
 
 jest.mock('firebase-functions/v1', () => {
   const mock = {
-    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
     database: {
       instance: jest.fn(() => ({
         ref: jest.fn(() => ({
@@ -32,7 +31,6 @@ describe('functions/invoiceRecipients/invoiceRecipientsTrigger', () => {
 
     jest.mock('firebase-functions/v1', () => {
       const mock = {
-        config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
         database: {
           instance: jest.fn(() => ({
             ref: jest.fn(() => ({

--- a/functions/params.js
+++ b/functions/params.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const { defineString } = require('firebase-functions/params');
+
+exports.RTDB_URL = defineString('RTDB_URL', { default: '' });
+exports.RTDB_INSTANCE = defineString('RTDB_INSTANCE');

--- a/functions/updateArrivalPaymentStatus.js
+++ b/functions/updateArrivalPaymentStatus.js
@@ -1,7 +1,8 @@
 const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
+const { RTDB_INSTANCE } = require('./params');
 
-const instance = functions.config().rtdb.instance;
+const instance = RTDB_INSTANCE.value();
 
 const handleUpdate = async (change) => {
   if (!change.before.exists() || !change.after.exists()) {

--- a/functions/updateArrivalPaymentStatus.spec.js
+++ b/functions/updateArrivalPaymentStatus.spec.js
@@ -12,7 +12,6 @@ describe('functions', () => {
         database: jest.fn()
       };
       mockFunctions = {
-        config: jest.fn().mockReturnValue({ rtdb: { instance: 'test-instance' } }),
         logger: { info: jest.fn(), error: jest.fn() },
         region: jest.fn().mockReturnValue({
           database: {

--- a/functions/webhook/index.js
+++ b/functions/webhook/index.js
@@ -1,8 +1,9 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 const request = require('request-promise');
+const { RTDB_INSTANCE } = require('../params');
 
-const instance = functions.config().rtdb.instance;
+const instance = RTDB_INSTANCE.value();
 
 module.exports = functions.region('europe-west1').database.instance(instance).ref('status/{statusId}').onCreate(async (snap) => {
   const r = await admin.database().ref("settings/webhookUrl").once('value')


### PR DESCRIPTION
## Summary
First step in migrating off `functions.config()` (which is removed in `firebase-functions` v7). This PR moves only the `rtdb.url` / `rtdb.instance` reads to the `firebase-functions/params` module. The other config keys (`webauthn.*`, `auth.ips`, `auth.staticcredentials`, `api.serviceuser.*`, `testing.enabled`) keep using `functions.config()` under v6 until follow-up PRs migrate them.

The migration is split across four PRs:

1. **This PR** — `rtdb` migration (7 source files + 2 workflow files).
2. Remaining non-secret config (webauthn, auth.ips, testing flag).
3. Secrets via `defineSecret()` + `runWith` on entry points.
4. Bump `firebase-functions` 6 → 7 (one-line change).

## Why `rtdb` first
The 6 trigger files use `rtdb.instance` to *bind triggers* at module-load time (`functions.region(...).database.instance(<value>).ref(...)`). Firebase's deploy CLI loads these modules to discover triggers, so the param value must be present in `process.env` when the CLI runs. PR 1 isolates this trigger-binding-at-deploy-analysis-time risk so we can verify Firebase's params resolution works for triggers before committing to a larger diff.

## Changes
- New `functions/params.js` with `RTDB_URL` (default `''`) and `RTDB_INSTANCE` defines.
- 7 source files updated to read `RTDB_URL.value()` / `RTDB_INSTANCE.value()` from `./params` (or `../params`):
  - `functions/index.js`
  - `functions/updateArrivalPaymentStatus.js`
  - `functions/enrichMovements.js`
  - `functions/webhook/index.js`
  - `functions/associatedMovements/setAssociatedMovementsTriggers.js`
  - `functions/invoiceRecipients/invoiceRecipientsTrigger.js`
  - `functions/homebasedAircraft/homebasedAircraftTrigger.js`
- 5 spec files: removed now-dead `config: jest.fn(...)` mocks for `rtdb` (source no longer calls `functions.config()`).
- Both deploy workflows (`firebase-hosting-dev.yml`, `firebase-hosting-prod.yml`) pass both env vars on the `firebase deploy --only functions` step:
  - `RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}` (existing GH var, set on every env)
  - `RTDB_URL: ${{ vars.FIREBASE_RTDB_URL }}` (new GH var — see action required below)
- `index.js` keeps the `https://${dbInstance}.firebaseio.com` fallback for projects where `rtdb.url` was never set (4 US-region projects rely on this).

## ⚠ Action required before merge: set `FIREBASE_RTDB_URL` in EU environments

I queried `firebase functions:config:get` against all 11 projects. 7 are EU-region with `rtdb.url` explicitly set today; 4 are US-region with no `rtdb.url` (they use the `firebaseio.com` fallback). Set `FIREBASE_RTDB_URL` as an environment variable in GitHub Settings → Environments for each EU env, sourced from each project's current `rtdb.url`:

| GH Actions env | `FIREBASE_RTDB_URL` |
|---|---|
| `lspl_test` | `https://lspl-test-default-rtdb.europe-west1.firebasedatabase.app` |
| `lsze_test` | `https://lsze-test-default-rtdb.europe-west1.firebasedatabase.app` |
| `lsze_prod` | `https://lsze-prod-default-rtdb.europe-west1.firebasedatabase.app` |
| `lszm_test` | `https://lszm-test-eu.europe-west1.firebasedatabase.app` |
| `lszm_prod` | `https://lszm-prod-eu.europe-west1.firebasedatabase.app` |
| `lszo_test` | `https://lszo-test-eu.europe-west1.firebasedatabase.app` |
| `lszo_prod` | `https://lszo-prod-default-rtdb.europe-west1.firebasedatabase.app` |

The 4 US envs (`lszt_test`, `lszt_prod`, `lspv_test`, `lspv_prod`) can leave `FIREBASE_RTDB_URL` unset — the workflow passes an empty string and `index.js`'s fallback constructs `https://<instance>.firebaseio.com`, which is what they use today.

If `FIREBASE_RTDB_URL` is missing on an EU env at deploy time, `index.js` will fall back to the US-format URL, `admin.initializeApp` will point at a non-existent database, and runtime calls will fail.

## Test plan
- [x] `cd functions && npm test` — all 293 tests pass.
- [x] **Set `FIREBASE_RTDB_URL` in the 7 EU environments before merging.**
- [ ] After merge, watch CI's `build_and_deploy_functions` job succeed for all 6 test environments.
- [ ] **Confirm an RTDB trigger fires** on `lszm_test` (or any test project) by writing/updating a movement record. Watch Cloud Functions logs for `enrichDepartureOnCreate`, `setAssociatedMovementOnCreatedDeparture`, `updateArrivalPaymentStatusOnCardPaymentUpdate`, or `updateCustomsHomebasedAircraftOnUpdate` firing. **This is the load-bearing verification** — it proves trigger-binding params resolved correctly at deploy analysis. If triggers don't fire (or fire against an empty database instance), revert this PR.
- [ ] Spot-check `firebase functions:list --project=<lszm-test>` shows triggers bound to the correct database instance, not an empty one.