### PR TITLE
Migrate scheduledCleanupMessages to Gen 2 onSchedule

### DIFF
--- a/functions/cleanupMessages.js
+++ b/functions/cleanupMessages.js
@@ -1,17 +1,18 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onSchedule } = require('firebase-functions/v2/scheduler');
 const admin = require('firebase-admin');
 
 const SCHEDULE = '0 2 * * *'; // Every day at 2 AM
 const TIMEZONE = 'Europe/Zurich';
 
-exports.scheduledCleanupMessages = functions
-  .region('europe-west1')
-  .pubsub
-  .schedule(SCHEDULE)
-  .timeZone(TIMEZONE)
-  .onRun(async () => {
+exports.scheduledCleanupMessages = onSchedule(
+  {
+    region: 'europe-west1',
+    schedule: SCHEDULE,
+    timeZone: TIMEZONE,
+  },
+  async () => {
     const db = admin.database();
 
     const retentionSnap = await db.ref('/settings/messageRetentionDays').once('value');
@@ -47,4 +48,5 @@ exports.scheduledCleanupMessages = functions
       await db.ref('/messages').update(updates);
       console.log(`Deleted ${count} messages`);
     }
-  });
+  }
+);

--- a/functions/cleanupMessages.spec.js
+++ b/functions/cleanupMessages.spec.js
@@ -17,15 +17,8 @@ jest.mock('firebase-admin', () => ({
   initializeApp: jest.fn(),
 }));
 
-jest.mock('firebase-functions/v1', () => ({
-  region: jest.fn().mockReturnThis(),
-  pubsub: {
-    schedule: jest.fn().mockReturnValue({
-      timeZone: jest.fn().mockReturnValue({
-        onRun: jest.fn(fn => fn),
-      }),
-    }),
-  },
+jest.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: jest.fn((opts, fn) => fn),
 }));
 
 function createSnapshot(data) {


### PR DESCRIPTION
## Summary

Swap `firebase-functions/v1` `pubsub.schedule().timeZone().onRun()` chain for the v2 `onSchedule({ region, schedule, timeZone }, handler)` API on `scheduledCleanupMessages`. Handler body is byte-identical; region (`europe-west1`), schedule (`0 2 * * *`), and timezone (`Europe/Zurich`) preserved. Test mock swapped from `firebase-functions/v1` to `firebase-functions/v2/scheduler`.

## Why

First Gen 1 → Gen 2 function in this codebase, picked as the lowest-risk proving ground:
- Scheduled trigger — simplest Gen 2 surface
- No RTDB instance binding, no params, no auth context
- Self-contained 50-line handler
- Already covered by `cleanupMessages.spec.js` (4 cases)
- Daily cleanup — a brief gap during the Gen 1 → Gen 2 swap is harmless

This PR validates the migration pattern that the trigger functions (the actual `firebase-functions` v7 unblock) will follow.

## Verification

- `npm test` in `functions/` — 34 suites / 293 tests pass.
- Endpoint metadata after load: `platform: gcfv2`, `schedule: '0 2 * * *'`, `timeZone: 'Europe/Zurich'`, `region: ['europe-west1']`.
- **End-to-end on `lszm-test`**: deployed cleanly (after deleting the Gen 1 function and providing `RTDB_URL` via `functions/.env.lszm-test`), executed via Cloud Scheduler "Force run", successfully deleted messages older than the configured `messageRetentionDays` setting.

## Deploy procedure (must run on every project before merge)

Firebase **rejects in-place Gen 1 → Gen 2 upgrades** with: *"Upgrading from 1st Gen to 2nd Gen is not yet supported."* The `--force` flag does not bypass this. The supported path is delete-then-redeploy:

```sh
# For each project: dev mfgt-flights, then prod lszt, lszm, lspv, lsze, lszo

# 1. Provide the project's RTDB URL as a Gen 2 runtime env var.
#    Look up the URL in projects/<aerodrome>.json (firebaseDatabaseUrl).
echo "RTDB_URL=https://<projectRtdbHost>.europe-west1.firebasedatabase.app" \
  > functions/.env.<projectId>

# 2. Delete the Gen 1 function.
firebase functions:delete scheduledCleanupMessages \
  --region europe-west1 --force --project <projectId>

# 3. Redeploy as Gen 2.
firebase deploy --only functions:scheduledCleanupMessages --project <projectId>

# 4. Verify.
firebase functions:list --project <projectId> | grep scheduledCleanupMessages
# Expected: v2, europe-west1
```

Brief gap (a few minutes) between delete and deploy where the daily cleanup wouldn't run if 02:00 Europe/Zurich falls in that window — harmless for cleanup.

Once all projects are migrated, merge → CI (`firebase deploy --only functions`) sees no gen change and deploys cleanly on master push.

> Note: `functions/.env.<projectId>` files are not committed in this PR. The Gen 2 function reads `RTDB_URL` at runtime via the K_CONFIGURATION-aware fallback in `index.js` (added in #748 + #749). The `.env` files persist across redeploys because Firebase loads them on every deploy. CI's deploy will pick them up too **once they exist in the repo or are written by the workflow** — that wiring is a separate follow-up PR (and only matters when more than one Gen 2 function exists; today this is the only one).

## Test plan

- [x] CI test job green (Jest)
- [x] Manual delete + deploy on `lszm-test`; Gen 2 listing confirmed; Force Run executed and deleted messages successfully
- [ ] Repeat the deploy procedure on `mfgt-flights` (dev) and the 5 prod projects (`lszt`, `lszm`, `lspv`, `lsze`, `lszo`)
- [ ] After merge, confirm CI prod deploys succeed without prompts
- [ ] Confirm a natural daily 02:00 Europe/Zurich run completes successfully on each project the day after merge

## Out of scope (next PRs)

- Other 3 scheduled functions (`scheduledAerodromesUpdate`, `scheduledAircraftListUpdate`, `scheduledAnonymizeMovements`) — same pattern, each its own PR.
- HTTPS callables (WebAuthn, sign-in code, etc.) — different Gen 2 import (`firebase-functions/v2/https`) and mock shape.
- The 9 instance-bound RTDB / webhook triggers — the actual `firebase-functions` v7 unblock.
- Wiring `RTDB_URL` into Gen 2 deploys via committed `.env.<projectId>` files or CI-side write — only needed when the second Gen 2 function lands.