### PR TITLE
Use process.env for rtdb config (Gen 1 trigger binding)

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -55,7 +55,7 @@ jobs:
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
-      - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }}
+      - name: Resolve RTDB env vars for deploy
         env:
           FIREBASE_RTDB_NAME: ${{ vars.FIREBASE_RTDB_NAME }}
           FIREBASE_RTDB_URL: ${{ vars.FIREBASE_RTDB_URL }}
@@ -67,5 +67,5 @@ jobs:
           {
             echo "RTDB_INSTANCE=${FIREBASE_RTDB_NAME}"
             echo "RTDB_URL=${URL}"
-          } > "functions/.env.${{ vars.FIREBASE_PROJECT }}"
+          } >> "$GITHUB_ENV"
       - run: firebase deploy --only functions

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -53,7 +53,7 @@ jobs:
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
-      - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }}
+      - name: Resolve RTDB env vars for deploy
         env:
           FIREBASE_RTDB_NAME: ${{ vars.FIREBASE_RTDB_NAME }}
           FIREBASE_RTDB_URL: ${{ vars.FIREBASE_RTDB_URL }}
@@ -65,5 +65,5 @@ jobs:
           {
             echo "RTDB_INSTANCE=${FIREBASE_RTDB_NAME}"
             echo "RTDB_URL=${URL}"
-          } > "functions/.env.${{ vars.FIREBASE_PROJECT }}"
+          } >> "$GITHUB_ENV"
       - run: firebase deploy --only functions

--- a/functions/associatedMovements/setAssociatedMovementsTriggers.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.js
@@ -174,8 +174,7 @@ const updateOnDelete = async (snap, type) => {
   }
 }
 
-const { RTDB_INSTANCE } = require('../params');
-const instance = RTDB_INSTANCE.value();
+const instance = process.env.RTDB_INSTANCE;
 
 module.exports.setAssociatedMovementOnCreatedDeparture =
   functions.region('europe-west1').database.instance(instance).ref('/departures/{departureId}')

--- a/functions/enrichMovements.js
+++ b/functions/enrichMovements.js
@@ -93,8 +93,7 @@ async function enrichOnUpdate(change, movementType) {
   }
 }
 
-const { RTDB_INSTANCE } = require('./params');
-const instance = RTDB_INSTANCE.value();
+const instance = process.env.RTDB_INSTANCE;
 
 const handleUpdate = (change, movementType) => {
   if (!change.before.exists() || !change.after.exists()) {

--- a/functions/homebasedAircraft/homebasedAircraftTrigger.js
+++ b/functions/homebasedAircraft/homebasedAircraftTrigger.js
@@ -1,8 +1,7 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
-const { RTDB_INSTANCE } = require('../params')
 
-const instance = RTDB_INSTANCE.value()
+const instance = process.env.RTDB_INSTANCE
 
 function buildBody(snapshot) {
   const homeBase = (snapshot && snapshot.homeBase) || {}

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const admin = require('firebase-admin');
-const { RTDB_URL, RTDB_INSTANCE } = require('./params');
 
-const dbUrl = RTDB_URL.value();
-const dbInstance = RTDB_INSTANCE.value();
+const dbUrl = process.env.RTDB_URL;
+const dbInstance = process.env.RTDB_INSTANCE;
 
 admin.initializeApp({
   databaseURL: dbUrl || `https://${dbInstance}.firebaseio.com`

--- a/functions/invoiceRecipients/invoiceRecipientsTrigger.js
+++ b/functions/invoiceRecipients/invoiceRecipientsTrigger.js
@@ -1,8 +1,7 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
-const { RTDB_INSTANCE } = require('../params')
 
-const instance = RTDB_INSTANCE.value()
+const instance = process.env.RTDB_INSTANCE
 
 module.exports.updateCustomsInvoiceRecipientsOnUpdate =
   functions.region('europe-west1').database.instance(instance).ref('/settings/invoiceRecipients')

--- a/functions/params.js
+++ b/functions/params.js
@@ -1,6 +1,0 @@
-'use strict';
-
-const { defineString } = require('firebase-functions/params');
-
-exports.RTDB_URL = defineString('RTDB_URL', { default: '' });
-exports.RTDB_INSTANCE = defineString('RTDB_INSTANCE');

--- a/functions/updateArrivalPaymentStatus.js
+++ b/functions/updateArrivalPaymentStatus.js
@@ -1,8 +1,7 @@
 const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
-const { RTDB_INSTANCE } = require('./params');
 
-const instance = RTDB_INSTANCE.value();
+const instance = process.env.RTDB_INSTANCE;
 
 const handleUpdate = async (change) => {
   if (!change.before.exists() || !change.after.exists()) {

--- a/functions/webhook/index.js
+++ b/functions/webhook/index.js
@@ -1,9 +1,8 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 const request = require('request-promise');
-const { RTDB_INSTANCE } = require('../params');
 
-const instance = RTDB_INSTANCE.value();
+const instance = process.env.RTDB_INSTANCE;
 
 module.exports = functions.region('europe-west1').database.instance(instance).ref('status/{statusId}').onCreate(async (snap) => {
   const r = await admin.database().ref("settings/webhookUrl").once('value')


### PR DESCRIPTION
## Summary
Second follow-up to PR #743. The first follow-up (#744) wrote \`functions/.env.<projectId>\` files, which fixed Firebase's "non-interactive mode but no value" error — but exposed a deeper issue: Firebase loads those .env files **after** source analysis, and Gen 1 trigger binding (\`functions.region(...).database.instance(<value>).ref(...)\`) evaluates the value at module-load time during analysis. So \`RTDB_INSTANCE.value()\` returned empty and triggers registered against \`instance('')\`.

The deploy log made this explicit:
\`\`\`
WARNING: params.RTDB_INSTANCE.value() invoked during function deployment,
         instead of during runtime. This is usually a mistake.
...
Failed to configure trigger for ... resource:projects/_/instances//refs/departures/{departureId}
\`\`\`
Note the empty path between \`instances/\` and \`/refs/\`.

## Why params don't work here
\`firebase-functions/params\` (\`defineString\`/\`defineSecret\`) is designed for **runtime** reads — handlers, cold-start init, etc. The values are populated when the function actually runs. For Gen 1 functions, the trigger configuration (\`.database.instance()\`) is decided at module load during deploy analysis, **before** Firebase populates param values from .env files. \`.value()\` at that moment returns empty.

This will keep working for non-trigger config in PRs 2 & 3 (webauthn, auth.ips, secrets, testing flag) since those are runtime-only reads. The limitation is specifically Gen 1 trigger binding.

## Fix
- Delete \`functions/params.js\` (no longer needed for these two values; will be reintroduced in PR 2 with non-trigger params).
- 7 source files now read \`process.env.RTDB_INSTANCE\` / \`process.env.RTDB_URL\` directly.
- Both workflows replace the \`Write functions/.env.<projectId>\` step with a \`Resolve RTDB env vars for deploy\` step that exports the same values to \`$GITHUB_ENV\` (with the same firebaseio.com fallback for US projects). \`$GITHUB_ENV\` makes them available as process env vars in the subsequent \`firebase deploy\` step, populated **before** Firebase CLI starts source analysis.

## Test plan
- [x] \`cd functions && npm test\` — 293 tests pass (no test changes needed).
- [ ] After merge, watch \`build_and_deploy_functions\` succeed across all 6 test environments.
- [ ] **Confirm an RTDB trigger fires** on lszm_test by writing/updating a movement record. Verify in deploy logs that no "Failed to configure trigger" lines appear and that \`firebase functions:list --project=lszm-test\` shows non-empty database instances on the trigger functions.