### PR TITLE
Migrate enrichMovements triggers to Gen 2

### DIFF
--- a/functions/enrichMovements.js
+++ b/functions/enrichMovements.js
@@ -1,9 +1,17 @@
-const functions = require('firebase-functions/v1');
+const { onValueCreated, onValueWritten } = require('firebase-functions/v2/database');
+const { logger } = require('firebase-functions/v2');
+const { defineString } = require('firebase-functions/params');
 const admin = require('firebase-admin');
+
+const RTDB_INSTANCE = defineString('RTDB_INSTANCE');
+const RTDB_REGION = defineString('RTDB_REGION', { default: 'europe-west1' });
+
+const instanceOpt = `{{ params.${RTDB_INSTANCE.name} }}`;
+const regionOpt = `{{ params.${RTDB_REGION.name} }}`;
 
 const getEnrichedData = (aerodromeSnapshot, icaoCode) => {
   if (!aerodromeSnapshot.exists()) {
-    functions.logger.warn(`Aerodrome data not found for ICAO code: ${icaoCode}. Clearing enriched data.`);
+    logger.warn(`Aerodrome data not found for ICAO code: ${icaoCode}. Clearing enriched data.`);
     return {
       locationName: null,
       locationCountry: null,
@@ -21,7 +29,7 @@ const getEnrichedData = (aerodromeSnapshot, icaoCode) => {
 
 async function enrichMovementWithAerodromeMetadata(movement, movementType, movementKey) {
   if (!movement?.location) {
-    functions.logger.warn(`No location found for ${movementType} ${movementKey}`);
+    logger.warn(`No location found for ${movementType} ${movementKey}`);
     return;
   }
 
@@ -44,20 +52,20 @@ async function enrichMovementWithAerodromeMetadata(movement, movementType, movem
       const movementRef = admin.database().ref(movementPath).child(movementKey);
       const currentSnapshot = await movementRef.once('value');
       if (!currentSnapshot.exists()) {
-        functions.logger.info(
+        logger.info(
           `${movementType} ${movementKey} no longer exists, skipping enrichment`
         );
         return;
       }
       await movementRef.update(enrichedData);
 
-      functions.logger.info(
+      logger.info(
         `Enriched ${movementType} ${movementKey} with aerodrome metadata for ${icaoCode}: ${enrichedData.locationName}, ${enrichedData.country}`
       );
     }
 
   } catch (error) {
-    functions.logger.error(
+    logger.error(
       `Failed to enrich ${movementType} ${movementKey} with aerodrome metadata:`,
       error
     );
@@ -69,7 +77,7 @@ async function enrichOnCreate(snapshot, movementType) {
   const movementKey = snapshot.ref.key;
   const movement = snapshot.val();
 
-  functions.logger.info(`Enriching new ${movementType} ${movementKey} with aerodrome metadata`);
+  logger.info(`Enriching new ${movementType} ${movementKey} with aerodrome metadata`);
 
   await enrichMovementWithAerodromeMetadata(movement, movementType, movementKey);
 }
@@ -85,17 +93,13 @@ async function enrichOnUpdate(change, movementType) {
                          !afterMovement.locationTimezone;
 
   if (locationChanged || missingMetadata) {
-    functions.logger.info(
+    logger.info(
       `Enriching updated ${movementType} ${movementKey} (location changed: ${locationChanged}, missing metadata: ${missingMetadata})`
     );
 
     await enrichMovementWithAerodromeMetadata(afterMovement, movementType, movementKey);
   }
 }
-
-const config = process.env.K_CONFIGURATION ? {} : functions.config();
-const { rtdb = {} } = config;
-const instance = rtdb.instance || process.env.RTDB_INSTANCE;
 
 const handleUpdate = (change, movementType) => {
   if (!change.before.exists() || !change.after.exists()) {
@@ -108,22 +112,22 @@ const handleUpdate = (change, movementType) => {
   return enrichOnUpdate(change, movementType);
 };
 
-exports.enrichDepartureOnCreate = functions.region('europe-west1').database
-  .instance(instance)
-  .ref('/departures/{departureId}')
-  .onCreate((snapshot) => enrichOnCreate(snapshot, 'departure'));
+exports.enrichDepartureOnCreate = onValueCreated(
+  { region: regionOpt, instance: instanceOpt, ref: '/departures/{departureId}' },
+  event => enrichOnCreate(event.data, 'departure')
+);
 
-exports.enrichDepartureOnUpdate = functions.region('europe-west1').database
-  .instance(instance)
-  .ref('/departures/{departureId}')
-  .onWrite((change) => handleUpdate(change, 'departure'));
+exports.enrichDepartureOnUpdate = onValueWritten(
+  { region: regionOpt, instance: instanceOpt, ref: '/departures/{departureId}' },
+  event => handleUpdate(event.data, 'departure')
+);
 
-exports.enrichArrivalOnCreate = functions.region('europe-west1').database
-  .instance(instance)
-  .ref('/arrivals/{arrivalId}')
-  .onCreate((snapshot) => enrichOnCreate(snapshot, 'arrival'));
+exports.enrichArrivalOnCreate = onValueCreated(
+  { region: regionOpt, instance: instanceOpt, ref: '/arrivals/{arrivalId}' },
+  event => enrichOnCreate(event.data, 'arrival')
+);
 
-exports.enrichArrivalOnUpdate = functions.region('europe-west1').database
-  .instance(instance)
-  .ref('/arrivals/{arrivalId}')
-  .onWrite((change) => handleUpdate(change, 'arrival'));
+exports.enrichArrivalOnUpdate = onValueWritten(
+  { region: regionOpt, instance: instanceOpt, ref: '/arrivals/{arrivalId}' },
+  event => handleUpdate(event.data, 'arrival')
+);

--- a/functions/enrichMovements.spec.js
+++ b/functions/enrichMovements.spec.js
@@ -3,35 +3,27 @@
 // Capture handlers registered by the module
 const mockCapturedHandlers = {};
 
-jest.mock('firebase-functions/v1', () => {
-  const makeRef = (handlers) => (path) => ({
-    onCreate: jest.fn(handler => {
-      const key = `onCreate:${path}`;
-      handlers[key] = handler;
-    }),
-    onWrite: jest.fn(handler => {
-      const key = `onWrite:${path}`;
-      handlers[key] = handler;
-    })
-  });
+jest.mock('firebase-functions/v2/database', () => ({
+  onValueCreated: jest.fn((opts, handler) => {
+    mockCapturedHandlers[`onCreate:${opts.ref}`] = handler;
+  }),
+  onValueWritten: jest.fn((opts, handler) => {
+    mockCapturedHandlers[`onWrite:${opts.ref}`] = handler;
+  })
+}));
 
-  const mock = {
-    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
-    logger: {
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-      log: jest.fn()
-    },
-    database: {
-      instance: jest.fn(() => ({
-        ref: makeRef(mockCapturedHandlers)
-      }))
-    }
-  };
-  mock.region = jest.fn(() => mock);
-  return mock;
-});
+jest.mock('firebase-functions/v2', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn()
+  }
+}));
+
+jest.mock('firebase-functions/params', () => ({
+  defineString: jest.fn(name => ({ name }))
+}));
 
 const mockOnce = jest.fn();
 const mockUpdate = jest.fn();
@@ -96,7 +88,7 @@ describe('functions/enrichMovements', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snapshot);
+      await handler({ data: snapshot });
     };
 
     it('enriches departure with aerodrome data when aerodrome exists', async () => {
@@ -139,7 +131,7 @@ describe('functions/enrichMovements', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snapshot);
+      await handler({ data: snapshot });
 
       expect(childMock).toHaveBeenCalledWith('LSZH');
     });
@@ -203,7 +195,7 @@ describe('functions/enrichMovements', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snapshot);
+      await handler({ data: snapshot });
 
       expect(mockUpdate).not.toHaveBeenCalled();
     });
@@ -219,7 +211,7 @@ describe('functions/enrichMovements', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snapshot);
+      await handler({ data: snapshot });
 
       expect(mockOnce).not.toHaveBeenCalled();
       expect(mockUpdate).not.toHaveBeenCalled();
@@ -236,7 +228,7 @@ describe('functions/enrichMovements', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await handler(snapshot);
+      await handler({ data: snapshot });
 
       expect(mockOnce).not.toHaveBeenCalled();
     });
@@ -259,7 +251,7 @@ describe('functions/enrichMovements', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/departures/{departureId}'];
-      await expect(handler(snapshot)).rejects.toThrow('DB error');
+      await expect(handler({ data: snapshot })).rejects.toThrow('DB error');
     });
   });
 
@@ -296,7 +288,7 @@ describe('functions/enrichMovements', () => {
       };
 
       const handler = mockCapturedHandlers['onCreate:/arrivals/{arrivalId}'];
-      await handler(snapshot);
+      await handler({ data: snapshot });
 
       expect(childForMovement).toHaveBeenCalledWith('arr-001');
       expect(updateMock).toHaveBeenCalled();
@@ -319,7 +311,7 @@ describe('functions/enrichMovements', () => {
       };
 
       const handler = mockCapturedHandlers['onWrite:/departures/{departureId}'];
-      return handler(change);
+      return handler({ data: change });
     };
 
     it('returns null when before does not exist (create event)', async () => {


### PR DESCRIPTION
## Summary
- Migrates the four RTDB triggers in `enrichMovements.js` (`enrichDepartureOnCreate`, `enrichDepartureOnUpdate`, `enrichArrivalOnCreate`, `enrichArrivalOnUpdate`) from `firebase-functions/v1` to v2 (`onValueCreated` / `onValueWritten`), matching the multi-trigger pattern used by `associatedMovements`.
- Drops the legacy `functions.config() / process.env.RTDB_INSTANCE` fallback and the hardcoded `europe-west1` region in favour of the shared `RTDB_INSTANCE` / `RTDB_REGION` params.
- The six `functions.logger.{info,warn,error}` call sites swap to the v2 `logger` via prefix removal; severity preserved exactly.
- Helper functions (`getEnrichedData`, `enrichMovementWithAerodromeMetadata`, `enrichOnCreate`, `enrichOnUpdate`, `handleUpdate`) and all guards (`before/after.exists`, `anonymized` skip, `currentSnapshot.exists` race check) are preserved byte-identical.
- Spec rewritten to mock the Gen 2 trigger surface; the existing `mockCapturedHandlers` map carries over because lookup keys are derived from the `ref` path. All 14 tests preserved.

## Test plan
- [x] `npx jest enrichMovements.spec.js` — 14 / 14 pass
- [x] `npm run test:functions` — 294 / 294 pass
- [ ] Manual Gen 1 → Gen 2 cutover per test env. For each project, delete all four Gen 1 functions then deploy:
  ```sh
  for fn in enrichDepartureOnCreate enrichDepartureOnUpdate \
            enrichArrivalOnCreate enrichArrivalOnUpdate; do
    firebase functions:delete $fn --region europe-west1 \
      --force --project <projectId>
  done
  firebase deploy --only \
    functions:enrichDepartureOnCreate,functions:enrichDepartureOnUpdate,functions:enrichArrivalOnCreate,functions:enrichArrivalOnUpdate \
    --project <projectId> --force
  ```
  - [ ] lspl-test
  - [ ] lspv-test (RTDB in us-central1 — functions move region)
  - [ ] lsze-test
  - [ ] lszm-test
  - [ ] lszo-test
  - [ ] mfgt-flights (RTDB in us-central1 — functions move region)
- [ ] On lszm-test, create a new departure with `location: 'lszh'` and confirm `locationName/Country/Timezone` get written. Update the location to a different ICAO and confirm metadata refresh.

## Migration progress
**Last RTDB trigger module on v1.** Once all six per-env cutovers complete, the `firebase-functions` v6 → v7 dep bump becomes a routine PR.