### PR TITLE
Set RTDB env vars directly on deploy step

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -55,17 +55,14 @@ jobs:
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
-      - name: Resolve RTDB env vars for deploy
+      - name: Confirm RTDB env vars
         env:
-          FIREBASE_RTDB_NAME: ${{ vars.FIREBASE_RTDB_NAME }}
-          FIREBASE_RTDB_URL: ${{ vars.FIREBASE_RTDB_URL }}
+          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
+          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL || format('https://{0}.firebaseio.com', vars.FIREBASE_RTDB_NAME) }}
         run: |
-          URL="${FIREBASE_RTDB_URL}"
-          if [ -z "$URL" ]; then
-            URL="https://${FIREBASE_RTDB_NAME}.firebaseio.com"
-          fi
-          {
-            echo "RTDB_INSTANCE=${FIREBASE_RTDB_NAME}"
-            echo "RTDB_URL=${URL}"
-          } >> "$GITHUB_ENV"
+          echo "RTDB_INSTANCE=[$RTDB_INSTANCE]"
+          echo "RTDB_URL=[$RTDB_URL]"
       - run: firebase deploy --only functions
+        env:
+          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
+          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL || format('https://{0}.firebaseio.com', vars.FIREBASE_RTDB_NAME) }}

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -53,17 +53,14 @@ jobs:
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
-      - name: Resolve RTDB env vars for deploy
+      - name: Confirm RTDB env vars
         env:
-          FIREBASE_RTDB_NAME: ${{ vars.FIREBASE_RTDB_NAME }}
-          FIREBASE_RTDB_URL: ${{ vars.FIREBASE_RTDB_URL }}
+          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
+          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL || format('https://{0}.firebaseio.com', vars.FIREBASE_RTDB_NAME) }}
         run: |
-          URL="${FIREBASE_RTDB_URL}"
-          if [ -z "$URL" ]; then
-            URL="https://${FIREBASE_RTDB_NAME}.firebaseio.com"
-          fi
-          {
-            echo "RTDB_INSTANCE=${FIREBASE_RTDB_NAME}"
-            echo "RTDB_URL=${URL}"
-          } >> "$GITHUB_ENV"
+          echo "RTDB_INSTANCE=[$RTDB_INSTANCE]"
+          echo "RTDB_URL=[$RTDB_URL]"
       - run: firebase deploy --only functions
+        env:
+          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
+          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL || format('https://{0}.firebaseio.com', vars.FIREBASE_RTDB_NAME) }}


### PR DESCRIPTION
## Summary
Third follow-up to PR #743 (the original \`rtdb\` migration). PR #745 used \`\$GITHUB_ENV\` to set RTDB_INSTANCE/RTDB_URL for subsequent steps, but the deploy still failed with triggers registering against \`instances/undefined/\`, meaning \`process.env.RTDB_INSTANCE\` was JS-undefined when source modules loaded. \`\$GITHUB_ENV\` write didn't propagate as expected.

## Fix
Move the env-var-setting **directly onto the firebase deploy step's \`env:\` block**. This is GitHub Actions' most direct mechanism for setting process.env for a specific step's run command. The URL fallback for US projects (where \`vars.FIREBASE_RTDB_URL\` is intentionally unset) is now an inline expression: \`\${{ vars.FIREBASE_RTDB_URL || format('https://{0}.firebaseio.com', vars.FIREBASE_RTDB_NAME) }}\`.

Also adds a "Confirm RTDB env vars" debug step right before deploy that echoes both values, so if this still fails we can verify whether the env vars are present at the workflow level (vs being stripped by firebase-tools when spawning the analysis subprocess).

## Why this might still fail
firebase-tools spawns a subprocess to analyze function exports for trigger discovery. If that subprocess does NOT inherit \`process.env\` from the parent firebase CLI process (i.e., it explicitly curates a set of env vars to pass), then no amount of env-setting at the workflow level will reach the analysis subprocess. The debug step will confirm whether that's the actual cause.

## Test plan
- [ ] Watch the "Confirm RTDB env vars" output — both values should be set as expected (e.g., \`RTDB_INSTANCE=[lszm-test-eu]\`, \`RTDB_URL=[https://lszm-test-eu...]\`).
- [ ] After merge, watch \`build_and_deploy_functions\` succeed across all 6 test environments.
- [ ] **Confirm an RTDB trigger fires** on lszm_test by writing/updating a movement record.

If the debug step shows the values correctly but firebase deploy still fails with \`instances/undefined/\`, firebase-tools is curating env in the analysis subprocess. We'd then need to either (a) move trigger-defining values to defineString and rely on Firebase's params system to populate them in the analysis subprocess (which might or might not happen before module load — earlier evidence suggested no), or (b) move to Gen 2 functions which support trigger configuration via Param objects directly.