### PR TITLE
Migrate invoiceRecipientsTrigger to Gen 2

### DIFF
--- a/functions/invoiceRecipients/invoiceRecipientsTrigger.js
+++ b/functions/invoiceRecipients/invoiceRecipientsTrigger.js
@@ -1,53 +1,58 @@
-const functions = require('firebase-functions/v1')
+const { onValueWritten } = require('firebase-functions/v2/database')
+const { logger } = require('firebase-functions/v2')
+const { defineString } = require('firebase-functions/params')
 const admin = require('firebase-admin')
 
-const config = process.env.K_CONFIGURATION ? {} : functions.config()
-const { rtdb = {} } = config
-const instance = rtdb.instance || process.env.RTDB_INSTANCE
+const RTDB_INSTANCE = defineString('RTDB_INSTANCE')
+const RTDB_REGION = defineString('RTDB_REGION', { default: 'europe-west1' })
 
-module.exports.updateCustomsInvoiceRecipientsOnUpdate =
-  functions.region('europe-west1').database.instance(instance).ref('/settings/invoiceRecipients')
-    .onWrite(async (change, context) => {
-      const before = change.before.val()
-      const after = change.after.val()
+const instanceOpt = `{{ params.${RTDB_INSTANCE.name} }}`
+const regionOpt = `{{ params.${RTDB_REGION.name} }}`
 
-      if (JSON.stringify(before) === JSON.stringify(after)) {
-        console.log('No change detected.')
-        return
-      }
+module.exports.updateCustomsInvoiceRecipientsOnUpdate = onValueWritten(
+  { region: regionOpt, instance: instanceOpt, ref: '/settings/invoiceRecipients' },
+  async (event) => {
+    const before = event.data.before.val()
+    const after = event.data.after.val()
 
-      const snapshot = await admin.database().ref('/settings/customsDeclarationApp').once('value')
-      const customsSettings = snapshot.val()
+    if (JSON.stringify(before) === JSON.stringify(after)) {
+      logger.info('No change detected.')
+      return
+    }
 
-      if (!customsSettings || !customsSettings.baseUrl) {
-        console.log('No customs declaration settings in /settings/customsDeclarationApp. Aborting...')
-        return
-      }
+    const snapshot = await admin.database().ref('/settings/customsDeclarationApp').once('value')
+    const customsSettings = snapshot.val()
 
-      const url = `${customsSettings.baseUrl}/api/invoice-recipients?ad=${customsSettings.aerodrome}`
+    if (!customsSettings || !customsSettings.baseUrl) {
+      logger.info('No customs declaration settings in /settings/customsDeclarationApp. Aborting...')
+      return
+    }
 
-      const body = (after || []).map(recipient => ({
-        name: recipient.name,
-        emails: recipient.emails || []
-      }))
+    const url = `${customsSettings.baseUrl}/api/invoice-recipients?ad=${customsSettings.aerodrome}`
 
-      const jsonBody = JSON.stringify(body)
+    const body = (after || []).map(recipient => ({
+      name: recipient.name,
+      emails: recipient.emails || []
+    }))
 
-      const response = await fetch(url, {
-        method: 'PUT',
-        headers: {
-          'Authorization': `Bearer ${customsSettings.accessToken}`,
-          'Content-Type': 'application/json'
-        },
-        body: jsonBody
-      })
+    const jsonBody = JSON.stringify(body)
 
-      if (response.ok) {
-        console.log('Successfully updated invoice recipients of the customs app')
-      } else {
-        console.log('Failed to update the invoice recipients of the customs app', response)
-
-        const body = await response.json()
-        console.log('Response body', body)
-      }
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Bearer ${customsSettings.accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: jsonBody
     })
+
+    if (response.ok) {
+      logger.info('Successfully updated invoice recipients of the customs app')
+    } else {
+      logger.error('Failed to update the invoice recipients of the customs app', response)
+
+      const body = await response.json()
+      logger.error('Response body', body)
+    }
+  }
+)

--- a/functions/invoiceRecipients/invoiceRecipientsTrigger.spec.js
+++ b/functions/invoiceRecipients/invoiceRecipientsTrigger.spec.js
@@ -1,21 +1,27 @@
 'use strict';
 
-let capturedHandler;
+let mockCapturedHandler = null;
 
-jest.mock('firebase-functions/v1', () => {
-  const mock = {
-    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
-    database: {
-      instance: jest.fn(() => ({
-        ref: jest.fn(() => ({
-          onWrite: jest.fn(handler => { capturedHandler = handler; }),
-        })),
-      })),
-    },
-  };
-  mock.region = jest.fn(() => mock);
-  return mock;
-});
+jest.mock('firebase-functions/v2/database', () => ({
+  onValueWritten: jest.fn((opts, handler) => {
+    mockCapturedHandler = handler;
+  })
+}));
+
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  log: jest.fn()
+};
+
+jest.mock('firebase-functions/v2', () => ({
+  logger: mockLogger
+}));
+
+jest.mock('firebase-functions/params', () => ({
+  defineString: jest.fn(name => ({ name }))
+}));
 
 const mockAdminDbRef = jest.fn();
 jest.mock('firebase-admin', () => ({
@@ -24,32 +30,11 @@ jest.mock('firebase-admin', () => ({
 
 global.fetch = jest.fn();
 
+require('./invoiceRecipientsTrigger');
+
 describe('functions/invoiceRecipients/invoiceRecipientsTrigger', () => {
   beforeEach(() => {
-    jest.resetModules();
     jest.clearAllMocks();
-    capturedHandler = null;
-
-    jest.mock('firebase-functions/v1', () => {
-      const mock = {
-        config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
-        database: {
-          instance: jest.fn(() => ({
-            ref: jest.fn(() => ({
-              onWrite: jest.fn(handler => { capturedHandler = handler; }),
-            })),
-          })),
-        },
-      };
-      mock.region = jest.fn(() => mock);
-      return mock;
-    });
-
-    jest.mock('firebase-admin', () => ({
-      database: jest.fn(() => ({ ref: mockAdminDbRef })),
-    }));
-
-    require('./invoiceRecipientsTrigger');
   });
 
   const makeChange = (before, after) => ({
@@ -59,7 +44,7 @@ describe('functions/invoiceRecipients/invoiceRecipientsTrigger', () => {
 
   it('does nothing when before and after are equal', async () => {
     const change = makeChange([{ name: 'A', emails: [] }], [{ name: 'A', emails: [] }]);
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
     expect(mockAdminDbRef).not.toHaveBeenCalled();
     expect(global.fetch).not.toHaveBeenCalled();
   });
@@ -69,7 +54,7 @@ describe('functions/invoiceRecipients/invoiceRecipientsTrigger', () => {
       once: jest.fn().mockResolvedValue({ val: () => null }),
     });
     const change = makeChange([{ name: 'A' }], [{ name: 'B' }]);
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -78,7 +63,7 @@ describe('functions/invoiceRecipients/invoiceRecipientsTrigger', () => {
       once: jest.fn().mockResolvedValue({ val: () => ({ aerodrome: 'LSZT' }) }),
     });
     const change = makeChange([{ name: 'A' }], [{ name: 'B' }]);
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -100,7 +85,7 @@ describe('functions/invoiceRecipients/invoiceRecipientsTrigger', () => {
       { name: 'Bob', emails: ['bob@example.com', 'bob2@example.com'] },
     ];
     const change = makeChange([{ name: 'Old' }], after);
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
 
     expect(global.fetch).toHaveBeenCalledWith(
       'https://customs.example.com/api/invoice-recipients?ad=LSZT',
@@ -132,7 +117,7 @@ describe('functions/invoiceRecipients/invoiceRecipientsTrigger', () => {
     global.fetch.mockResolvedValue({ ok: true });
 
     const change = makeChange([{ name: 'Old' }], null);
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.any(String),
@@ -156,14 +141,12 @@ describe('functions/invoiceRecipients/invoiceRecipientsTrigger', () => {
       json: jest.fn().mockResolvedValue({ error: 'Not authorized' }),
     });
 
-    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const change = makeChange([{ name: 'A' }], [{ name: 'B' }]);
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
 
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(mockLogger.error).toHaveBeenCalledWith(
       'Failed to update the invoice recipients of the customs app',
       expect.anything()
     );
-    consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Migrates `updateCustomsInvoiceRecipientsOnUpdate` from `firebase-functions/v1` to v2 `onValueWritten`, following the pattern landed in #758.
- Drops the legacy `functions.config() / process.env.RTDB_INSTANCE` fallback and the hardcoded `europe-west1` region in favour of the shared `RTDB_INSTANCE` / `RTDB_REGION` params.
- Swaps the 5 `console.log` calls for the v2 `logger` (success/no-op at info, fetch-failure at error). Failure-path severity in Cloud Logging changes INFO → ERROR.
- Spec rewritten to mock the Gen 2 trigger surface; the 6 test cases keep their inputs and semantics, and the fetch-failure test now asserts on `mockLogger.error` instead of spying `console.log`.

## Test plan
- [x] `npx jest invoiceRecipientsTrigger.spec.js` — 6 / 6 pass
- [x] `npm run test:functions` — 294 / 294 pass
- [ ] Manual Gen 1 → Gen 2 cutover per test env (`firebase functions:delete updateCustomsInvoiceRecipientsOnUpdate --region europe-west1`, then deploy):
  - [ ] lspl-test
  - [ ] lspv-test (RTDB in us-central1 — function moves region)
  - [ ] lsze-test
  - [ ] lszm-test
  - [ ] lszo-test
  - [ ] mfgt-flights (RTDB in us-central1 — function moves region)
- [ ] On lszm-test, modify `/settings/invoiceRecipients` in the RTDB and confirm the customs API receives the PUT (verify in customs app logs or by checking the recipients list there).

## Migration progress
Part of the Gen 1 → Gen 2 RTDB trigger migration unblocking the `firebase-functions` v7 bump. Remaining after this PR: `homebasedAircraftTrigger`, `enrichMovements`.