### PR TITLE
Bump react-day-picker to 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "qrcode-svg": "^1.1.0",
         "ramda": "^0.32.0",
         "react": "^19.2.6",
-        "react-day-picker": "^9.14.0",
+        "react-day-picker": "^10.0.1",
         "react-dom": "^19.2.6",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.15.1",
@@ -5630,16 +5630,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/@tabby_ai/hijri-converter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
-      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -8988,13 +8978,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
-    },
-    "node_modules/date-fns-jalali": {
-      "version": "4.1.0-0",
-      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
-      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/dateformat": {
       "version": "2.2.0",
@@ -16612,16 +16595,14 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
-      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz",
+      "integrity": "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
-        "@tabby_ai/hijri-converter": "1.0.5",
-        "date-fns": "^4.1.0",
-        "date-fns-jalali": "4.1.0-0"
+        "date-fns": "^4.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -16631,7 +16612,13 @@
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8.0",
         "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "qrcode-svg": "^1.1.0",
     "ramda": "^0.32.0",
     "react": "^19.2.6",
-    "react-day-picker": "^9.14.0",
+    "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.6",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.15.1",


### PR DESCRIPTION
## Summary
- Bumps `react-day-picker` from `^9.14.0` to `^10.0.1`.
- No source changes required: the library is only used in `src/components/DatePicker/DayPicker.tsx` with a small set of props (`mode="single"`, `selected`, `defaultMonth`, `onSelect`, `locale`, `weekStartsOn`) and three CSS variables (`--rdp-accent-color`, `--rdp-accent-background-color`, `--rdp-today-color`). None of these were touched by the v10 breaking changes (renamed `classNames`/`styles` keys, nav prop renames, non-Gregorian calendar split, removed deprecated type exports).
- v10 keeps the `react-day-picker` package name and `react-day-picker/style.css` import path working for backwards compatibility.

## Test plan
- [x] `npm install` clean
- [x] `npm run typecheck` green
- [x] `npm test` — 1889 tests / 159 suites pass
- [x] `npm start --project=lszm` — webpack compiles, no console warnings
- [x] Visual: movement list filter (start/end date, clear button), departure/arrival wizards (date field), admin lock-movements form — calendar opens, selected day uses theme accent, today uses theme danger, week starts Monday, EN/DE locale switch works