### PR TITLE
Detect Gen 2 runtime to avoid functions.config() throw

### DIFF
--- a/functions/api/basicAuth.js
+++ b/functions/api/basicAuth.js
@@ -1,6 +1,6 @@
 const functions = require('firebase-functions/v1')
 
-const config = functions.config();
+const config = process.env.K_CONFIGURATION ? {} : functions.config();
 
 const basicAuth = (req, res, next) => {
   if (!config.api || !config.api.serviceuser || !config.api.serviceuser.username || !config.api.serviceuser.password) {

--- a/functions/associatedMovements/setAssociatedMovementsTriggers.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.js
@@ -174,7 +174,8 @@ const updateOnDelete = async (snap, type) => {
   }
 }
 
-const { rtdb = {} } = functions.config() || {};
+const config = process.env.K_CONFIGURATION ? {} : functions.config();
+const { rtdb = {} } = config;
 const instance = rtdb.instance || process.env.RTDB_INSTANCE;
 
 module.exports.setAssociatedMovementOnCreatedDeparture =

--- a/functions/auth/modes/flightnet/index.js
+++ b/functions/auth/modes/flightnet/index.js
@@ -5,7 +5,7 @@ const flightnet = require('./flightnet');
 const requestHelper = require('../../util/requestHelper');
 
 const parseStaticCredentials = () => {
-  const config = functions.config();
+  const config = process.env.K_CONFIGURATION ? {} : functions.config();
   if (config.auth && config.auth.staticcredentials) {
     return config.auth.staticcredentials.split(',').map(login => {
       const parts = login.split(':');

--- a/functions/auth/modes/ip/index.js
+++ b/functions/auth/modes/ip/index.js
@@ -5,7 +5,7 @@ const requestHelper = require('../../util/requestHelper');
 
 let ips = [];
 
-const config = functions.config();
+const config = process.env.K_CONFIGURATION ? {} : functions.config();
 if (!config.auth || !config.auth.ips) {
   console.info(
     "Set configuration property auth.ips to allow authentication by request IP address " +

--- a/functions/enrichMovements.js
+++ b/functions/enrichMovements.js
@@ -93,7 +93,8 @@ async function enrichOnUpdate(change, movementType) {
   }
 }
 
-const { rtdb = {} } = functions.config() || {};
+const config = process.env.K_CONFIGURATION ? {} : functions.config();
+const { rtdb = {} } = config;
 const instance = rtdb.instance || process.env.RTDB_INSTANCE;
 
 const handleUpdate = (change, movementType) => {

--- a/functions/homebasedAircraft/homebasedAircraftTrigger.js
+++ b/functions/homebasedAircraft/homebasedAircraftTrigger.js
@@ -1,7 +1,8 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 
-const { rtdb = {} } = functions.config() || {}
+const config = process.env.K_CONFIGURATION ? {} : functions.config()
+const { rtdb = {} } = config
 const instance = rtdb.instance || process.env.RTDB_INSTANCE
 
 function buildBody(snapshot) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -3,7 +3,8 @@
 const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
-const { rtdb = {} } = functions.config() || {};
+const config = process.env.K_CONFIGURATION ? {} : functions.config();
+const { rtdb = {} } = config;
 const dbUrl = rtdb.url || process.env.RTDB_URL;
 const dbInstance = rtdb.instance || process.env.RTDB_INSTANCE;
 

--- a/functions/invoiceRecipients/invoiceRecipientsTrigger.js
+++ b/functions/invoiceRecipients/invoiceRecipientsTrigger.js
@@ -1,7 +1,8 @@
 const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 
-const { rtdb = {} } = functions.config() || {}
+const config = process.env.K_CONFIGURATION ? {} : functions.config()
+const { rtdb = {} } = config
 const instance = rtdb.instance || process.env.RTDB_INSTANCE
 
 module.exports.updateCustomsInvoiceRecipientsOnUpdate =

--- a/functions/updateArrivalPaymentStatus.js
+++ b/functions/updateArrivalPaymentStatus.js
@@ -1,7 +1,8 @@
 const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
-const { rtdb = {} } = functions.config() || {};
+const config = process.env.K_CONFIGURATION ? {} : functions.config();
+const { rtdb = {} } = config;
 const instance = rtdb.instance || process.env.RTDB_INSTANCE;
 
 const handleUpdate = async (change) => {

--- a/functions/webhook/index.js
+++ b/functions/webhook/index.js
@@ -2,7 +2,8 @@ const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 const request = require('request-promise');
 
-const { rtdb = {} } = functions.config() || {};
+const config = process.env.K_CONFIGURATION ? {} : functions.config();
+const { rtdb = {} } = config;
 const instance = rtdb.instance || process.env.RTDB_INSTANCE;
 
 module.exports = functions.region('europe-west1').database.instance(instance).ref('status/{statusId}').onCreate(async (snap) => {


### PR DESCRIPTION
## Summary

Hotfix to PR #748. `functions.config()` doesn't return `{}` in Gen 2 Cloud Run runtimes — it explicitly **throws**:

```js
// firebase-functions/lib/v1/config.js
if (process.env.K_CONFIGURATION) {
  throw new Error("functions.config() is no longer available in Cloud Functions for Firebase v2. ...");
}
```

`K_CONFIGURATION` is only set in Gen 2. The previous defensive form `functions.config() || {}` shipped in #748 only handled falsy returns and didn't catch the throw — so module-load still crashes the Gen 2 container.

This PR switches all module-load reads to:

```js
const config = process.env.K_CONFIGURATION ? {} : functions.config();
```

Still a no-op for Gen 1: when `K_CONFIGURATION` is unset (Gen 1), the right-hand side runs and resolves the real config exactly as before. Tests still pass against the same mocked `functions.config()`.

## Sites updated (10 total)

The 7 already touched in #748:
- `index.js`
- `enrichMovements.js`
- `updateArrivalPaymentStatus.js`
- `associatedMovements/setAssociatedMovementsTriggers.js`
- `invoiceRecipients/invoiceRecipientsTrigger.js`
- `homebasedAircraft/homebasedAircraftTrigger.js`
- `webhook/index.js`

Plus 3 module-load sites missed in #748:
- `api/basicAuth.js` — top-level `const config = functions.config();`
- `auth/modes/ip/index.js` — top-level `const config = functions.config();`
- `auth/modes/flightnet/index.js` — `parseStaticCredentials()` is invoked at module top (line 25), and reads `functions.config()` inside

Three other call sites (`auth/createTestEmailToken.js`, `auth/webauthnHelpers.js`, the rest of `flightnet/index.js`) read `functions.config()` only inside function handlers, so they fail only on invocation. Those are deferred — they'll be addressed when the corresponding functions migrate to Gen 2.

## Verification

- `npm test` in `functions/` — 34 suites / 293 tests pass.
- Runtime simulation **(Gen 2)**: `K_CONFIGURATION` set, `RTDB_URL` provided as env → `index.js` loads cleanly, `admin.initializeApp` gets the env URL, all submodules load without throwing.
- Runtime simulation **(Gen 1)**: `K_CONFIGURATION` unset, mocked `functions.config()` populated → `index.js` loads cleanly, `admin.initializeApp` gets the config URL (existing behavior unchanged).
- **End-to-end on `lszm-test`**: Gen 2 `scheduledCleanupMessages` deployed with the previous PR #748 code failed at container startup with this exact `functions.config()` throw. With this fix applied locally, the function deployed cleanly, ran via Cloud Scheduler "Force run", and successfully deleted messages older than the configured retention.

## Shippability

Same as #748: pure no-op for current Gen 1 deploys. CI continues to deploy normally on merge.

## Test plan

- [x] CI test job green (Jest)
- [ ] Merge → CI prod deploys succeed unchanged
- [ ] Sanity-check one trigger after deploy (e.g. add a movement, confirm enrichDeparture still fires)

## Follow-up

The `scheduledCleanupMessages` Gen 2 migration (PR #2, currently on `feat/scheduled-cleanup-messages-gen2`) waits for this hotfix to land, then rebases on develop and opens.