### PR TITLE
Migrate webhook trigger to Gen 2 onValueCreated

### DIFF
--- a/functions/webhook/index.js
+++ b/functions/webhook/index.js
@@ -1,29 +1,38 @@
-const functions = require('firebase-functions/v1')
-const admin = require('firebase-admin')
+const { onValueCreated } = require('firebase-functions/v2/database');
+const { defineString } = require('firebase-functions/params');
+const { logger } = require('firebase-functions/v2');
+const admin = require('firebase-admin');
 const request = require('request-promise');
 
-const config = process.env.K_CONFIGURATION ? {} : functions.config();
-const { rtdb = {} } = config;
-const instance = rtdb.instance || process.env.RTDB_INSTANCE;
+const RTDB_INSTANCE = defineString('RTDB_INSTANCE');
+const WEBHOOK_REGION = defineString('WEBHOOK_REGION', { default: 'europe-west1' });
 
-module.exports = functions.region('europe-west1').database.instance(instance).ref('status/{statusId}').onCreate(async (snap) => {
-  const r = await admin.database().ref("settings/webhookUrl").once('value')
-  const webhook_url = r.val();
-  if (webhook_url == null || webhook_url == "") {
-    functions.logger.log('Webhook disabled', snap.ref);
-    return;
+module.exports = onValueCreated(
+  {
+    region: `{{ params.${WEBHOOK_REGION.name} }}`,
+    instance: `{{ params.${RTDB_INSTANCE.name} }}`,
+    ref: 'status/{statusId}',
+  },
+  async (event) => {
+    const snap = event.data;
+    const r = await admin.database().ref('settings/webhookUrl').once('value');
+    const webhook_url = r.val();
+    if (webhook_url == null || webhook_url === '') {
+      logger.log('Webhook disabled', snap.ref);
+      return;
+    }
+    logger.log('Webhook started', snap.ref, webhook_url);
+    const message = { text: snap.val().details };
+    const response = await request({
+      uri: webhook_url,
+      method: 'POST',
+      json: true,
+      body: message,
+      resolveWithFullResponse: true,
+    });
+    if (response.statusCode >= 400) {
+      throw new Error(`HTTP Error: ${response.statusCode}`);
+    }
+    logger.log('SUCCESS! Posted', snap.ref);
   }
-  functions.logger.log('Webhook started', snap.ref, webhook_url);
-  const message = {"text": snap.val().details};
-  const response = await request({
-    uri: webhook_url,
-    method: 'POST',
-    json: true,
-    body: message,
-    resolveWithFullResponse: true,
-  });
-  if (response.statusCode >= 400) {
-    throw new Error(`HTTP Error: ${response.statusCode}`);
-  }
-  functions.logger.log('SUCCESS! Posted', snap.ref);
-});
+);


### PR DESCRIPTION
## Summary

Migrate `functions/webhook/index.js` from Gen 1 `database.instance(...).ref(...).onCreate(...)` to Gen 2 `onValueCreated({ region, instance, ref }, handler)`. First instance-bound RTDB trigger to migrate.

Trigger config uses `defineString('RTDB_INSTANCE')` and `defineString('WEBHOOK_REGION')`, embedded as the deploy-time placeholders `` `{{ params.RTDB_INSTANCE }}` `` and `` `{{ params.WEBHOOK_REGION }}` ``. `firebase-tools` resolves these against each project's local `.env.<projectId>` at deploy time.

## Why

This is the **first instance-bound RTDB trigger** to move to Gen 2 — the actual unblock path for the `firebase-functions` v7 bump. Pattern proven here applies to the remaining 8 instance-bound triggers (`enrichMovements` ×4, `setAssociatedMovementsTriggers` ×6, `updateArrivalPaymentStatus`, `invoiceRecipientsTrigger`, `homebasedAircraftTrigger`).

`webhook` was picked because it's the smallest one (1 file, 1 trigger, ~30 lines).

## What does NOT work (documented for the next migrations)

- **Passing the Param object directly** to `instance:` — `PathPattern`'s constructor expects a string and calls `.replace()` on it.
- **Template-literal interpolation `` `${RTDB_INSTANCE}` ``** — produces the string `'params.RTDB_INSTANCE'` (no curly braces); firebase-tools' CEL parser only matches `{{ params.X }}`, so the placeholder is passed through to the Cloud Functions API as-is and rejected as `invalid database name`.
- **`defineString('X').value()` at module load** — returns empty during firebase-tools' source-analysis subprocess; the trigger binds against an empty string.
- **`defineString` defaults in non-interactive deploys** — defaults are only used during interactive prompting; CI deploys in non-interactive mode throw rather than falling back. Every project's `.env` file must explicitly set `RTDB_INSTANCE` and `WEBHOOK_REGION`.

## Why parameterize region

Gen 2 RTDB triggers **cannot be cross-region** (Gen 1 allowed it). Two of our six test envs (`lspv-test`, `mfgt-flights`) have RTDBs in `us-central1`; the rest are in `europe-west1`. Hard-coding `region: 'europe-west1'` would fail with `cannot register cross-region trigger` for the us-central1 projects.

## Verification (end-to-end on all 6 test envs)

| project | RTDB instance | region | trigger-tested |
|---|---|---|---|
| lszm-test | lszm-test-eu | europe-west1 | ✅ Webhook disabled |
| lspl-test | lspl-test-default-rtdb | europe-west1 | (deployed only) |
| lspv-test | lspv-test | us-central1 | ✅ Webhook disabled |
| lszo-test | lszo-test-eu | europe-west1 | ✅ Webhook disabled |
| lsze-test | lsze-test-default-rtdb | europe-west1 | (deployed only) |
| mfgt-flights | mfgt-flights | us-central1 | (deploy only — Google Chat URL configured, skipped trigger-test) |

`npm test` in `functions/`: 34 suites / 293 tests pass unchanged.

## Per-project deploy procedure (for the record)

For each test env (already done before this PR can merge):

```sh
# 1. Add RTDB_INSTANCE + WEBHOOK_REGION to local .env.<projectId>:
#    RTDB_INSTANCE=<instance from `firebase functions:config:get rtdb`>
#    WEBHOOK_REGION=europe-west1  # or us-central1 for cross-region projects

# 2. Delete Gen 1, redeploy Gen 2:
firebase functions:delete webhook --region europe-west1 \
  --force --project <projectId>
firebase deploy --only functions:webhook \
  --project <projectId> --force
```

Note: the delete still uses `--region europe-west1` (where Gen 1 was deployed), even when the new Gen 2 will land in us-central1. The deploy region is determined by the `WEBHOOK_REGION` env var at deploy time.

## Test plan

- [x] Local `npm test` green
- [x] All 6 test envs migrated and verified (table above)
- [ ] CI test job green (Jest)
- [ ] Merge → CI deploys cleanly on develop (no in-place upgrade prompts because Gen 2 already exists per project)
- [ ] Daily app usage on each test env: real `/status` writes fire the webhook (mfgt-flights to Google Chat, others log "Webhook disabled")

## Out of scope (next PRs)

- `updateArrivalPaymentStatus` (1 trigger, has spec, no cross-region issue likely)
- `invoiceRecipientsTrigger` / `homebasedAircraftTrigger` (1 each, customs API side effects)
- `enrichMovements` (4 triggers in one file)
- `setAssociatedMovementsTriggers` (6 triggers in one file)
- Production rollout of `scheduledCleanupMessages` and `webhook`