### PR TITLE
Use shared RTDB_REGION param across Gen 2 RTDB triggers

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -60,6 +60,6 @@ jobs:
           cat > functions/.env.${{ vars.FIREBASE_PROJECT }} <<EOF
           RTDB_URL=${{ vars.FIREBASE_RTDB_URL }}
           RTDB_INSTANCE=${{ vars.FIREBASE_RTDB_NAME }}
-          WEBHOOK_REGION=${{ vars.WEBHOOK_REGION }}
+          RTDB_REGION=${{ vars.RTDB_REGION }}
           EOF
       - run: firebase deploy --only functions

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -58,6 +58,6 @@ jobs:
           cat > functions/.env.${{ vars.FIREBASE_PROJECT }} <<EOF
           RTDB_URL=${{ vars.FIREBASE_RTDB_URL }}
           RTDB_INSTANCE=${{ vars.FIREBASE_RTDB_NAME }}
-          WEBHOOK_REGION=${{ vars.WEBHOOK_REGION }}
+          RTDB_REGION=${{ vars.RTDB_REGION }}
           EOF
       - run: firebase deploy --only functions

--- a/functions/associatedMovements/setAssociatedMovementsTriggers.js
+++ b/functions/associatedMovements/setAssociatedMovementsTriggers.js
@@ -5,7 +5,7 @@ const admin = require('firebase-admin')
 const utils = require('./utils')
 
 const RTDB_INSTANCE = defineString('RTDB_INSTANCE')
-const REGION = 'europe-west1'
+const RTDB_REGION = defineString('RTDB_REGION', { default: 'europe-west1' })
 
 const toValidAssoc = data =>
   data && ['departure', 'arrival'].includes(data.type) ? data : null
@@ -180,33 +180,34 @@ const updateOnDelete = async (snap, type) => {
 }
 
 const instanceOpt = `{{ params.${RTDB_INSTANCE.name} }}`
+const regionOpt = `{{ params.${RTDB_REGION.name} }}`
 
 module.exports.setAssociatedMovementOnCreatedDeparture = onValueCreated(
-  { region: REGION, instance: instanceOpt, ref: '/departures/{departureId}' },
+  { region: regionOpt, instance: instanceOpt, ref: '/departures/{departureId}' },
   event => updateOnCreate(event.data, 'departure')
 )
 
 module.exports.setAssociatedMovementOnCreatedArrival = onValueCreated(
-  { region: REGION, instance: instanceOpt, ref: '/arrivals/{arrivalId}' },
+  { region: regionOpt, instance: instanceOpt, ref: '/arrivals/{arrivalId}' },
   event => updateOnCreate(event.data, 'arrival')
 )
 
 module.exports.setAssociatedMovementOnUpdatedDeparture = onValueWritten(
-  { region: REGION, instance: instanceOpt, ref: '/departures/{departureId}' },
+  { region: regionOpt, instance: instanceOpt, ref: '/departures/{departureId}' },
   event => updateOnWrite(event.data, 'departure')
 )
 
 module.exports.setAssociatedMovementOnUpdatedArrival = onValueWritten(
-  { region: REGION, instance: instanceOpt, ref: '/arrivals/{arrivalId}' },
+  { region: regionOpt, instance: instanceOpt, ref: '/arrivals/{arrivalId}' },
   event => updateOnWrite(event.data, 'arrival')
 )
 
 module.exports.setAssociatedMovementOnDeletedDeparture = onValueDeleted(
-  { region: REGION, instance: instanceOpt, ref: '/departures/{departureId}' },
+  { region: regionOpt, instance: instanceOpt, ref: '/departures/{departureId}' },
   event => updateOnDelete(event.data, 'departure')
 )
 
 module.exports.setAssociatedMovementOnDeletedArrival = onValueDeleted(
-  { region: REGION, instance: instanceOpt, ref: '/arrivals/{arrivalId}' },
+  { region: regionOpt, instance: instanceOpt, ref: '/arrivals/{arrivalId}' },
   event => updateOnDelete(event.data, 'arrival')
 )

--- a/functions/webhook/index.js
+++ b/functions/webhook/index.js
@@ -5,11 +5,11 @@ const admin = require('firebase-admin');
 const request = require('request-promise');
 
 const RTDB_INSTANCE = defineString('RTDB_INSTANCE');
-const WEBHOOK_REGION = defineString('WEBHOOK_REGION', { default: 'europe-west1' });
+const RTDB_REGION = defineString('RTDB_REGION', { default: 'europe-west1' });
 
 module.exports = onValueCreated(
   {
-    region: `{{ params.${WEBHOOK_REGION.name} }}`,
+    region: `{{ params.${RTDB_REGION.name} }}`,
     instance: `{{ params.${RTDB_INSTANCE.name} }}`,
     ref: 'status/{statusId}',
   },


### PR DESCRIPTION
## Summary
- Replace the hardcoded `europe-west1` in `setAssociatedMovementsTriggers.js` with an `RTDB_REGION` `defineString` param.
- Rename the existing `WEBHOOK_REGION` param to the same `RTDB_REGION`, since every RTDB-bound Gen 2 trigger in a project must run in the RTDB's region — the value is per-database, not per-function.
- Update both deploy workflows (`firebase-hosting-{dev,prod}.yml`) to write `RTDB_REGION=${{ vars.RTDB_REGION }}` into the generated `.env.<projectId>`.

## Why
The associatedMovements Gen 2 migration (#TBD, merged just before this) ships with `region: 'europe-west1'` hardcoded. Two of our deploy targets (`lspv-test`, `mfgt-flights`) have RTDBs in `us-central1`, and Gen 2 rejects cross-region RTDB triggers with `cannot register cross-region trigger`. Without this change, those two envs cannot get the new triggers at all.

Rather than introduce a parallel `<FUNC>_REGION` per function group (`ASSOCIATED_MOVEMENTS_REGION`, then later `ENRICH_MOVEMENTS_REGION`, etc.), use a single `RTDB_REGION` shared across all RTDB triggers — the region is a property of the database, not the function. Pairs naturally with the existing `RTDB_INSTANCE` param.

## Action required before merge
Rename the per-environment GitHub variable `WEBHOOK_REGION` → `RTDB_REGION` in each environment's settings (values unchanged). The CI `.env.<projectId>` write step references `${{ vars.RTDB_REGION }}` after this PR; without the variable rename, deploys will produce an empty `RTDB_REGION` and firebase-tools will reject the deploy.

Environments affected:
- `lspl-test`, `lspv-test`, `lsze-test`, `lszm-test`, `lszo-test`, `mfgt-flights`
- corresponding prod envs

## Test plan
- [ ] Rename GH variable `WEBHOOK_REGION` → `RTDB_REGION` in every environment
- [ ] Delete Gen 1 associatedMovements functions per env (`firebase functions:delete <names> --region europe-west1 --force --project <projectId>`)
- [ ] CI deploy of this branch lands Gen 2 triggers in the correct region per env
- [ ] Verify webhook still fires after the rename
- [ ] Verify associatedMovements triggers fire on a test movement in `lspv-test` (us-central1) and `lszm-test` (europe-west1)