### PR TITLE
Migrate homebasedAircraftTrigger to Gen 2

### DIFF
--- a/functions/homebasedAircraft/homebasedAircraftTrigger.js
+++ b/functions/homebasedAircraft/homebasedAircraftTrigger.js
@@ -1,9 +1,13 @@
-const functions = require('firebase-functions/v1')
+const { onValueWritten } = require('firebase-functions/v2/database')
+const { logger } = require('firebase-functions/v2')
+const { defineString } = require('firebase-functions/params')
 const admin = require('firebase-admin')
 
-const config = process.env.K_CONFIGURATION ? {} : functions.config()
-const { rtdb = {} } = config
-const instance = rtdb.instance || process.env.RTDB_INSTANCE
+const RTDB_INSTANCE = defineString('RTDB_INSTANCE')
+const RTDB_REGION = defineString('RTDB_REGION', { default: 'europe-west1' })
+
+const instanceOpt = `{{ params.${RTDB_INSTANCE.name} }}`
+const regionOpt = `{{ params.${RTDB_REGION.name} }}`
 
 function buildBody(snapshot) {
   const homeBase = (snapshot && snapshot.homeBase) || {}
@@ -12,43 +16,44 @@ function buildBody(snapshot) {
   return registrations.map(registration => ({ registration }))
 }
 
-module.exports.updateCustomsHomebasedAircraftOnUpdate =
-  functions.region('europe-west1').database.instance(instance).ref('/settings/aircrafts')
-    .onWrite(async (change, context) => {
-      const beforeBody = buildBody(change.before.val())
-      const afterBody = buildBody(change.after.val())
-      const jsonBody = JSON.stringify(afterBody)
+module.exports.updateCustomsHomebasedAircraftOnUpdate = onValueWritten(
+  { region: regionOpt, instance: instanceOpt, ref: '/settings/aircrafts' },
+  async (event) => {
+    const beforeBody = buildBody(event.data.before.val())
+    const afterBody = buildBody(event.data.after.val())
+    const jsonBody = JSON.stringify(afterBody)
 
-      if (JSON.stringify(beforeBody) === jsonBody) {
-        console.log('No change detected.')
-        return
-      }
+    if (JSON.stringify(beforeBody) === jsonBody) {
+      logger.info('No change detected.')
+      return
+    }
 
-      const snapshot = await admin.database().ref('/settings/customsDeclarationApp').once('value')
-      const customsSettings = snapshot.val()
+    const snapshot = await admin.database().ref('/settings/customsDeclarationApp').once('value')
+    const customsSettings = snapshot.val()
 
-      if (!customsSettings || !customsSettings.baseUrl) {
-        console.log('No customs declaration settings in /settings/customsDeclarationApp. Aborting...')
-        return
-      }
+    if (!customsSettings || !customsSettings.baseUrl) {
+      logger.info('No customs declaration settings in /settings/customsDeclarationApp. Aborting...')
+      return
+    }
 
-      const url = `${customsSettings.baseUrl}/api/homebased-aircraft?ad=${customsSettings.aerodrome}`
+    const url = `${customsSettings.baseUrl}/api/homebased-aircraft?ad=${customsSettings.aerodrome}`
 
-      const response = await fetch(url, {
-        method: 'PUT',
-        headers: {
-          'Authorization': `Bearer ${customsSettings.accessToken}`,
-          'Content-Type': 'application/json'
-        },
-        body: jsonBody
-      })
-
-      if (response.ok) {
-        console.log('Successfully updated homebased aircraft of the customs app')
-      } else {
-        console.log('Failed to update the homebased aircraft of the customs app', response)
-
-        const responseBody = await response.text().catch(() => '')
-        console.log('Response body', responseBody)
-      }
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Bearer ${customsSettings.accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: jsonBody
     })
+
+    if (response.ok) {
+      logger.info('Successfully updated homebased aircraft of the customs app')
+    } else {
+      logger.error('Failed to update the homebased aircraft of the customs app', response)
+
+      const responseBody = await response.text().catch(() => '')
+      logger.error('Response body', responseBody)
+    }
+  }
+)

--- a/functions/homebasedAircraft/homebasedAircraftTrigger.spec.js
+++ b/functions/homebasedAircraft/homebasedAircraftTrigger.spec.js
@@ -1,21 +1,27 @@
 'use strict';
 
-let capturedHandler;
+let mockCapturedHandler = null;
 
-jest.mock('firebase-functions/v1', () => {
-  const mock = {
-    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
-    database: {
-      instance: jest.fn(() => ({
-        ref: jest.fn(() => ({
-          onWrite: jest.fn(handler => { capturedHandler = handler; }),
-        })),
-      })),
-    },
-  };
-  mock.region = jest.fn(() => mock);
-  return mock;
-});
+jest.mock('firebase-functions/v2/database', () => ({
+  onValueWritten: jest.fn((opts, handler) => {
+    mockCapturedHandler = handler;
+  })
+}));
+
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  log: jest.fn()
+};
+
+jest.mock('firebase-functions/v2', () => ({
+  logger: mockLogger
+}));
+
+jest.mock('firebase-functions/params', () => ({
+  defineString: jest.fn(name => ({ name }))
+}));
 
 const mockAdminDbRef = jest.fn();
 jest.mock('firebase-admin', () => ({
@@ -24,32 +30,11 @@ jest.mock('firebase-admin', () => ({
 
 global.fetch = jest.fn();
 
+require('./homebasedAircraftTrigger');
+
 describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
   beforeEach(() => {
-    jest.resetModules();
     jest.clearAllMocks();
-    capturedHandler = null;
-
-    jest.mock('firebase-functions/v1', () => {
-      const mock = {
-        config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
-        database: {
-          instance: jest.fn(() => ({
-            ref: jest.fn(() => ({
-              onWrite: jest.fn(handler => { capturedHandler = handler; }),
-            })),
-          })),
-        },
-      };
-      mock.region = jest.fn(() => mock);
-      return mock;
-    });
-
-    jest.mock('firebase-admin', () => ({
-      database: jest.fn(() => ({ ref: mockAdminDbRef })),
-    }));
-
-    require('./homebasedAircraftTrigger');
   });
 
   const makeChange = (before, after) => ({
@@ -60,7 +45,7 @@ describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
   it('does nothing when before and after are equal', async () => {
     const value = { homeBase: { HBXYZ: true }, club: { HBABC: true } };
     const change = makeChange(value, value);
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
     expect(mockAdminDbRef).not.toHaveBeenCalled();
     expect(global.fetch).not.toHaveBeenCalled();
   });
@@ -70,7 +55,7 @@ describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
       { homeBase: { HBXYZ: true }, club: { HBABC: true }, other: 1 },
       { homeBase: { HBXYZ: true }, club: { HBABC: true }, other: 2 }
     );
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
     expect(mockAdminDbRef).not.toHaveBeenCalled();
     expect(global.fetch).not.toHaveBeenCalled();
   });
@@ -83,7 +68,7 @@ describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
       { homeBase: { HBXYZ: true } },
       { homeBase: { HBABC: true } }
     );
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -95,7 +80,7 @@ describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
       { homeBase: { HBXYZ: true } },
       { homeBase: { HBABC: true } }
     );
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -117,7 +102,7 @@ describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
       club: { HBABC: true, HBCLU: true },
     };
     const change = makeChange({ homeBase: { HBOLD: true } }, after);
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
 
     expect(global.fetch).toHaveBeenCalledWith(
       'https://customs.example.com/api/homebased-aircraft?ad=LSZT',
@@ -153,7 +138,7 @@ describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
       { homeBase: { HBOLD: true }, club: { HBCLU: true } },
       { club: { HBCLU: true, HBNEW: true } }
     );
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.any(String),
@@ -180,7 +165,7 @@ describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
     global.fetch.mockResolvedValue({ ok: true });
 
     const change = makeChange({ homeBase: { HBOLD: true } }, null);
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.any(String),
@@ -204,19 +189,17 @@ describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
       text: jest.fn().mockResolvedValue('Not authorized'),
     });
 
-    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const change = makeChange(
       { homeBase: { HBOLD: true } },
       { homeBase: { HBNEW: true } }
     );
-    await capturedHandler(change, {});
+    await mockCapturedHandler({ data: change });
 
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(mockLogger.error).toHaveBeenCalledWith(
       'Failed to update the homebased aircraft of the customs app',
       expect.anything()
     );
-    expect(consoleSpy).toHaveBeenCalledWith('Response body', 'Not authorized');
-    consoleSpy.mockRestore();
+    expect(mockLogger.error).toHaveBeenCalledWith('Response body', 'Not authorized');
   });
 
   it('tolerates non-text error responses without throwing', async () => {
@@ -235,13 +218,11 @@ describe('functions/homebasedAircraft/homebasedAircraftTrigger', () => {
       text: jest.fn().mockRejectedValue(new Error('stream error')),
     });
 
-    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const change = makeChange(
       { homeBase: { HBOLD: true } },
       { homeBase: { HBNEW: true } }
     );
-    await expect(capturedHandler(change, {})).resolves.toBeUndefined();
-    expect(consoleSpy).toHaveBeenCalledWith('Response body', '');
-    consoleSpy.mockRestore();
+    await expect(mockCapturedHandler({ data: change })).resolves.toBeUndefined();
+    expect(mockLogger.error).toHaveBeenCalledWith('Response body', '');
   });
 });


### PR DESCRIPTION
## Summary
- Migrates `updateCustomsHomebasedAircraftOnUpdate` from `firebase-functions/v1` to v2 `onValueWritten`, following the pattern landed in #758 and #759.
- Drops the legacy `functions.config() / process.env.RTDB_INSTANCE` fallback and the hardcoded `europe-west1` region in favour of the shared `RTDB_INSTANCE` / `RTDB_REGION` params.
- Swaps the 5 `console.log` calls for the v2 `logger` (success/no-op at info, fetch-failure at error). Failure-path severity in Cloud Logging changes INFO → ERROR.
- `buildBody()` helper (Set union over `homeBase` + `club`) and the `response.text().catch(() => '')` fallback are preserved unchanged.
- Spec rewritten to mock the Gen 2 trigger surface; the 9 test cases keep their inputs and semantics, and the fetch-failure tests now assert on `mockLogger.error` instead of spying `console.log`.

## Test plan
- [x] `npx jest homebasedAircraftTrigger.spec.js` — 9 / 9 pass
- [x] `npm run test:functions` — 294 / 294 pass
- [ ] Manual Gen 1 → Gen 2 cutover per test env (`firebase functions:delete updateCustomsHomebasedAircraftOnUpdate --region europe-west1`, then deploy):
  - [ ] lspl-test
  - [ ] lspv-test (RTDB in us-central1 — function moves region)
  - [ ] lsze-test
  - [ ] lszm-test
  - [ ] lszo-test
  - [ ] mfgt-flights (RTDB in us-central1 — function moves region)
- [ ] On lszm-test, modify `/settings/aircrafts` in the RTDB and confirm the customs API receives the PUT (verify in customs app logs or by checking the homebased aircraft list there).

## Migration progress
Part of the Gen 1 → Gen 2 RTDB trigger migration unblocking the `firebase-functions` v7 bump. Remaining after this PR: `enrichMovements` (4 triggers in one file).