### PR TITLE
Make functions.config() reads survive empty config

### DIFF
--- a/functions/associatedMovements/setAssociatedMovementsTriggers.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.js
@@ -174,7 +174,8 @@ const updateOnDelete = async (snap, type) => {
   }
 }
 
-const instance = functions.config().rtdb.instance;
+const { rtdb = {} } = functions.config() || {};
+const instance = rtdb.instance || process.env.RTDB_INSTANCE;
 
 module.exports.setAssociatedMovementOnCreatedDeparture =
   functions.region('europe-west1').database.instance(instance).ref('/departures/{departureId}')

--- a/functions/enrichMovements.js
+++ b/functions/enrichMovements.js
@@ -93,7 +93,8 @@ async function enrichOnUpdate(change, movementType) {
   }
 }
 
-const instance = functions.config().rtdb.instance;
+const { rtdb = {} } = functions.config() || {};
+const instance = rtdb.instance || process.env.RTDB_INSTANCE;
 
 const handleUpdate = (change, movementType) => {
   if (!change.before.exists() || !change.after.exists()) {

--- a/functions/homebasedAircraft/homebasedAircraftTrigger.js
+++ b/functions/homebasedAircraft/homebasedAircraftTrigger.js
@@ -1,7 +1,8 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 
-const instance = functions.config().rtdb.instance
+const { rtdb = {} } = functions.config() || {}
+const instance = rtdb.instance || process.env.RTDB_INSTANCE
 
 function buildBody(snapshot) {
   const homeBase = (snapshot && snapshot.homeBase) || {}

--- a/functions/index.js
+++ b/functions/index.js
@@ -3,13 +3,12 @@
 const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
-const config = functions.config()
-
-const dbUrl = config.rtdb.url
-const dbInstance = config.rtdb.instance;
+const { rtdb = {} } = functions.config() || {};
+const dbUrl = rtdb.url || process.env.RTDB_URL;
+const dbInstance = rtdb.instance || process.env.RTDB_INSTANCE;
 
 admin.initializeApp({
-  databaseURL: dbUrl || `https://${dbInstance}.firebaseio.com`
+  databaseURL: dbUrl || (dbInstance ? `https://${dbInstance}.firebaseio.com` : undefined),
 });
 
 const { scheduledAerodromesUpdate } = require('./updateAerodromes');

--- a/functions/invoiceRecipients/invoiceRecipientsTrigger.js
+++ b/functions/invoiceRecipients/invoiceRecipientsTrigger.js
@@ -1,7 +1,8 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 
-const instance = functions.config().rtdb.instance
+const { rtdb = {} } = functions.config() || {}
+const instance = rtdb.instance || process.env.RTDB_INSTANCE
 
 module.exports.updateCustomsInvoiceRecipientsOnUpdate =
   functions.region('europe-west1').database.instance(instance).ref('/settings/invoiceRecipients')

--- a/functions/updateArrivalPaymentStatus.js
+++ b/functions/updateArrivalPaymentStatus.js
@@ -1,7 +1,8 @@
 const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
-const instance = functions.config().rtdb.instance;
+const { rtdb = {} } = functions.config() || {};
+const instance = rtdb.instance || process.env.RTDB_INSTANCE;
 
 const handleUpdate = async (change) => {
   if (!change.before.exists() || !change.after.exists()) {

--- a/functions/webhook/index.js
+++ b/functions/webhook/index.js
@@ -2,7 +2,8 @@ const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 const request = require('request-promise');
 
-const instance = functions.config().rtdb.instance;
+const { rtdb = {} } = functions.config() || {};
+const instance = rtdb.instance || process.env.RTDB_INSTANCE;
 
 module.exports = functions.region('europe-west1').database.instance(instance).ref('status/{statusId}').onCreate(async (snap) => {
   const r = await admin.database().ref("settings/webhookUrl").once('value')


### PR DESCRIPTION
## Summary

Make all 7 module-load reads of `functions.config().rtdb.*` survive `functions.config()` returning `{}`. Gen 1 behavior is unchanged — `functions.config()` still resolves first when populated, the env-var fallback only kicks in when it's empty.

```js
const { rtdb = {} } = functions.config() || {};
const instance = rtdb.instance || process.env.RTDB_INSTANCE;
```

Applied to:
- `functions/index.js` — `admin.initializeApp({ databaseURL })`
- `functions/enrichMovements.js`
- `functions/updateArrivalPaymentStatus.js`
- `functions/associatedMovements/setAssociatedMovementsTriggers.js`
- `functions/invoiceRecipients/invoiceRecipientsTrigger.js`
- `functions/homebasedAircraft/homebasedAircraftTrigger.js`
- `functions/webhook/index.js`

## Why

Prerequisite for adding any Gen 2 function alongside the existing Gen 1 codebase. In a Gen 2 Cloud Run runtime, `functions.config()` returns `{}` (CLOUD_RUNTIME_CONFIG isn't injected there). With the current unguarded `config.rtdb.url` / `config.rtdb.instance` reads, requiring any of these files crashes the Gen 2 container at module load — the symptom is the deploy-time `Container Healthcheck failed` error.

This PR is the **prerequisite** that unblocks the actual `firebase-functions` v7 bump path. The next PR migrates `scheduledCleanupMessages` to Gen 2 `onSchedule`; subsequent PRs migrate the 6 instance-bound RTDB triggers (the actual v7 unblock).

## Shippability

**Pure no-op for current Gen 1 deployments.** Verified by simulation:

| Scenario | `admin.initializeApp` receives | Module load |
|---|---|---|
| Gen 1 with `functions.config()` populated | `{ databaseURL: 'https://gen1-url.firebaseio.com' }` (from config) | ✅ |
| Gen 2 with `RTDB_URL` / `RTDB_INSTANCE` env | `{ databaseURL: 'https://lszm-test-eu.europe-west1.firebasedatabase.app' }` (from env) | ✅ |
| Gen 2 with neither | `{}` (no databaseURL — falls back to ADC) | ✅ |

CI continues to deploy normally on merge — no operational changes, no env vars to set yet, no manual steps.

## Verification

- `npm test` in `functions/` — 34 suites / 293 tests pass.
- `node --check` on all 6 modified trigger files — syntax OK.
- Runtime simulation (Gen 1 / Gen 2 with env / Gen 2 without env) — all three scenarios load successfully.

## Test plan

- [x] CI test job green (Jest)
- [ ] Merge → CI prod deploys succeed unchanged (no behavior change expected)
- [ ] Sanity-check one trigger after deploy (e.g. add a movement, confirm `enrichDeparture` still fires)

## Out of scope (follow-up PRs)

- **Migrate `scheduledCleanupMessages` to Gen 2 `onSchedule`** — the original goal. Stashed locally on `backup/cleanupMessages-migration`; will rebase as a fresh PR after this lands.
- Other 3 scheduled functions, HTTPS callables, and the 9 instance-bound RTDB / webhook triggers — each its own PR.
- Wiring `RTDB_URL` / `RTDB_INSTANCE` into Gen 2 deploys (committed `.env.<projectId>` files, or CI writing them at deploy time) — only needed when the first Gen 2 function actually lands.