### PR TITLE
Migrate associatedMovements triggers to Gen 2

### DIFF
--- a/functions/associatedMovements/setAssociatedMovementsTriggers.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.js
@@ -1,6 +1,11 @@
-const functions = require('firebase-functions/v1')
+const { onValueCreated, onValueWritten, onValueDeleted } = require('firebase-functions/v2/database')
+const { logger } = require('firebase-functions/v2')
+const { defineString } = require('firebase-functions/params')
 const admin = require('firebase-admin')
 const utils = require('./utils')
+
+const RTDB_INSTANCE = defineString('RTDB_INSTANCE')
+const REGION = 'europe-west1'
 
 const toValidAssoc = data =>
   data && ['departure', 'arrival'].includes(data.type) ? data : null
@@ -35,7 +40,7 @@ const loadAndUpdateAssociatedMovement = async (
 }
 
 const updateAssociatedMovement = async (movement, aircraftMovements, updatedMovements, isHomeBase) => {
-  functions.logger.log(`Updating associated movement for ${movement.type} ${movement.key}`)
+  logger.log(`Updating associated movement for ${movement.type} ${movement.key}`)
 
   if (updatedMovements[movement.key]) {
     return
@@ -69,11 +74,11 @@ const updateAssociatedMovement = async (movement, aircraftMovements, updatedMove
   updatedMovements[movement.key] = true
 
   if (associatedMovement) {
-    functions.logger.log(
+    logger.log(
       `Updated ${movement.type} ${movement.key} with new associated ${associatedMovement.type} ${associatedMovement.key}`
     )
   } else {
-    functions.logger.log(
+    logger.log(
       `Updated ${movement.type} ${movement.key} with new associated movement missing`
     )
   }
@@ -116,7 +121,7 @@ const isRelevantUpdate = (valuesBefore, valuesAfter) => {
 }
 
 const updateOnCreate = async (snap, type) => {
-  functions.logger.log(`Setting associated movement for new ${type} ${snap.ref.key}`)
+  logger.log(`Setting associated movement for new ${type} ${snap.ref.key}`)
 
   const movement = snap.val()
   movement.key = snap.ref.key
@@ -137,7 +142,7 @@ const updateOnWrite = async (change, type) => {
 
   const snap = change.after
 
-  functions.logger.log(`Setting associated movement for updated ${type} ${snap.ref.key}`)
+  logger.log(`Setting associated movement for updated ${type} ${snap.ref.key}`)
 
   const movement = snap.val()
   movement.key = snap.ref.key
@@ -152,7 +157,7 @@ const updateOnWrite = async (change, type) => {
 }
 
 const updateOnDelete = async (snap, type) => {
-  functions.logger.log(`Setting associated movement for deleted ${type} ${snap.ref.key}`)
+  logger.log(`Setting associated movement for deleted ${type} ${snap.ref.key}`)
 
   const movementKey = snap.ref.key
 
@@ -174,30 +179,34 @@ const updateOnDelete = async (snap, type) => {
   }
 }
 
-const config = process.env.K_CONFIGURATION ? {} : functions.config();
-const { rtdb = {} } = config;
-const instance = rtdb.instance || process.env.RTDB_INSTANCE;
+const instanceOpt = `{{ params.${RTDB_INSTANCE.name} }}`
 
-module.exports.setAssociatedMovementOnCreatedDeparture =
-  functions.region('europe-west1').database.instance(instance).ref('/departures/{departureId}')
-    .onCreate(snap => updateOnCreate(snap, 'departure'))
+module.exports.setAssociatedMovementOnCreatedDeparture = onValueCreated(
+  { region: REGION, instance: instanceOpt, ref: '/departures/{departureId}' },
+  event => updateOnCreate(event.data, 'departure')
+)
 
-module.exports.setAssociatedMovementOnCreatedArrival =
-  functions.region('europe-west1').database.instance(instance).ref('/arrivals/{arrivalId}')
-    .onCreate(snap => updateOnCreate(snap, 'arrival'))
+module.exports.setAssociatedMovementOnCreatedArrival = onValueCreated(
+  { region: REGION, instance: instanceOpt, ref: '/arrivals/{arrivalId}' },
+  event => updateOnCreate(event.data, 'arrival')
+)
 
-module.exports.setAssociatedMovementOnUpdatedDeparture =
-  functions.region('europe-west1').database.instance(instance).ref('/departures/{departureId}')
-    .onWrite(change => updateOnWrite(change, 'departure'))
+module.exports.setAssociatedMovementOnUpdatedDeparture = onValueWritten(
+  { region: REGION, instance: instanceOpt, ref: '/departures/{departureId}' },
+  event => updateOnWrite(event.data, 'departure')
+)
 
-module.exports.setAssociatedMovementOnUpdatedArrival =
-  functions.region('europe-west1').database.instance(instance).ref('/arrivals/{arrivalId}')
-    .onWrite(change => updateOnWrite(change, 'arrival'))
+module.exports.setAssociatedMovementOnUpdatedArrival = onValueWritten(
+  { region: REGION, instance: instanceOpt, ref: '/arrivals/{arrivalId}' },
+  event => updateOnWrite(event.data, 'arrival')
+)
 
-module.exports.setAssociatedMovementOnDeletedDeparture =
-  functions.region('europe-west1').database.instance(instance).ref('/departures/{departureId}')
-    .onDelete(snap => updateOnDelete(snap, 'departure'))
+module.exports.setAssociatedMovementOnDeletedDeparture = onValueDeleted(
+  { region: REGION, instance: instanceOpt, ref: '/departures/{departureId}' },
+  event => updateOnDelete(event.data, 'departure')
+)
 
-module.exports.setAssociatedMovementOnDeletedArrival =
-  functions.region('europe-west1').database.instance(instance).ref('/arrivals/{arrivalId}')
-    .onDelete(snap => updateOnDelete(snap, 'arrival'))
+module.exports.setAssociatedMovementOnDeletedArrival = onValueDeleted(
+  { region: REGION, instance: instanceOpt, ref: '/arrivals/{arrivalId}' },
+  event => updateOnDelete(event.data, 'arrival')
+)

--- a/functions/associatedMovements/setAssociatedMovementsTriggers.spec.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.spec.js
@@ -2,36 +2,30 @@
 
 const mockCapturedHandlers = {};
 
-jest.mock('firebase-functions/v1', () => {
-  const makeDbRef = (path) => ({
-    onCreate: jest.fn(handler => {
-      mockCapturedHandlers[`onCreate:${path}`] = handler;
-    }),
-    onWrite: jest.fn(handler => {
-      mockCapturedHandlers[`onWrite:${path}`] = handler;
-    }),
-    onDelete: jest.fn(handler => {
-      mockCapturedHandlers[`onDelete:${path}`] = handler;
-    })
-  });
+jest.mock('firebase-functions/v2/database', () => ({
+  onValueCreated: jest.fn((opts, handler) => {
+    mockCapturedHandlers[`onCreate:${opts.ref}`] = handler;
+  }),
+  onValueWritten: jest.fn((opts, handler) => {
+    mockCapturedHandlers[`onWrite:${opts.ref}`] = handler;
+  }),
+  onValueDeleted: jest.fn((opts, handler) => {
+    mockCapturedHandlers[`onDelete:${opts.ref}`] = handler;
+  })
+}));
 
-  const mock = {
-    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
-    logger: {
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-      log: jest.fn()
-    },
-    database: {
-      instance: jest.fn(() => ({
-        ref: makeDbRef
-      }))
-    }
-  };
-  mock.region = jest.fn(() => mock);
-  return mock;
-});
+jest.mock('firebase-functions/v2', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn()
+  }
+}));
+
+jest.mock('firebase-functions/params', () => ({
+  defineString: jest.fn(name => ({ name }))
+}));
 
 const mockUpdate = jest.fn();
 const mockOnce = jest.fn();
@@ -91,7 +85,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onWrite:/departures/{departureId}'];
-      await handler(change);
+      await handler({ data: change });
 
       expect(utils.setAssociatedMovement).toHaveBeenCalled();
     });
@@ -113,7 +107,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onWrite:/departures/{departureId}'];
-      await handler(change);
+      await handler({ data: change });
 
       expect(utils.setAssociatedMovement).toHaveBeenCalled();
     });
@@ -135,7 +129,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onWrite:/arrivals/{arrivalId}'];
-      await handler(change);
+      await handler({ data: change });
 
       expect(utils.setAssociatedMovement).toHaveBeenCalled();
     });
@@ -157,7 +151,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onWrite:/departures/{departureId}'];
-      await handler(change);
+      await handler({ data: change });
 
       expect(utils.setAssociatedMovement).toHaveBeenCalled();
     });
@@ -186,7 +180,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onWrite:/departures/{departureId}'];
-      await handler(change);
+      await handler({ data: change });
 
       expect(utils.setAssociatedMovement).not.toHaveBeenCalled();
     });
@@ -203,7 +197,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onWrite:/departures/{departureId}'];
-      await handler(change);
+      await handler({ data: change });
 
       expect(utils.setAssociatedMovement).not.toHaveBeenCalled();
     });
@@ -215,7 +209,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onWrite:/departures/{departureId}'];
-      await handler(change);
+      await handler({ data: change });
 
       expect(utils.setAssociatedMovement).not.toHaveBeenCalled();
     });
@@ -236,7 +230,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.loadAircraftMovements).toHaveBeenCalledWith('HBKOF');
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('dep-001', 'departure', null);
@@ -257,7 +251,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/arrivals/{arrivalId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.loadAircraftMovements).toHaveBeenCalledWith('HBABC');
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('arr-001', 'arrival', associatedDep);
@@ -278,7 +272,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/arrivals/{arrivalId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('arr-001', 'arrival', associatedDep);
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('dep-001', 'departure', { key: 'arr-001', type: 'arrival' });
@@ -295,7 +289,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onDelete:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.setAssociatedMovement).not.toHaveBeenCalled();
     });
@@ -309,7 +303,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onDelete:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.setAssociatedMovement).not.toHaveBeenCalled();
     });
@@ -334,7 +328,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onDelete:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(mockRemove).toHaveBeenCalled();
       expect(utils.setAssociatedMovement).not.toHaveBeenCalled();
@@ -360,7 +354,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onDelete:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(mockRemove).toHaveBeenCalled();
       expect(utils.setAssociatedMovement).not.toHaveBeenCalled();
@@ -396,7 +390,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onDelete:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.setAssociatedMovement).toHaveBeenCalled();
     });
@@ -431,7 +425,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onDelete:/arrivals/{arrivalId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.setAssociatedMovement).toHaveBeenCalled();
     });
@@ -476,7 +470,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onDelete:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.loadAircraftMovements).toHaveBeenCalledWith('HBKOF');
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('arr-001', 'arrival', null);
@@ -520,7 +514,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onDelete:/arrivals/{arrivalId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.loadAircraftMovements).toHaveBeenCalledWith('DEXYZ');
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('dep-001', 'departure', null);
@@ -546,7 +540,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(callCount).toBe(1);
     });
@@ -589,7 +583,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(onceCalls).toBeGreaterThanOrEqual(2);
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('dep-001', 'departure', null);
@@ -647,7 +641,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('dep-001', 'departure', newAssociatedMovement);
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('arr-001', 'arrival', { key: 'dep-001', type: 'departure' });
@@ -686,7 +680,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('dep-001', 'departure', arrMovement);
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('arr-001', 'arrival', { key: 'dep-001', type: 'departure' });
@@ -726,7 +720,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('dep-001', 'departure', null);
       expect(utils.setAssociatedMovement).toHaveBeenCalledTimes(1);
@@ -765,7 +759,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(onceCalls).toBeGreaterThanOrEqual(2);
       expect(utils.setAssociatedMovement).toHaveBeenCalledWith('dep-001', 'departure', null);
@@ -806,7 +800,7 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
       };
 
       const handler = mockCapturedHandlers['onDelete:/departures/{departureId}'];
-      await handler(snap);
+      await handler({ data: snap });
 
       expect(utils.loadAircraftMovements).toHaveBeenCalledWith('HBKOF');
       expect(utils.loadAircraftMovements).not.toHaveBeenCalledWith(undefined);

--- a/functions/associatedMovements/setAssociatedMovementsTriggers.spec.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.spec.js
@@ -213,6 +213,21 @@ describe('functions/associatedMovements/setAssociatedMovementsTriggers', () => {
 
       expect(utils.setAssociatedMovement).not.toHaveBeenCalled();
     });
+
+    it('returns early for anonymized movements without processing', async () => {
+      const change = {
+        before: { val: () => ({ dateTime: '2024-01-01T10:00:00', immatriculation: 'HBKOF' }) },
+        after: {
+          val: () => ({ dateTime: '2024-01-01T10:00:00', immatriculation: 'HBKOF', anonymized: true }),
+          ref: { key: 'dep-001' }
+        }
+      };
+
+      const handler = mockCapturedHandlers['onWrite:/departures/{departureId}'];
+      await handler({ data: change });
+
+      expect(utils.setAssociatedMovement).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateOnCreate', () => {


### PR DESCRIPTION
## Summary
- Ports the six RTDB triggers in `functions/associatedMovements/setAssociatedMovementsTriggers.js` (`onCreate`/`onWrite`/`onDelete` × departures/arrivals) from `firebase-functions/v1` to v2 (`onValueCreated` / `onValueWritten` / `onValueDeleted`), matching the pattern used by `webhook/index.js`.
- RTDB instance now sourced from the `RTDB_INSTANCE` param via `defineString`; legacy `functions.config()` / `K_CONFIGURATION` fallback removed.
- Export names preserved (`setAssociatedMovementOn{Created,Updated,Deleted}{Departure,Arrival}`) so existing deployments don't rename functions.
- Spec rewritten to mock `firebase-functions/v2/database`, `v2` (logger), and `params`; all 25 tests updated to invoke handlers with `{ data: ... }` events.

## Deploy note
Gen 1 → Gen 2 changes the underlying transport; the first `firebase deploy` after merge may need `--force` to recreate these six functions. Plan a low-traffic window — during the swap, associated-movement updates may be momentarily skipped.

## Test plan
- [x] `cd functions && npm test` — 293/293 passing
- [x] `npm run typecheck` — clean
- [ ] Staging deploy: confirm Gen 2 logs ("Setting associated movement for new departure …") fire on `/departures/{id}` write
- [ ] Verify no Gen 1 ghost remains in Firebase console after deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjHWApkU9Bg8Qf5LPvjzx9)_