### PR TITLE
Read RTDB env vars directly from process.env in index.js

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,12 +1,9 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 
-const config = process.env.K_CONFIGURATION ? {} : functions.config();
-const { rtdb = {} } = config;
-const dbUrl = rtdb.url || process.env.RTDB_URL;
-const dbInstance = rtdb.instance || process.env.RTDB_INSTANCE;
+const dbUrl = process.env.RTDB_URL;
+const dbInstance = process.env.RTDB_INSTANCE;
 
 admin.initializeApp({
   databaseURL: dbUrl || (dbInstance ? `https://${dbInstance}.firebaseio.com` : undefined),


### PR DESCRIPTION
## Summary
- Drops the `firebase-functions/v1` import and the `functions.config()` indirection from `functions/index.js`.
- The `process.env.RTDB_URL` / `RTDB_INSTANCE` fallbacks already existed in this file and are set on every env's `.env.<projectId>` by the CI workflow, so this is a behaviour-preserving refactor with zero infra change.

## Why
First step in preparing the codebase for `firebase-functions` v7, which removes `functions.config()` entirely (calling it throws on every cold start). `index.js` is the easiest call site because it has no new env-var dependency and no GH-vars work.

Five remaining call sites (`api/basicAuth.js`, `auth/modes/flightnet/index.js`, `auth/modes/ip/index.js`, `auth/createTestEmailToken.js`, `auth/webauthnHelpers.js`) need new env vars; those follow in a separate PR.

## Test plan
- [x] `npm run test:functions` — 294 / 294 pass
- [ ] Deploy to one test env (e.g. `lszm-test`) and verify a Gen 2 RTDB trigger still receives events — proves `admin.initializeApp` still resolves the right database URL.