### PR TITLE
Migrate api Express function to Gen 2 onRequest

### DIFF
--- a/functions/api/index.js
+++ b/functions/api/index.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions/v1')
+const { onRequest } = require('firebase-functions/v2/https')
 const admin = require('firebase-admin')
 const express = require('express')
 const cors = require('cors')({origin: true, credentials: true})
@@ -100,4 +100,4 @@ api.get('(/api)?/users/me/invoice-recipients', fbAuth, async (req, res) => {
   }
 })
 
-module.exports = functions.region('europe-west1').https.onRequest(api)
+module.exports = onRequest({ region: 'europe-west1' }, api)


### PR DESCRIPTION
## Summary
- PR 2 of 3 for the Gen 1 → Gen 2 migration of the remaining `functions/`. Covers the `api` Express function; PR 3 will cover the `auth/` HTTPS handlers.
- Swaps the export from `functions.region('europe-west1').https.onRequest(api)` to `onRequest({ region: 'europe-west1' }, api)` from `firebase-functions/v2/https`. Express app, routes, cors/basicAuth/fbAuth/fbAdminAuth middleware and response-header writes are unchanged.
- The `cloudfunctions.net` URL and the `firebase.json` `/api/**` hosting rewrite are preserved by Gen 2's compatibility URL, so frontend callers in `customs`/`invoiceRecipients` sagas and `InvoicesReport` need no change.

## Test plan
- [x] `cd functions && npm test` — 314 tests / 36 suites pass
- [x] `node -e "require('./index.js')"` — module loads, `api` export is a function
- [ ] Per-env rollout (handled separately): `firebase functions:delete api --region europe-west1 --force --project <projectId>` on each env before CI redeploys
- [ ] After deploy on each env: hit `/api/aerodrome/status` via the Hosting rewrite, verify customs sagas continue to work