### PR TITLE
Migrate scheduled functions to Gen 2 onSchedule

### DIFF
--- a/functions/anonymizeMovements.js
+++ b/functions/anonymizeMovements.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onSchedule } = require('firebase-functions/v2/scheduler');
 const admin = require('firebase-admin');
 
 const SCHEDULE = '0 2 * * *'; // Every day at 2 AM
@@ -43,12 +43,9 @@ function getAnonymizationUpdates(snapshot, cutoffIso) {
   return updates;
 }
 
-exports.scheduledAnonymizeMovements = functions
-  .region('europe-west1')
-  .pubsub
-  .schedule(SCHEDULE)
-  .timeZone(TIMEZONE)
-  .onRun(async () => {
+exports.scheduledAnonymizeMovements = onSchedule(
+  { region: 'europe-west1', schedule: SCHEDULE, timeZone: TIMEZONE },
+  async () => {
     const db = admin.database();
 
     const retentionSnap = await db.ref('/settings/movementRetentionDays').once('value');
@@ -96,4 +93,5 @@ exports.scheduledAnonymizeMovements = functions
     if (Object.keys(departureUpdates).length === 0 && Object.keys(arrivalUpdates).length === 0) {
       console.log('No movements to anonymize');
     }
-  });
+  }
+);

--- a/functions/anonymizeMovements.spec.js
+++ b/functions/anonymizeMovements.spec.js
@@ -19,15 +19,8 @@ jest.mock('firebase-admin', () => ({
   initializeApp: jest.fn(),
 }));
 
-jest.mock('firebase-functions/v1', () => ({
-  region: jest.fn().mockReturnThis(),
-  pubsub: {
-    schedule: jest.fn().mockReturnValue({
-      timeZone: jest.fn().mockReturnValue({
-        onRun: jest.fn(fn => fn),
-      }),
-    }),
-  },
+jest.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: jest.fn((opts, fn) => fn),
 }));
 
 function createSnapshot(data) {

--- a/functions/auth/cleanupExpiredSignInCodes.js
+++ b/functions/auth/cleanupExpiredSignInCodes.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onSchedule } = require('firebase-functions/v2/scheduler');
 const admin = require('firebase-admin');
 
 const MAX_ATTEMPTS = 5;
 
-exports.cleanupExpiredSignInCodes = functions
-  .region('europe-west1')
-  .pubsub
-  .schedule('every 60 minutes')
-  .onRun(async () => {
+exports.cleanupExpiredSignInCodes = onSchedule(
+  { region: 'europe-west1', schedule: 'every 60 minutes' },
+  async () => {
     const db = admin.database();
     const codesRef = db.ref('/signInCodes');
     const snapshot = await codesRef.once('value');
@@ -31,4 +29,5 @@ exports.cleanupExpiredSignInCodes = functions
     if (Object.keys(updates).length > 0) {
       await codesRef.update(updates);
     }
-  });
+  }
+);

--- a/functions/auth/cleanupExpiredSignInCodes.spec.js
+++ b/functions/auth/cleanupExpiredSignInCodes.spec.js
@@ -1,8 +1,8 @@
 describe('functions', () => {
   describe('auth/cleanupExpiredSignInCodes', () => {
     let mockAdmin;
-    let mockFunctions;
     let capturedHandler;
+    let capturedOptions;
     let mockCodesRef;
 
     const now = Date.now();
@@ -10,6 +10,7 @@ describe('functions', () => {
     beforeEach(() => {
       jest.resetModules();
       capturedHandler = null;
+      capturedOptions = null;
 
       mockCodesRef = {
         once: jest.fn(),
@@ -22,19 +23,13 @@ describe('functions', () => {
         })
       };
 
-      const mockSchedule = {
-        onRun: jest.fn().mockImplementation(handler => { capturedHandler = handler; })
-      };
-
-      mockFunctions = {
-        pubsub: {
-          schedule: jest.fn().mockReturnValue(mockSchedule)
-        }
-      };
-      mockFunctions.region = jest.fn(() => mockFunctions);
-
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
+      jest.mock('firebase-functions/v2/scheduler', () => ({
+        onSchedule: jest.fn((opts, handler) => {
+          capturedOptions = opts;
+          capturedHandler = handler;
+        })
+      }));
 
       require('./cleanupExpiredSignInCodes');
     });
@@ -125,7 +120,7 @@ describe('functions', () => {
     });
 
     it('is scheduled to run every 60 minutes', () => {
-      expect(mockFunctions.pubsub.schedule).toHaveBeenCalledWith('every 60 minutes');
+      expect(capturedOptions.schedule).toBe('every 60 minutes');
     });
   });
 });

--- a/functions/auth/cleanupExpiredWebauthnChallenges.js
+++ b/functions/auth/cleanupExpiredWebauthnChallenges.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onSchedule } = require('firebase-functions/v2/scheduler');
 const admin = require('firebase-admin');
 
-exports.cleanupExpiredWebauthnChallenges = functions
-  .region('europe-west1')
-  .pubsub
-  .schedule('every 60 minutes')
-  .onRun(async () => {
+exports.cleanupExpiredWebauthnChallenges = onSchedule(
+  { region: 'europe-west1', schedule: 'every 60 minutes' },
+  async () => {
     const db = admin.database();
     const ref = db.ref('/webauthnChallenges');
     const snapshot = await ref.once('value');
@@ -29,4 +27,5 @@ exports.cleanupExpiredWebauthnChallenges = functions
     if (Object.keys(updates).length > 0) {
       await ref.update(updates);
     }
-  });
+  }
+);

--- a/functions/auth/cleanupExpiredWebauthnChallenges.spec.js
+++ b/functions/auth/cleanupExpiredWebauthnChallenges.spec.js
@@ -1,8 +1,8 @@
 describe('functions', () => {
   describe('auth/cleanupExpiredWebauthnChallenges', () => {
     let mockAdmin;
-    let mockFunctions;
     let capturedHandler;
+    let capturedOptions;
     let mockChallengesRef;
 
     const now = Date.now();
@@ -10,6 +10,7 @@ describe('functions', () => {
     beforeEach(() => {
       jest.resetModules();
       capturedHandler = null;
+      capturedOptions = null;
 
       mockChallengesRef = {
         once: jest.fn(),
@@ -22,19 +23,13 @@ describe('functions', () => {
         })
       };
 
-      const mockSchedule = {
-        onRun: jest.fn().mockImplementation(handler => { capturedHandler = handler; })
-      };
-
-      mockFunctions = {
-        pubsub: {
-          schedule: jest.fn().mockReturnValue(mockSchedule)
-        }
-      };
-      mockFunctions.region = jest.fn(() => mockFunctions);
-
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
+      jest.mock('firebase-functions/v2/scheduler', () => ({
+        onSchedule: jest.fn((opts, handler) => {
+          capturedOptions = opts;
+          capturedHandler = handler;
+        })
+      }));
 
       require('./cleanupExpiredWebauthnChallenges');
     });
@@ -89,7 +84,7 @@ describe('functions', () => {
     });
 
     it('is scheduled to run every 60 minutes', () => {
-      expect(mockFunctions.pubsub.schedule).toHaveBeenCalledWith('every 60 minutes');
+      expect(capturedOptions.schedule).toBe('every 60 minutes');
     });
   });
 });

--- a/functions/updateAerodromes.js
+++ b/functions/updateAerodromes.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions/v1');
+const { onSchedule } = require('firebase-functions/v2/scheduler');
 const admin = require('firebase-admin');
 
 const AERODROMES_URL = 'https://raw.githubusercontent.com/odch/aerodromes/refs/heads/main/aerodromes.json';
@@ -63,10 +63,9 @@ function getAerodromesToRemove(existingIcaoCodes, importedIcaoCodes) {
 /**
  * Scheduled Cloud Function to synchronize aerodromes data with GitHub repository
  */
-exports.scheduledAerodromesUpdate = functions.region('europe-west1').pubsub
-  .schedule(SCHEDULE)
-  .timeZone(TIMEZONE)
-  .onRun(async () => {
+exports.scheduledAerodromesUpdate = onSchedule(
+  { region: 'europe-west1', schedule: SCHEDULE, timeZone: TIMEZONE },
+  async () => {
     try {
       const db = admin.database();
 
@@ -98,4 +97,5 @@ exports.scheduledAerodromesUpdate = functions.region('europe-west1').pubsub
       console.error('Aerodromes sync failed:', error);
       throw error;
     }
-  });
+  }
+);

--- a/functions/updateAerodromes.spec.js
+++ b/functions/updateAerodromes.spec.js
@@ -2,28 +2,11 @@
 
 let capturedOnRun;
 
-jest.mock('firebase-functions/v1', () => {
-  const mock = {
-    pubsub: {
-      schedule: jest.fn(() => ({
-        timeZone: jest.fn(() => ({
-          onRun: jest.fn(handler => {
-            capturedOnRun = handler;
-          })
-        }))
-      }))
-    },
-    config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
-    logger: {
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-      log: jest.fn()
-    }
-  };
-  mock.region = jest.fn(() => mock);
-  return mock;
-});
+jest.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: jest.fn((opts, handler) => {
+    capturedOnRun = handler;
+  })
+}));
 
 const mockUpdate = jest.fn();
 const mockRef = jest.fn();

--- a/functions/updateAircraftList.js
+++ b/functions/updateAircraftList.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions/v1');
+const { onSchedule } = require('firebase-functions/v2/scheduler');
 const admin = require('firebase-admin');
 
 // Note: this map must be kept in sync with the list in `aircraftCategories.js`.
@@ -85,10 +85,9 @@ function getAircraftItemsToRemove(existingRegistrations, importedRegistrations) 
 /**
  * Scheduled Cloud Function to synchronize aircraft data with GitHub repository
  */
-exports.scheduledAircraftListUpdate = functions.region('europe-west1').pubsub
-  .schedule(SCHEDULE)
-  .timeZone(TIMEZONE)
-  .onRun(async () => {
+exports.scheduledAircraftListUpdate = onSchedule(
+  { region: 'europe-west1', schedule: SCHEDULE, timeZone: TIMEZONE },
+  async () => {
     try {
       const db = admin.database();
 
@@ -120,4 +119,5 @@ exports.scheduledAircraftListUpdate = functions.region('europe-west1').pubsub
       console.error('Aircraft list sync failed:', error);
       throw error;
     }
-  });
+  }
+);

--- a/functions/updateAircraftList.spec.js
+++ b/functions/updateAircraftList.spec.js
@@ -2,25 +2,10 @@
 
 let capturedOnRun;
 
-jest.mock('firebase-functions/v1', () => ({
-  region: jest.fn(() => ({
-    pubsub: {
-      schedule: jest.fn(() => ({
-        timeZone: jest.fn(() => ({
-          onRun: jest.fn(handler => {
-            capturedOnRun = handler;
-          })
-        }))
-      }))
-    }
-  })),
-  config: jest.fn(() => ({ rtdb: { instance: 'test-instance' } })),
-  logger: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    log: jest.fn()
-  }
+jest.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: jest.fn((opts, handler) => {
+    capturedOnRun = handler;
+  })
 }));
 
 const mockUpdate = jest.fn();


### PR DESCRIPTION
## Summary
- PR 1 of 3 for the Gen 1 → Gen 2 migration of the remaining `functions/`. Covers the 5 scheduled pubsub jobs; PR 2 will cover `api/`, PR 3 the `auth/` HTTPS handlers.
- Switches each scheduler from `functions.region(...).pubsub.schedule(...).timeZone(...).onRun(...)` (Gen 1) to `onSchedule({ region, schedule, timeZone }, handler)` from `firebase-functions/v2/scheduler`. Cron strings, timezones, region (`europe-west1`) and handler bodies are unchanged.
- Specs swap the chained v1 mock for the same v2 `onSchedule` mock pattern already used by `cleanupMessages.spec.js`. `cleanupExpired*` specs capture the options object so the "scheduled every 60 minutes" assertion still holds.
- Unblocks bumping `engines.node` to 24 on Cloud Functions (Node 24 isn't available on Gen 1).

## Files
- `functions/anonymizeMovements.js` + spec
- `functions/updateAerodromes.js` + spec
- `functions/updateAircraftList.js` + spec
- `functions/auth/cleanupExpiredSignInCodes.js` + spec
- `functions/auth/cleanupExpiredWebauthnChallenges.js` + spec

## Test plan
- [x] `cd functions && npm test` — 314 tests / 36 suites pass
- [x] `node -e "require('./index.js')"` — module loads, all 5 exports are functions
- [ ] Per-env rollout (handled separately): `firebase functions:delete scheduledAnonymizeMovements scheduledAerodromesUpdate scheduledAircraftListUpdate cleanupExpiredSignInCodes cleanupExpiredWebauthnChallenges --region europe-west1 --force --project <projectId>` on each env before CI redeploys