### PR TITLE
Write functions/.env.<projectId> from per-environment GH vars

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -55,4 +55,11 @@ jobs:
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
+      - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars
+        run: |
+          cat > functions/.env.${{ vars.FIREBASE_PROJECT }} <<EOF
+          RTDB_URL=${{ vars.FIREBASE_RTDB_URL }}
+          RTDB_INSTANCE=${{ vars.FIREBASE_RTDB_NAME }}
+          WEBHOOK_REGION=${{ vars.WEBHOOK_REGION }}
+          EOF
       - run: firebase deploy --only functions

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -53,4 +53,11 @@ jobs:
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
+      - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars
+        run: |
+          cat > functions/.env.${{ vars.FIREBASE_PROJECT }} <<EOF
+          RTDB_URL=${{ vars.FIREBASE_RTDB_URL }}
+          RTDB_INSTANCE=${{ vars.FIREBASE_RTDB_NAME }}
+          WEBHOOK_REGION=${{ vars.WEBHOOK_REGION }}
+          EOF
       - run: firebase deploy --only functions


### PR DESCRIPTION
## Summary

After PR #751 (webhook Gen 2 migration) merged, the dev CI deploy fails for all 6 test envs:

```
Error: In non-interactive mode but have no value for the following environment variables: RTDB_INSTANCE, WEBHOOK_REGION
```

(see [run 25053372418](https://github.com/odch/flightbox/actions/runs/25053372418))

`defineString` params require a value at deploy time. firebase-tools' validation only consults loaded `.env.<projectId>` files (`userEnvs`), not `process.env` — so workflow `env:` blocks don't bypass it (matches the Gen 1 dead-end documented in the migration memory).

## Solution

Add an env-file-write step to **both** workflows that reads per-environment GitHub variables and writes `functions/.env.<projectId>` before `firebase deploy`. Reuses existing `FIREBASE_RTDB_URL` / `FIREBASE_RTDB_NAME` vars and introduces one new var, `WEBHOOK_REGION`.

```yaml
- name: Write functions/.env.<projectId> from environment vars
  run: |
    cat > functions/.env.${{ vars.FIREBASE_PROJECT }} <<EOF
    RTDB_URL=${{ vars.FIREBASE_RTDB_URL }}
    RTDB_INSTANCE=${{ vars.FIREBASE_RTDB_NAME }}
    WEBHOOK_REGION=${{ vars.WEBHOOK_REGION }}
    EOF
```

## GitHub variables — all 6 dev envs configured ✅

Set via `gh variable set` while preparing this PR:

| environment | FIREBASE_RTDB_URL | FIREBASE_RTDB_NAME | WEBHOOK_REGION |
|---|---|---|---|
| `lszt_test` | `https://mfgt-flights.firebaseio.com` *(added)* | `mfgt-flights` *(existing)* | `us-central1` *(added)* |
| `lszm_test` | `https://lszm-test-eu.europe-west1.firebasedatabase.app` *(existing)* | `lszm-test-eu` *(existing)* | `europe-west1` *(added)* |
| `lspl_test` | `https://lspl-test-default-rtdb.europe-west1.firebasedatabase.app` *(existing)* | `lspl-test-default-rtdb` *(existing)* | `europe-west1` *(added)* |
| `lspv_test` | `https://lspv-test.firebaseio.com` *(added)* | `lspv-test` *(existing)* | `us-central1` *(added)* |
| `lsze_test` | `https://lsze-test-default-rtdb.europe-west1.firebasedatabase.app` *(existing)* | `lsze-test-default-rtdb` *(existing)* | `europe-west1` *(added)* |
| `lszo_test` | `https://lszo-test-eu.europe-west1.firebasedatabase.app` *(existing)* | `lszo-test-eu` *(existing)* | `europe-west1` *(added)* |

For prod environments — same three vars need to be set when prod migration happens. Values follow the same pattern (FIREBASE_RTDB_URL/NAME from `projects/*.json` `firebaseDatabaseUrl`, WEBHOOK_REGION matching the prod RTDB region).

## Why these values aren't secret

- `FIREBASE_RTDB_URL` is already in `projects/<aerodrome>.json` (committed)
- `FIREBASE_RTDB_NAME` is the URL's subdomain — derivable from FIREBASE_RTDB_URL
- `WEBHOOK_REGION` is just `europe-west1` or `us-central1`

GH variables (plaintext) is appropriate; no need for secrets.

## Test plan

- [x] All 6 dev env-vars set in the GH UI
- [x] Workflow syntax matches existing step structure
- [ ] CI test job green (Jest)
- [ ] Merge → next push to `develop` triggers the dev deploy with the new step → all 6 functions deploys succeed

## Out of scope

- Prod GH vars + prod webhook migration — happening tonight; this PR's prod workflow change is forward-compatible (won't be exercised until next master push, which only happens after prod migration is complete and prod vars are set)
- Migrating other RTDB triggers — independent follow-up PRs