### PR TITLE
Write functions/.env.<projectId> at deploy time

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -55,7 +55,17 @@ jobs:
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
-      - run: firebase deploy --only functions
+      - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }}
         env:
-          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
-          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL }}
+          FIREBASE_RTDB_NAME: ${{ vars.FIREBASE_RTDB_NAME }}
+          FIREBASE_RTDB_URL: ${{ vars.FIREBASE_RTDB_URL }}
+        run: |
+          URL="${FIREBASE_RTDB_URL}"
+          if [ -z "$URL" ]; then
+            URL="https://${FIREBASE_RTDB_NAME}.firebaseio.com"
+          fi
+          {
+            echo "RTDB_INSTANCE=${FIREBASE_RTDB_NAME}"
+            echo "RTDB_URL=${URL}"
+          } > "functions/.env.${{ vars.FIREBASE_PROJECT }}"
+      - run: firebase deploy --only functions

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -53,7 +53,17 @@ jobs:
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
-      - run: firebase deploy --only functions
+      - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }}
         env:
-          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
-          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL }}
+          FIREBASE_RTDB_NAME: ${{ vars.FIREBASE_RTDB_NAME }}
+          FIREBASE_RTDB_URL: ${{ vars.FIREBASE_RTDB_URL }}
+        run: |
+          URL="${FIREBASE_RTDB_URL}"
+          if [ -z "$URL" ]; then
+            URL="https://${FIREBASE_RTDB_NAME}.firebaseio.com"
+          fi
+          {
+            echo "RTDB_INSTANCE=${FIREBASE_RTDB_NAME}"
+            echo "RTDB_URL=${URL}"
+          } > "functions/.env.${{ vars.FIREBASE_PROJECT }}"
+      - run: firebase deploy --only functions

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules/
 npm-debug.log
 firebase-debug.log
 .runtimeconfig.json
+functions/.env*


### PR DESCRIPTION
## Summary
Follow-up fix to PR #743. The previous PR set \`RTDB_INSTANCE\` and \`RTDB_URL\` on the \`firebase deploy\` step's \`env\` block, expecting Firebase's params system to read them from \`process.env\`. It doesn't — Firebase's params system reads param values from \`functions/.env.<projectId>\` dotenv files at deploy analysis time, not from the shell environment. The deploy job on develop just failed with:

\`\`\`
Error: In non-interactive mode but have no value for the
following environment variables: RTDB_URL, RTDB_INSTANCE
\`\`\`

## Changes
- Both deploy workflows (\`firebase-hosting-dev.yml\`, \`firebase-hosting-prod.yml\`) now run a step that writes \`functions/.env.<projectId>\` from the per-environment GitHub Actions vars before \`firebase deploy --only functions\`.
- For the 4 US envs where \`vars.FIREBASE_RTDB_URL\` is intentionally unset, the workflow constructs the \`https://<instance>.firebaseio.com\` fallback so the dotenv file always populates both keys explicitly.
- \`functions/.env*\` added to \`.gitignore\` (defensive — for any locally-generated dotenv files).

## Test plan
- [x] \`cd functions && npm test\` — all 293 tests pass (no source code changes).
- [ ] After merge, \`build_and_deploy_functions\` succeeds across all 6 test envs.
- [ ] **Confirm an RTDB trigger fires** on lszm_test by writing/updating a movement record (the same load-bearing check from #743).