### PR TITLE
Bump firebase-functions from 6.6 to 7.2.5

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,7 +10,7 @@
         "@simplewebauthn/server": "^13.3.0",
         "cors": "^2.8.6",
         "firebase-admin": "^13.9.0",
-        "firebase-functions": "^6.6.0",
+        "firebase-functions": "^7.0.0",
         "moment": "^2.30.1",
         "nodemailer": "^8.0.7",
         "request-promise": "^4.2.6",
@@ -3824,9 +3824,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.6.0.tgz",
-      "integrity": "sha512-wwfo6JF+N7HUExVs5gUFgkgVGHDEog9O+qtouh7IuJWk8TBQ+KwXEgRiXbatSj7EbTu3/yYnHuzh3XExbfF6wQ==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
+      "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
@@ -3839,10 +3839,24 @@
         "firebase-functions": "lib/bin/firebase-functions.js"
       },
       "engines": {
-        "node": ">=14.10.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
+        "@apollo/server": "^5.2.0",
+        "@as-integrations/express4": "^1.1.2",
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0",
+        "graphql": "^16.12.0"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/server": {
+          "optional": true
+        },
+        "@as-integrations/express4": {
+          "optional": true
+        },
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/follow-redirects": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "@simplewebauthn/server": "^13.3.0",
     "cors": "^2.8.6",
     "firebase-admin": "^13.9.0",
-    "firebase-functions": "^6.6.0",
+    "firebase-functions": "^7.0.0",
     "moment": "^2.30.1",
     "nodemailer": "^8.0.7",
     "request-promise": "^4.2.6",


### PR DESCRIPTION
## Summary

Trivial dep bump that completes the v7 prep work. v7's main breaking change (removal of `functions.config()`) was handled in PR #766 and rolled out to all 11 envs on 2026-05-15.

- `functions/package.json`: `firebase-functions: ^6.6.0` → `^7.0.0`
- Lockfile resolves to **`firebase-functions@7.2.5`** (latest stable).
- No code changes.

## v7 breaking-change enumeration (per regression-risk feedback)

**Affects us, already handled or N/A:**

| Change | Status |
|---|---|
| `functions.config()` removed | Handled in PR #766 — all 5 call sites migrated to `process.env`, deployed to all 11 envs. |
| Node 18 minimum | We run Node 22 (`functions/package.json` engines + CI). |
| firebase-admin peer-dep `^11 \|\| ^12 \|\| ^13` | We're on `^13.9.0`. ✓ |

**Affects us, behaviour change (low risk):**

| Change | Impact |
|---|---|
| Firebase emulator now returns 500 on unhandled async rejections in `onRequest` handlers (production behaviour unchanged) | Our `onRequest` handlers (`auth/*`, `/api/*`) all wrap their async work in `try/catch`. The only surface risk is Cypress E2E against the emulator, which the test plan probes. |

**Does not affect us:**

- TS5 / ES2022 target — `functions/` is plain JS, no `tsconfig`.
- v1 `Event` TS type renamed to `LegacyEvent` — TS-only.
- `attemptDeadlineSeconds` removed from Gen 2 scheduled — we use Gen 1 `pubsub.schedule(...)`.
- Gen 2 RTDB triggers (`onValueCreated/Updated/Deleted/Written`), `defineString`, `firebase-functions/params` — APIs unchanged across v7.x.

## Tests

`npm run test:functions` — 36 suites / 314 tests passing under v7.2.5.

## Test plan

- [ ] CI green
- [ ] Cypress E2E green against the emulator (sole surface where the v7 emulator behaviour change could trip a regression)
- [ ] Deploy canary on `lszm_test` → `firebase functions:log --project lszm-test` clean, no cold-start crashes
- [ ] Roll across remaining 5 dev envs, then prod (per-env manual approvals)

## Out of scope

- Stale `WEBHOOK_REGION` GH vars across all 11 envs — dead config from the early Gen 2 webhook migration. Harmless. Clean separately.
- Stale `auth.testcredentials.*` (on `lspv-test`) and `serviceaccount.*` (on `mfgt-flights`, `project-...332047`) in `firebase functions:config` — zero references in code. Clean via `firebase functions:config:unset` separately.
- The `functions/package.json` `shell` script still references `firebase functions:config:get` (a CLI subcommand). The CLI may still support reading from a now-permanently-empty config; not exercised by deploys. Out of scope.