### PR TITLE
Migrate functions.config() reads to process.env

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -61,5 +61,13 @@ jobs:
           RTDB_URL=${{ vars.FIREBASE_RTDB_URL }}
           RTDB_INSTANCE=${{ vars.FIREBASE_RTDB_NAME }}
           RTDB_REGION=${{ vars.RTDB_REGION }}
+          API_SERVICEUSER_USERNAME=${{ vars.API_SERVICEUSER_USERNAME }}
+          API_SERVICEUSER_PASSWORD=${{ secrets.API_SERVICEUSER_PASSWORD }}
+          AUTH_STATIC_CREDENTIALS=${{ secrets.AUTH_STATIC_CREDENTIALS }}
+          AUTH_IPS=${{ vars.AUTH_IPS }}
+          TESTING_ENABLED=${{ vars.TESTING_ENABLED }}
+          WEBAUTHN_RPID=${{ vars.WEBAUTHN_RPID }}
+          WEBAUTHN_RPNAME=${{ vars.WEBAUTHN_RPNAME }}
+          WEBAUTHN_ORIGINS=${{ vars.WEBAUTHN_ORIGINS }}
           EOF
       - run: firebase deploy --only functions

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -59,5 +59,13 @@ jobs:
           RTDB_URL=${{ vars.FIREBASE_RTDB_URL }}
           RTDB_INSTANCE=${{ vars.FIREBASE_RTDB_NAME }}
           RTDB_REGION=${{ vars.RTDB_REGION }}
+          API_SERVICEUSER_USERNAME=${{ vars.API_SERVICEUSER_USERNAME }}
+          API_SERVICEUSER_PASSWORD=${{ secrets.API_SERVICEUSER_PASSWORD }}
+          AUTH_STATIC_CREDENTIALS=${{ secrets.AUTH_STATIC_CREDENTIALS }}
+          AUTH_IPS=${{ vars.AUTH_IPS }}
+          TESTING_ENABLED=${{ vars.TESTING_ENABLED }}
+          WEBAUTHN_RPID=${{ vars.WEBAUTHN_RPID }}
+          WEBAUTHN_RPNAME=${{ vars.WEBAUTHN_RPNAME }}
+          WEBAUTHN_ORIGINS=${{ vars.WEBAUTHN_ORIGINS }}
           EOF
       - run: firebase deploy --only functions

--- a/functions/api/basicAuth.js
+++ b/functions/api/basicAuth.js
@@ -1,11 +1,10 @@
-const functions = require('firebase-functions/v1')
-
-const config = process.env.K_CONFIGURATION ? {} : functions.config();
+const expectedUsername = process.env.API_SERVICEUSER_USERNAME
+const expectedPassword = process.env.API_SERVICEUSER_PASSWORD
 
 const basicAuth = (req, res, next) => {
-  if (!config.api || !config.api.serviceuser || !config.api.serviceuser.username || !config.api.serviceuser.password) {
+  if (!expectedUsername || !expectedPassword) {
     console.info(
-      "Set configuration properties `api.serviceuser.username` and `api.serviceuser.password` for the API auth"
+      "Set API_SERVICEUSER_USERNAME and API_SERVICEUSER_PASSWORD env vars for the API auth"
     )
     res.status(401).send('Unauthorized')
     return
@@ -18,7 +17,7 @@ const basicAuth = (req, res, next) => {
     const decoded = Buffer.from(credentials, 'base64').toString('utf-8')
     const [username, password] = decoded.split(':')
 
-    if (username === config.api.serviceuser.username && password === config.api.serviceuser.password) {
+    if (username === expectedUsername && password === expectedPassword) {
       return next()
     }
   }

--- a/functions/api/basicAuth.spec.js
+++ b/functions/api/basicAuth.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
-// basicAuth.js captures functions.config() at require time, so each describe
-// block resets modules and requires the module with the relevant config.
+// basicAuth.js captures process.env at require time, so each describe
+// block resets modules and requires the module with the relevant env.
 
 const makeReq = (authHeader) => ({
   headers: { authorization: authHeader || '' },
@@ -13,18 +13,27 @@ const makeRes = () => ({
 });
 
 describe('functions/api/basicAuth', () => {
-  describe('when config is missing', () => {
+  let consoleInfoSpy;
+
+  beforeEach(() => {
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleInfoSpy.mockRestore();
+    delete process.env.API_SERVICEUSER_USERNAME;
+    delete process.env.API_SERVICEUSER_PASSWORD;
+  });
+
+  describe('when env vars are missing', () => {
     let basicAuth;
 
     beforeEach(() => {
       jest.resetModules();
-      jest.mock('firebase-functions/v1', () => ({
-        config: jest.fn(() => ({})),
-      }));
       basicAuth = require('./basicAuth');
     });
 
-    it('returns 401 when api config is absent', () => {
+    it('returns 401 when both env vars are absent', () => {
       const next = jest.fn();
       const res = makeRes();
       basicAuth(makeReq(), res, next);
@@ -34,14 +43,12 @@ describe('functions/api/basicAuth', () => {
     });
   });
 
-  describe('when config is missing username', () => {
+  describe('when username is missing', () => {
     let basicAuth;
 
     beforeEach(() => {
       jest.resetModules();
-      jest.mock('firebase-functions/v1', () => ({
-        config: jest.fn(() => ({ api: { serviceuser: { password: 'pass' } } })),
-      }));
+      process.env.API_SERVICEUSER_PASSWORD = 'pass';
       basicAuth = require('./basicAuth');
     });
 
@@ -54,14 +61,12 @@ describe('functions/api/basicAuth', () => {
     });
   });
 
-  describe('when config is missing password', () => {
+  describe('when password is missing', () => {
     let basicAuth;
 
     beforeEach(() => {
       jest.resetModules();
-      jest.mock('firebase-functions/v1', () => ({
-        config: jest.fn(() => ({ api: { serviceuser: { username: 'user' } } })),
-      }));
+      process.env.API_SERVICEUSER_USERNAME = 'user';
       basicAuth = require('./basicAuth');
     });
 
@@ -74,16 +79,13 @@ describe('functions/api/basicAuth', () => {
     });
   });
 
-  describe('with valid config', () => {
+  describe('with valid env vars', () => {
     let basicAuth;
 
     beforeEach(() => {
       jest.resetModules();
-      jest.mock('firebase-functions/v1', () => ({
-        config: jest.fn(() => ({
-          api: { serviceuser: { username: 'admin', password: 's3cret' } },
-        })),
-      }));
+      process.env.API_SERVICEUSER_USERNAME = 'admin';
+      process.env.API_SERVICEUSER_PASSWORD = 's3cret';
       basicAuth = require('./basicAuth');
     });
 

--- a/functions/auth/createTestEmailToken.js
+++ b/functions/auth/createTestEmailToken.js
@@ -9,8 +9,7 @@ const TEST_EMAIL = 'cypress-pilot@example.com';
 exports.createTestEmailToken = functions.region('europe-west1').https.onRequest((req, res) => {
   return cors(req, res, async () => {
     try {
-      const config = functions.config();
-      if (!config.testing || !config.testing.enabled) {
+      if (process.env.TESTING_ENABLED !== 'true') {
         return res.status(403).json({ error: 'Testing endpoints are not enabled' });
       }
 

--- a/functions/auth/createTestEmailToken.spec.js
+++ b/functions/auth/createTestEmailToken.spec.js
@@ -3,7 +3,6 @@
 const TEST_EMAIL = 'cypress-pilot@example.com';
 
 describe('functions/auth/createTestEmailToken', () => {
-  let mockConfig;
   let mockGetUserByEmail;
   let mockCreateUser;
   let mockCreateCustomToken;
@@ -19,7 +18,6 @@ describe('functions/auth/createTestEmailToken', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    mockConfig = jest.fn();
     mockGetUserByEmail = jest.fn();
     mockCreateUser = jest.fn();
     mockCreateCustomToken = jest.fn();
@@ -28,7 +26,6 @@ describe('functions/auth/createTestEmailToken', () => {
       region: () => ({
         https: { onRequest: fn => fn },
       }),
-      config: mockConfig,
     }));
 
     jest.doMock('firebase-admin', () => ({
@@ -48,19 +45,19 @@ describe('functions/auth/createTestEmailToken', () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    delete process.env.TESTING_ENABLED;
   });
 
   describe('when testing is not enabled', () => {
-    it('returns 403 when testing config key is absent', async () => {
-      mockConfig.mockReturnValue({});
+    it('returns 403 when TESTING_ENABLED is unset', async () => {
       const res = makeRes();
       await handler(makeReq(), res);
       expect(res.status).toHaveBeenCalledWith(403);
       expect(res.json).toHaveBeenCalledWith({ error: 'Testing endpoints are not enabled' });
     });
 
-    it('returns 403 when testing.enabled is false', async () => {
-      mockConfig.mockReturnValue({ testing: { enabled: false } });
+    it('returns 403 when TESTING_ENABLED is "false"', async () => {
+      process.env.TESTING_ENABLED = 'false';
       const res = makeRes();
       await handler(makeReq(), res);
       expect(res.status).toHaveBeenCalledWith(403);
@@ -69,7 +66,7 @@ describe('functions/auth/createTestEmailToken', () => {
 
   describe('when testing is enabled', () => {
     beforeEach(() => {
-      mockConfig.mockReturnValue({ testing: { enabled: true } });
+      process.env.TESTING_ENABLED = 'true';
     });
 
     it('returns 405 when method is not POST', async () => {

--- a/functions/auth/modes/flightnet/index.js
+++ b/functions/auth/modes/flightnet/index.js
@@ -1,21 +1,16 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
 const flightnet = require('./flightnet');
 const requestHelper = require('../../util/requestHelper');
 
 const parseStaticCredentials = () => {
-  const config = process.env.K_CONFIGURATION ? {} : functions.config();
-  if (config.auth && config.auth.staticcredentials) {
-    return config.auth.staticcredentials.split(',').map(login => {
+  const raw = process.env.AUTH_STATIC_CREDENTIALS;
+  if (raw) {
+    return raw.split(',').map(login => {
       const parts = login.split(':');
-
-      const username = parts[0];
-      const password = parts[1];
-
       return {
-        username: username,
-        password: password
+        username: parts[0],
+        password: parts[1]
       };
     })
   }

--- a/functions/auth/modes/flightnet/index.spec.js
+++ b/functions/auth/modes/flightnet/index.spec.js
@@ -1,9 +1,5 @@
 'use strict';
 
-jest.mock('firebase-functions/v1', () => ({
-  config: jest.fn(() => ({}))
-}));
-
 const flightnet = require('.');
 
 jest.mock('./flightnet', () => ({
@@ -73,15 +69,15 @@ describe('functions', () => {
           beforeEach(() => {
             jest.resetModules();
             mockPasswordCheck = jest.fn();
-            jest.doMock('firebase-functions/v1', () => ({
-              config: jest.fn(() => ({
-                auth: { staticcredentials: 'alice:pw1,bob:pw2' }
-              }))
-            }));
             jest.doMock('./flightnet', () => ({
               passwordCheck: mockPasswordCheck
             }));
+            process.env.AUTH_STATIC_CREDENTIALS = 'alice:pw1,bob:pw2';
             flightnetWithStatic = require('.');
+          });
+
+          afterEach(() => {
+            delete process.env.AUTH_STATIC_CREDENTIALS;
           });
 
           it("returns the username when the first static credential matches", () => {

--- a/functions/auth/modes/ip/index.js
+++ b/functions/auth/modes/ip/index.js
@@ -1,20 +1,18 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
 const requestHelper = require('../../util/requestHelper');
 
 let ips = [];
 
-const config = process.env.K_CONFIGURATION ? {} : functions.config();
-if (!config.auth || !config.auth.ips) {
+if (!process.env.AUTH_IPS) {
   console.info(
-    "Set configuration property auth.ips to allow authentication by request IP address " +
+    "Set AUTH_IPS env var to allow authentication by request IP address " +
     "(comma separated list of IP addresses). Currently no addresses set."
   )
 } else {
-  ips = config.auth.ips.split(',').map(ip => ip.trim());
+  ips = process.env.AUTH_IPS.split(',').map(ip => ip.trim());
   console.info(
-    "The following IP addresses are enabled (config property auth.ips): " + ips
+    "The following IP addresses are enabled (AUTH_IPS env var): " + ips
   )
 }
 

--- a/functions/auth/modes/ip/index.spec.js
+++ b/functions/auth/modes/ip/index.spec.js
@@ -12,15 +12,13 @@ describe('functions/auth/modes/ip', () => {
   });
   afterEach(() => {
     consoleInfoSpy.mockRestore();
+    delete process.env.AUTH_IPS;
   });
 
-  describe('when auth.ips is not configured', () => {
+  describe('when AUTH_IPS is not set', () => {
     let ip;
     beforeEach(() => {
       jest.resetModules();
-      jest.doMock('firebase-functions/v1', () => ({
-        config: jest.fn(() => ({})),
-      }));
       ip = require('.');
     });
 
@@ -29,13 +27,11 @@ describe('functions/auth/modes/ip', () => {
     });
   });
 
-  describe('when auth.ips is configured', () => {
+  describe('when AUTH_IPS is set', () => {
     let ip;
     beforeEach(() => {
       jest.resetModules();
-      jest.doMock('firebase-functions/v1', () => ({
-        config: jest.fn(() => ({ auth: { ips: '10.0.0.1, 10.0.0.2' } })),
-      }));
+      process.env.AUTH_IPS = '10.0.0.1, 10.0.0.2';
       ip = require('.');
     });
 

--- a/functions/auth/webauthnHelpers.js
+++ b/functions/auth/webauthnHelpers.js
@@ -1,23 +1,19 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const crypto = require('crypto');
 
 const CHALLENGE_TTL_MS = 5 * 60 * 1000;
 
 function getRpConfig() {
-  const cfg = (functions.config() && functions.config().webauthn) || {};
-  const rpID = cfg.rpid || cfg.rp_id;
-  const rpName = cfg.rpname || cfg.rp_name || 'Flightbox';
-  const originsRaw = cfg.origins || cfg.expected_origins || cfg.expectedorigins;
-  const expectedOrigins = Array.isArray(originsRaw)
-    ? originsRaw
-    : typeof originsRaw === 'string'
-      ? originsRaw.split(',').map(s => s.trim()).filter(Boolean)
-      : [];
+  const rpID = process.env.WEBAUTHN_RPID;
+  const rpName = process.env.WEBAUTHN_RPNAME || 'Flightbox';
+  const originsRaw = process.env.WEBAUTHN_ORIGINS;
+  const expectedOrigins = typeof originsRaw === 'string'
+    ? originsRaw.split(',').map(s => s.trim()).filter(Boolean)
+    : [];
   if (!rpID || expectedOrigins.length === 0) {
-    throw new Error('WebAuthn RP config missing: functions.config().webauthn.{rpid,origins} must be set');
+    throw new Error('WebAuthn RP config missing: WEBAUTHN_RPID and WEBAUTHN_ORIGINS env vars must be set');
   }
   return { rpID, rpName, expectedOrigins };
 }

--- a/functions/auth/webauthnHelpers.spec.js
+++ b/functions/auth/webauthnHelpers.spec.js
@@ -1,7 +1,6 @@
 describe('functions', () => {
   describe('auth/webauthnHelpers', () => {
     let mockAdmin;
-    let mockFunctions;
     let mockChallengesRef;
     let mockAuthAdmin;
     let helpers;
@@ -26,20 +25,19 @@ describe('functions', () => {
         auth: jest.fn().mockReturnValue(mockAuthAdmin),
       };
 
-      mockFunctions = {
-        config: jest.fn().mockReturnValue({
-          webauthn: {
-            rpid: 'flightbox.ch',
-            rpname: 'Flightbox',
-            origins: 'https://flightbox.ch,https://www.flightbox.ch',
-          },
-        }),
-      };
-
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
+
+      process.env.WEBAUTHN_RPID = 'flightbox.ch';
+      process.env.WEBAUTHN_RPNAME = 'Flightbox';
+      process.env.WEBAUTHN_ORIGINS = 'https://flightbox.ch,https://www.flightbox.ch';
 
       helpers = require('./webauthnHelpers');
+    });
+
+    afterEach(() => {
+      delete process.env.WEBAUTHN_RPID;
+      delete process.env.WEBAUTHN_RPNAME;
+      delete process.env.WEBAUTHN_ORIGINS;
     });
 
     describe('getRpConfig', () => {
@@ -50,22 +48,26 @@ describe('functions', () => {
         expect(cfg.expectedOrigins).toEqual(['https://flightbox.ch', 'https://www.flightbox.ch']);
       });
 
-      it('accepts origins as array', () => {
-        mockFunctions.config.mockReturnValue({
-          webauthn: { rpid: 'flightbox.ch', origins: ['https://a', 'https://b'] },
-        });
+      it('trims whitespace around CSV origins', () => {
+        process.env.WEBAUTHN_ORIGINS = 'https://a , https://b';
         const cfg = helpers.getRpConfig();
         expect(cfg.expectedOrigins).toEqual(['https://a', 'https://b']);
       });
 
-      it('throws if rpid missing', () => {
-        mockFunctions.config.mockReturnValue({ webauthn: { origins: 'https://x' } });
-        expect(() => helpers.getRpConfig()).toThrow(/rpid/);
+      it('defaults rpName to "Flightbox" when unset', () => {
+        delete process.env.WEBAUTHN_RPNAME;
+        const cfg = helpers.getRpConfig();
+        expect(cfg.rpName).toBe('Flightbox');
       });
 
-      it('throws if origins empty', () => {
-        mockFunctions.config.mockReturnValue({ webauthn: { rpid: 'x' } });
-        expect(() => helpers.getRpConfig()).toThrow(/origins/);
+      it('throws if WEBAUTHN_RPID is missing', () => {
+        delete process.env.WEBAUTHN_RPID;
+        expect(() => helpers.getRpConfig()).toThrow(/WEBAUTHN_RPID/);
+      });
+
+      it('throws if WEBAUTHN_ORIGINS is missing', () => {
+        delete process.env.WEBAUTHN_ORIGINS;
+        expect(() => helpers.getRpConfig()).toThrow(/WEBAUTHN_ORIGINS/);
       });
     });
 


### PR DESCRIPTION
## Summary

Replaces the five remaining Gen 1 `functions.config()` reads with direct `process.env` access, completing the prep work needed for the upcoming `firebase-functions` v6 → v7 bump (v7 removes `functions.config()` entirely; calling it throws).

**Production code (5 files):**

| File | Env var(s) | Notes |
|---|---|---|
| `functions/api/basicAuth.js` | `API_SERVICEUSER_USERNAME`, `API_SERVICEUSER_PASSWORD` | Module-load read; dropped `firebase-functions/v1` import. |
| `functions/auth/createTestEmailToken.js` | `TESTING_ENABLED` (compared `=== 'true'`) | Runtime read. Kept `firebase-functions/v1` import (still needed for `.region().https.onRequest`). |
| `functions/auth/webauthnHelpers.js` | `WEBAUTHN_RPID`, `WEBAUTHN_RPNAME` (default `'Flightbox'`), `WEBAUTHN_ORIGINS` (CSV → trimmed array) | Runtime read. Dropped legacy alias-handling (`rp_id`/`expected_origins`/`expectedorigins`) and the `Array.isArray(originsRaw)` branch — env vars are always strings. |
| `functions/auth/modes/flightnet/index.js` | `AUTH_STATIC_CREDENTIALS` (CSV `user:pass`) | Module-load read. |
| `functions/auth/modes/ip/index.js` | `AUTH_IPS` (CSV) | Module-load read. |

Also drops the `process.env.K_CONFIGURATION ? {} : functions.config()` guard in the three files that had it — the guard existed only because `functions.config()` throws in Gen 2 runtimes; `process.env` behaves identically in both, so the guard is dead code now.

**Specs (5 files):** mechanical swap — `jest.mock('firebase-functions/v1', { config: ... })` replaced with `process.env.X = ...` in `beforeEach` and `delete process.env.X` in `afterEach`. Same coverage. One stale test removed in `webauthnHelpers.spec.js` (`accepts origins as array` — no longer applicable) and two added (`trims whitespace around CSV origins`, `defaults rpName to "Flightbox"`).

**CI workflows (`firebase-hosting-{dev,prod}.yml`):** heredoc extended to write the new keys from per-env GH vars and secrets. `API_SERVICEUSER_PASSWORD` and `AUTH_STATIC_CREDENTIALS` are **secrets**; the rest are **vars**. Unset values render as empty strings, which the code's guards treat as disabled.

**Tests:** 36 suites / 314 tests passing. `grep functions.config functions/` returns zero hits.

## Un-draft checklist (track 2 — must complete before merging)

This PR is intentionally a draft. Merging without track 2 will cause every Gen 1 function that read `functions.config()` to start receiving empty values on the next deploy — auth will break.

- [ ] **WebAuthn alias audit:** run `firebase functions:config:get webauthn --project <projectId>` for each of the 6 dev + 5 prod projects and verify origins/rpid use the canonical keys. If any env uses `rp_id` / `expected_origins` / `expectedorigins`, canonicalize on copy into GH vars (or revert the alias-drop in `webauthnHelpers.js` via follow-up commit).
- [ ] **CSV-stringify array origins:** if any env stores `webauthn.origins` as a JSON array (`["a","b"]`), convert to CSV (`a,b`) before setting `WEBAUTHN_ORIGINS`.
- [ ] **Populate per-env GH vars** on all 11 envs (6 dev + 5 prod): `API_SERVICEUSER_USERNAME`, `AUTH_IPS`, `TESTING_ENABLED`, `WEBAUTHN_RPID`, `WEBAUTHN_RPNAME`, `WEBAUTHN_ORIGINS`.
- [ ] **Populate per-env GH secrets** on all 11 envs: `API_SERVICEUSER_PASSWORD`, `AUTH_STATIC_CREDENTIALS`.
- [ ] **TESTING_ENABLED note:** `createTestEmailToken.js` is now strict — only the literal string `"true"` enables the endpoint. Set `TESTING_ENABLED=true` on `cypress-testing` and any other test env that needs it (no longer accepts `"1"`, `"yes"`, etc.).
- [ ] **Secret-character hygiene:** confirm `API_SERVICEUSER_PASSWORD` does **not** contain `#`, `=`, leading/trailing whitespace, or newlines — the CI heredoc writes raw values into a dotenv file without quoting, and those characters break the dotenv parser. `AUTH_STATIC_CREDENTIALS` is structurally `user:pw,user:pw`, so it's safe.

## Post-merge canary

1. Watch `build_and_deploy_functions` for `lszm_test` (the test project per repo convention); confirm the heredoc step renders the expected `.env.<projectId>` and `firebase deploy` reports no config errors.
2. Probe deployed endpoints on `lszm-test`: API basic-auth (200), IP-mode allowed/disallowed (success/401), `createTestEmailToken` (token if `TESTING_ENABLED=true`, else 403), WebAuthn registration round-trip.
3. `firebase functions:log --project <projectId>` — confirm no `functions.config() is no longer available` errors and no `WebAuthn RP config missing` errors.
4. Roll across the remaining dev envs, then merge to `master` for prod rollout.

## Follow-up

Once this is deployed cleanly to all dev envs, PR C is a one-line `firebase-functions` `^6.6.0` → `^7.0.0` bump in `functions/package.json` + lockfile.