### PR TITLE
Migrate updateArrivalPaymentStatus trigger to Gen 2

### DIFF
--- a/functions/updateArrivalPaymentStatus.js
+++ b/functions/updateArrivalPaymentStatus.js
@@ -1,9 +1,10 @@
-const functions = require('firebase-functions/v1');
+const { onValueWritten } = require('firebase-functions/v2/database');
+const { logger } = require('firebase-functions/v2');
+const { defineString } = require('firebase-functions/params');
 const admin = require('firebase-admin');
 
-const config = process.env.K_CONFIGURATION ? {} : functions.config();
-const { rtdb = {} } = config;
-const instance = rtdb.instance || process.env.RTDB_INSTANCE;
+const RTDB_INSTANCE = defineString('RTDB_INSTANCE');
+const RTDB_REGION = defineString('RTDB_REGION', { default: 'europe-west1' });
 
 const handleUpdate = async (change) => {
   if (!change.before.exists() || !change.after.exists()) {
@@ -21,7 +22,7 @@ const handleUpdate = async (change) => {
   }
 
   if (!afterValue.arrivalReference) {
-    functions.logger.info(
+    logger.info(
       `Unable to set arrival payment status for card-payment ${cardPaymentKey}, because arrivalReference is missing`
     );
   }
@@ -35,7 +36,7 @@ const handleUpdate = async (change) => {
     const arrivalValues = arrivalSnapshot.val()
 
     if (arrivalValues.paymentMethod && arrivalValues.paymentMethod.status === 'pending') {
-      functions.logger.info(
+      logger.info(
         `Setting payment status of arrival ${afterValue.arrivalReference} to completed (card payment ${cardPaymentKey})`
       );
 
@@ -50,7 +51,7 @@ const handleUpdate = async (change) => {
         });
     }
   } catch (error) {
-    functions.logger.error(
+    logger.error(
       `Failed to update payment status of arrival ${afterValue.arrivalReference}`,
       error
     );
@@ -58,9 +59,10 @@ const handleUpdate = async (change) => {
   }
 };
 
-exports.updateArrivalPaymentStatusOnCardPaymentUpdate = functions
-  .region('europe-west1')
-  .database
-  .instance(instance)
-  .ref('/card-payments/{paymentId}')
-  .onWrite(handleUpdate);
+const instanceOpt = `{{ params.${RTDB_INSTANCE.name} }}`;
+const regionOpt = `{{ params.${RTDB_REGION.name} }}`;
+
+exports.updateArrivalPaymentStatusOnCardPaymentUpdate = onValueWritten(
+  { region: regionOpt, instance: instanceOpt, ref: '/card-payments/{paymentId}' },
+  event => handleUpdate(event.data)
+);

--- a/functions/updateArrivalPaymentStatus.spec.js
+++ b/functions/updateArrivalPaymentStatus.spec.js
@@ -1,34 +1,40 @@
+'use strict';
+
+let mockCapturedHandler = null;
+
+jest.mock('firebase-functions/v2/database', () => ({
+  onValueWritten: jest.fn((opts, handler) => {
+    mockCapturedHandler = handler;
+  })
+}));
+
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  log: jest.fn()
+};
+
+jest.mock('firebase-functions/v2', () => ({
+  logger: mockLogger
+}));
+
+jest.mock('firebase-functions/params', () => ({
+  defineString: jest.fn(name => ({ name }))
+}));
+
+const mockAdmin = {
+  database: jest.fn()
+};
+
+jest.mock('firebase-admin', () => mockAdmin);
+
+require('./updateArrivalPaymentStatus');
+
 describe('functions', () => {
   describe('updateArrivalPaymentStatus handleUpdate', () => {
-    let mockAdmin;
-    let mockFunctions;
-    let capturedHandler;
-
     beforeEach(() => {
-      jest.resetModules();
-
-      capturedHandler = null;
-      mockAdmin = {
-        database: jest.fn()
-      };
-      mockFunctions = {
-        config: jest.fn().mockReturnValue({ rtdb: { instance: 'test-instance' } }),
-        logger: { info: jest.fn(), error: jest.fn() },
-        region: jest.fn().mockReturnValue({
-          database: {
-            instance: jest.fn().mockReturnValue({
-              ref: jest.fn().mockReturnValue({
-                onWrite: jest.fn().mockImplementation(fn => { capturedHandler = fn; })
-              })
-            })
-          }
-        })
-      };
-
-      jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
-
-      require('./updateArrivalPaymentStatus');
+      jest.clearAllMocks();
     });
 
     const makeChange = (beforeVal, afterVal, afterKey = 'pay1') => ({
@@ -46,13 +52,13 @@ describe('functions', () => {
 
     it('returns null when before does not exist', async () => {
       const change = makeChange(null, { status: 'success', arrivalReference: 'arr1' });
-      const result = await capturedHandler(change);
+      const result = await mockCapturedHandler({ data: change });
       expect(result).toBeNull();
     });
 
     it('returns null when after does not exist', async () => {
       const change = makeChange({ status: 'pending' }, null);
-      const result = await capturedHandler(change);
+      const result = await mockCapturedHandler({ data: change });
       expect(result).toBeNull();
     });
 
@@ -61,7 +67,7 @@ describe('functions', () => {
         { status: 'pending' },
         { status: 'pending', arrivalReference: 'arr1' }
       );
-      const result = await capturedHandler(change);
+      const result = await mockCapturedHandler({ data: change });
       expect(result).toBeUndefined();
       expect(mockAdmin.database).not.toHaveBeenCalled();
     });
@@ -83,8 +89,8 @@ describe('functions', () => {
         { status: 'pending' },
         { status: 'success' }  // no arrivalReference
       );
-      await capturedHandler(change);
-      expect(mockFunctions.logger.info).toHaveBeenCalled();
+      await mockCapturedHandler({ data: change });
+      expect(mockLogger.info).toHaveBeenCalled();
     });
 
     it('updates arrival payment status when status changes to success', async () => {
@@ -106,7 +112,7 @@ describe('functions', () => {
         { status: 'success', arrivalReference: 'arr1' }
       );
 
-      await capturedHandler(change);
+      await mockCapturedHandler({ data: change });
 
       expect(mockRef.update).toHaveBeenCalledWith({
         paymentMethod: { status: 'completed', method: 'card' }
@@ -132,7 +138,7 @@ describe('functions', () => {
         { status: 'success', arrivalReference: 'arr1' }
       );
 
-      await capturedHandler(change);
+      await mockCapturedHandler({ data: change });
 
       expect(mockRef.update).not.toHaveBeenCalled();
     });
@@ -156,8 +162,8 @@ describe('functions', () => {
         { status: 'success', arrivalReference: 'arr1' }
       );
 
-      await expect(capturedHandler(change)).rejects.toThrow('DB error');
-      expect(mockFunctions.logger.error).toHaveBeenCalled();
+      await expect(mockCapturedHandler({ data: change })).rejects.toThrow('DB error');
+      expect(mockLogger.error).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Migrates `updateArrivalPaymentStatusOnCardPaymentUpdate` from `firebase-functions/v1` to v2 `onValueWritten`, following the associatedMovements pattern with the shared `RTDB_INSTANCE` / `RTDB_REGION` params.
- Drops the legacy `functions.config() / process.env.RTDB_INSTANCE` fallback and the hardcoded `europe-west1` region; logger calls swapped to v2.
- Spec rewritten to mock the Gen 2 trigger functions and invoke the captured handler with `{ data: change }`. Handler body unchanged.

## Test plan
- [x] `npm run test:functions` — 294 / 294 pass
- [ ] Manual Gen 1 → Gen 2 cutover per test env (firebase functions:delete in `europe-west1`, then deploy):
  - [ ] lspl-test
  - [ ] lspv-test (RTDB in us-central1 — function moves region)
  - [ ] lsze-test
  - [ ] lszm-test
  - [ ] lszo-test
  - [ ] mfgt-flights (RTDB in us-central1 — function moves region)
- [ ] On lszm-test, set a `/card-payments/{id}.status` to `success` with a valid `arrivalReference` and confirm `/arrivals/{ref}.paymentMethod.status` flips to `completed`.

## Migration progress
Part of the Gen 1 → Gen 2 RTDB trigger migration unblocking the `firebase-functions` v7 bump. Remaining after this PR: `invoiceRecipientsTrigger`, `homebasedAircraftTrigger`, `enrichMovements`.