### PR TITLE
Revert rtdb config migration (PRs #743/#744/#745/#746)

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -55,14 +55,4 @@ jobs:
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
-      - name: Confirm RTDB env vars
-        env:
-          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
-          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL || format('https://{0}.firebaseio.com', vars.FIREBASE_RTDB_NAME) }}
-        run: |
-          echo "RTDB_INSTANCE=[$RTDB_INSTANCE]"
-          echo "RTDB_URL=[$RTDB_URL]"
       - run: firebase deploy --only functions
-        env:
-          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
-          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL || format('https://{0}.firebaseio.com', vars.FIREBASE_RTDB_NAME) }}

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -53,14 +53,4 @@ jobs:
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
-      - name: Confirm RTDB env vars
-        env:
-          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
-          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL || format('https://{0}.firebaseio.com', vars.FIREBASE_RTDB_NAME) }}
-        run: |
-          echo "RTDB_INSTANCE=[$RTDB_INSTANCE]"
-          echo "RTDB_URL=[$RTDB_URL]"
       - run: firebase deploy --only functions
-        env:
-          RTDB_INSTANCE: ${{ vars.FIREBASE_RTDB_NAME }}
-          RTDB_URL: ${{ vars.FIREBASE_RTDB_URL || format('https://{0}.firebaseio.com', vars.FIREBASE_RTDB_NAME) }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ node_modules/
 npm-debug.log
 firebase-debug.log
 .runtimeconfig.json
-functions/.env*

--- a/functions/associatedMovements/setAssociatedMovementsTriggers.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.js
@@ -174,7 +174,7 @@ const updateOnDelete = async (snap, type) => {
   }
 }
 
-const instance = process.env.RTDB_INSTANCE;
+const instance = functions.config().rtdb.instance;
 
 module.exports.setAssociatedMovementOnCreatedDeparture =
   functions.region('europe-west1').database.instance(instance).ref('/departures/{departureId}')

--- a/functions/associatedMovements/setAssociatedMovementsTriggers.spec.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.spec.js
@@ -16,6 +16,7 @@ jest.mock('firebase-functions/v1', () => {
   });
 
   const mock = {
+    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
     logger: {
       info: jest.fn(),
       warn: jest.fn(),

--- a/functions/enrichMovements.js
+++ b/functions/enrichMovements.js
@@ -93,7 +93,7 @@ async function enrichOnUpdate(change, movementType) {
   }
 }
 
-const instance = process.env.RTDB_INSTANCE;
+const instance = functions.config().rtdb.instance;
 
 const handleUpdate = (change, movementType) => {
   if (!change.before.exists() || !change.after.exists()) {

--- a/functions/enrichMovements.spec.js
+++ b/functions/enrichMovements.spec.js
@@ -16,6 +16,7 @@ jest.mock('firebase-functions/v1', () => {
   });
 
   const mock = {
+    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
     logger: {
       info: jest.fn(),
       warn: jest.fn(),

--- a/functions/homebasedAircraft/homebasedAircraftTrigger.js
+++ b/functions/homebasedAircraft/homebasedAircraftTrigger.js
@@ -1,7 +1,7 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 
-const instance = process.env.RTDB_INSTANCE
+const instance = functions.config().rtdb.instance
 
 function buildBody(snapshot) {
   const homeBase = (snapshot && snapshot.homeBase) || {}

--- a/functions/homebasedAircraft/homebasedAircraftTrigger.spec.js
+++ b/functions/homebasedAircraft/homebasedAircraftTrigger.spec.js
@@ -4,6 +4,7 @@ let capturedHandler;
 
 jest.mock('firebase-functions/v1', () => {
   const mock = {
+    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
     database: {
       instance: jest.fn(() => ({
         ref: jest.fn(() => ({
@@ -31,6 +32,7 @@ describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
 
     jest.mock('firebase-functions/v1', () => {
       const mock = {
+        config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
         database: {
           instance: jest.fn(() => ({
             ref: jest.fn(() => ({

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,9 +1,12 @@
 'use strict';
 
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
-const dbUrl = process.env.RTDB_URL;
-const dbInstance = process.env.RTDB_INSTANCE;
+const config = functions.config()
+
+const dbUrl = config.rtdb.url
+const dbInstance = config.rtdb.instance;
 
 admin.initializeApp({
   databaseURL: dbUrl || `https://${dbInstance}.firebaseio.com`

--- a/functions/invoiceRecipients/invoiceRecipientsTrigger.js
+++ b/functions/invoiceRecipients/invoiceRecipientsTrigger.js
@@ -1,7 +1,7 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 
-const instance = process.env.RTDB_INSTANCE
+const instance = functions.config().rtdb.instance
 
 module.exports.updateCustomsInvoiceRecipientsOnUpdate =
   functions.region('europe-west1').database.instance(instance).ref('/settings/invoiceRecipients')

--- a/functions/invoiceRecipients/invoiceRecipientsTrigger.spec.js
+++ b/functions/invoiceRecipients/invoiceRecipientsTrigger.spec.js
@@ -4,6 +4,7 @@ let capturedHandler;
 
 jest.mock('firebase-functions/v1', () => {
   const mock = {
+    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
     database: {
       instance: jest.fn(() => ({
         ref: jest.fn(() => ({
@@ -31,6 +32,7 @@ describe('functions/invoiceRecipients/invoiceRecipientsTrigger', () => {
 
     jest.mock('firebase-functions/v1', () => {
       const mock = {
+        config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
         database: {
           instance: jest.fn(() => ({
             ref: jest.fn(() => ({

--- a/functions/updateArrivalPaymentStatus.js
+++ b/functions/updateArrivalPaymentStatus.js
@@ -1,7 +1,7 @@
 const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
-const instance = process.env.RTDB_INSTANCE;
+const instance = functions.config().rtdb.instance;
 
 const handleUpdate = async (change) => {
   if (!change.before.exists() || !change.after.exists()) {

--- a/functions/updateArrivalPaymentStatus.spec.js
+++ b/functions/updateArrivalPaymentStatus.spec.js
@@ -12,6 +12,7 @@ describe('functions', () => {
         database: jest.fn()
       };
       mockFunctions = {
+        config: jest.fn().mockReturnValue({ rtdb: { instance: 'test-instance' } }),
         logger: { info: jest.fn(), error: jest.fn() },
         region: jest.fn().mockReturnValue({
           database: {

--- a/functions/webhook/index.js
+++ b/functions/webhook/index.js
@@ -2,7 +2,7 @@ const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 const request = require('request-promise');
 
-const instance = process.env.RTDB_INSTANCE;
+const instance = functions.config().rtdb.instance;
 
 module.exports = functions.region('europe-west1').database.instance(instance).ref('status/{statusId}').onCreate(async (snap) => {
   const r = await admin.database().ref("settings/webhookUrl").once('value')


### PR DESCRIPTION
## Summary
Reverts the four PRs that attempted to migrate \`rtdb\` config off \`functions.config()\`:

- #743 (Migrate rtdb config to params)
- #744 (Write functions/.env.<projectId> at deploy time)
- #745 (Use process.env for rtdb config in functions)
- #746 (Set RTDB env vars directly on deploy step)

The seven source files, five spec files, two deploy workflows, and \`.gitignore\` are restored to their state at a05f574 (the commit before #743). \`functions.config()\` still works on firebase-functions v6, so this restores trigger registration.

## Why
Gen 1 trigger binding (\`functions.region(...).database.instance(<value>).ref(...)\`) requires the database instance **string** at module-load time during firebase-tools' source-analysis subprocess. None of the migration approaches we tried can deliver that string to the subprocess:

| Approach (PR) | Result |
|---|---|
| #743: defineString + workflow env block | params CLI: "no value for environment variables" |
| #744: defineString + .env.<projectId> file | .env loads after analysis; \`.value()\` returns empty (\`instances//refs/...\`) |
| #745: process.env + \$GITHUB_ENV | env vars don't propagate to deploy step |
| #746: process.env + env block on deploy step | debug step confirmed env vars set at workflow level, but firebase-tools' analysis subprocess does NOT inherit (\`instances/undefined/refs/...\`) |

## Impact
- Test environments have received broken trigger registrations on every deploy since #743 merged. Merging this revert restores them.
- No production deploy has happened during this period (those go via \`master\`, not \`develop\`).
- The \`firebase-functions\` v7 bump remains blocked. The likely path forward is migrating the 6 trigger functions to Gen 2, which natively supports parameterized trigger config (passing \`Param\` objects to the trigger config rather than calling \`.value()\`). Separate, larger plan to be drafted.

## Test plan
- [x] \`cd functions && npm test\` — all 293 tests pass with the restored \`functions.config()\` reads.
- [ ] After merge, \`build_and_deploy_functions\` succeeds across all 6 test environments.
- [ ] **Confirm an RTDB trigger fires** on lszm_test by writing/updating a movement record (this should work again — we're back to the pre-migration code that's been running for months).