### PR TITLE
Add specs for functions.config() reads in 3 auth call sites

### DIFF
--- a/functions/auth/createTestEmailToken.spec.js
+++ b/functions/auth/createTestEmailToken.spec.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const TEST_EMAIL = 'cypress-pilot@example.com';
+
+describe('functions/auth/createTestEmailToken', () => {
+  let mockConfig;
+  let mockGetUserByEmail;
+  let mockCreateUser;
+  let mockCreateCustomToken;
+  let handler;
+  let consoleErrorSpy;
+
+  const makeReq = (overrides = {}) => ({ method: 'POST', ...overrides });
+  const makeRes = () => ({
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  });
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    mockConfig = jest.fn();
+    mockGetUserByEmail = jest.fn();
+    mockCreateUser = jest.fn();
+    mockCreateCustomToken = jest.fn();
+
+    jest.doMock('firebase-functions/v1', () => ({
+      region: () => ({
+        https: { onRequest: fn => fn },
+      }),
+      config: mockConfig,
+    }));
+
+    jest.doMock('firebase-admin', () => ({
+      auth: () => ({
+        getUserByEmail: mockGetUserByEmail,
+        createUser: mockCreateUser,
+        createCustomToken: mockCreateCustomToken,
+      }),
+    }));
+
+    jest.doMock('cors', () => () => (req, res, cb) => Promise.resolve(cb()));
+
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    handler = require('./createTestEmailToken').createTestEmailToken;
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('when testing is not enabled', () => {
+    it('returns 403 when testing config key is absent', async () => {
+      mockConfig.mockReturnValue({});
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Testing endpoints are not enabled' });
+    });
+
+    it('returns 403 when testing.enabled is false', async () => {
+      mockConfig.mockReturnValue({ testing: { enabled: false } });
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+  });
+
+  describe('when testing is enabled', () => {
+    beforeEach(() => {
+      mockConfig.mockReturnValue({ testing: { enabled: true } });
+    });
+
+    it('returns 405 when method is not POST', async () => {
+      const res = makeRes();
+      await handler(makeReq({ method: 'GET' }), res);
+      expect(res.status).toHaveBeenCalledWith(405);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Method not allowed' });
+    });
+
+    it('returns 200 with token when user already exists', async () => {
+      mockGetUserByEmail.mockResolvedValue({ uid: 'existing-uid' });
+      mockCreateCustomToken.mockResolvedValue('tok');
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(mockGetUserByEmail).toHaveBeenCalledWith(TEST_EMAIL);
+      expect(mockCreateUser).not.toHaveBeenCalled();
+      expect(mockCreateCustomToken).toHaveBeenCalledWith('existing-uid', { email: TEST_EMAIL });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ token: 'tok' });
+    });
+
+    it('creates the user and returns 200 with token when user does not exist', async () => {
+      const notFound = Object.assign(new Error('not found'), { code: 'auth/user-not-found' });
+      mockGetUserByEmail.mockRejectedValue(notFound);
+      mockCreateUser.mockResolvedValue({ uid: 'new-uid' });
+      mockCreateCustomToken.mockResolvedValue('tok');
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(mockCreateUser).toHaveBeenCalledWith({ email: TEST_EMAIL });
+      expect(mockCreateCustomToken).toHaveBeenCalledWith('new-uid', { email: TEST_EMAIL });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ token: 'tok' });
+    });
+
+    it('returns 500 when getUserByEmail rejects with a non-not-found error', async () => {
+      mockGetUserByEmail.mockRejectedValue(new Error('boom'));
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(mockCreateUser).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Failed to create test email token' });
+    });
+
+    it('returns 500 when createCustomToken rejects', async () => {
+      mockGetUserByEmail.mockResolvedValue({ uid: 'u' });
+      mockCreateCustomToken.mockRejectedValue(new Error('token kaboom'));
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/functions/auth/modes/flightnet/index.spec.js
+++ b/functions/auth/modes/flightnet/index.spec.js
@@ -65,6 +65,51 @@ describe('functions', () => {
           };
           return expect(flightnet(request)).resolves.toEqual(null);
         });
+
+        describe('with static credentials configured', () => {
+          let flightnetWithStatic;
+          let mockPasswordCheck;
+
+          beforeEach(() => {
+            jest.resetModules();
+            mockPasswordCheck = jest.fn();
+            jest.doMock('firebase-functions/v1', () => ({
+              config: jest.fn(() => ({
+                auth: { staticcredentials: 'alice:pw1,bob:pw2' }
+              }))
+            }));
+            jest.doMock('./flightnet', () => ({
+              passwordCheck: mockPasswordCheck
+            }));
+            flightnetWithStatic = require('.');
+          });
+
+          it("returns the username when the first static credential matches", () => {
+            const request = { body: { username: 'alice', password: 'pw1' } };
+            return expect(flightnetWithStatic(request)).resolves.toEqual('alice');
+          });
+
+          it("returns the username when the second static credential matches", () => {
+            const request = { body: { username: 'bob', password: 'pw2' } };
+            return expect(flightnetWithStatic(request)).resolves.toEqual('bob');
+          });
+
+          it('returns null when the password is wrong for a known username', () => {
+            const request = { body: { username: 'alice', password: 'wrong' } };
+            return expect(flightnetWithStatic(request)).resolves.toBeNull();
+          });
+
+          it('returns null when the username is unknown', () => {
+            const request = { body: { username: 'charlie', password: 'pw1' } };
+            return expect(flightnetWithStatic(request)).resolves.toBeNull();
+          });
+
+          it('does not call flightnet.passwordCheck when static credentials are set', async () => {
+            const request = { body: { username: 'alice', password: 'pw1' } };
+            await flightnetWithStatic(request);
+            expect(mockPasswordCheck).not.toHaveBeenCalled();
+          });
+        });
       });
     });
   });

--- a/functions/auth/modes/ip/index.spec.js
+++ b/functions/auth/modes/ip/index.spec.js
@@ -1,0 +1,66 @@
+'use strict';
+
+describe('functions/auth/modes/ip', () => {
+  const makeReq = (xff, remote) => ({
+    headers: xff !== undefined ? { 'x-forwarded-for': xff } : {},
+    connection: { remoteAddress: remote === undefined ? null : remote },
+  });
+
+  let consoleInfoSpy;
+  beforeEach(() => {
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleInfoSpy.mockRestore();
+  });
+
+  describe('when auth.ips is not configured', () => {
+    let ip;
+    beforeEach(() => {
+      jest.resetModules();
+      jest.doMock('firebase-functions/v1', () => ({
+        config: jest.fn(() => ({})),
+      }));
+      ip = require('.');
+    });
+
+    it('resolves null for any request IP', () => {
+      return expect(ip(makeReq('10.0.0.1'))).resolves.toBeNull();
+    });
+  });
+
+  describe('when auth.ips is configured', () => {
+    let ip;
+    beforeEach(() => {
+      jest.resetModules();
+      jest.doMock('firebase-functions/v1', () => ({
+        config: jest.fn(() => ({ auth: { ips: '10.0.0.1, 10.0.0.2' } })),
+      }));
+      ip = require('.');
+    });
+
+    it("returns 'ipauth' when x-forwarded-for matches the first CSV entry", () => {
+      return expect(ip(makeReq('10.0.0.1'))).resolves.toBe('ipauth');
+    });
+
+    it("returns 'ipauth' when x-forwarded-for matches a trimmed CSV entry", () => {
+      return expect(ip(makeReq('10.0.0.2'))).resolves.toBe('ipauth');
+    });
+
+    it("returns 'ipauth' when remoteAddress matches and x-forwarded-for is absent", () => {
+      return expect(ip(makeReq(undefined, '10.0.0.1'))).resolves.toBe('ipauth');
+    });
+
+    it("returns 'ipauth' when x-forwarded-for has multiple hops and the first matches", () => {
+      return expect(ip(makeReq('10.0.0.1, 192.168.1.1'))).resolves.toBe('ipauth');
+    });
+
+    it('resolves null when the request IP does not match any allowed entry', () => {
+      return expect(ip(makeReq('192.168.1.1'))).resolves.toBeNull();
+    });
+
+    it('resolves null when no IP can be determined', () => {
+      return expect(ip(makeReq())).resolves.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Test-only change. Prerequisite for the upcoming `functions.config()` → `process.env` migration (PR B) — adds spec coverage for the three Gen 1 call sites that had insufficient or no tests, so PR B's diff can be a purely mechanical mock swap.

- **`functions/auth/createTestEmailToken.js`** — new spec, 7 cases: `testing.enabled` gate (×2), 405 method check, existing-user happy path, new-user happy path, two 500 error paths. Mocks `firebase-functions/v1.onRequest` to return the raw handler, `firebase-admin.auth()`, and `cors` (pass-through).
- **`functions/auth/modes/ip/index.js`** — new spec, 7 cases: empty config, both CSV entries with whitespace trim, `x-forwarded-for` multi-hop, `connection.remoteAddress` fallback, non-match, no-IP. Per-describe `jest.resetModules()` + `jest.doMock` to vary the module-load config.
- **`functions/auth/modes/flightnet/index.js`** — augmented with a new `with static credentials configured` describe block (5 cases): both static entries match, wrong password, unknown username, and an assertion that `flightnet.passwordCheck` is **not** called when static creds are set. Uses `jest.doMock` + `jest.resetModules` to override the file-level mock.

Mocks are written against the current `functions.config()` API on purpose; the follow-up PR swaps them to `process.env` assignments without touching assertions.

Full suite locally: 36 suites / 313 tests passing.

## Test plan

- [ ] CI green
- [ ] Sanity-check (already done locally): flipping the gate / IP match / password comparison in the three production files causes the relevant new tests to fail
- [ ] No production code touched — confirm via diff