### PR TITLE
Migrate auth HTTPS functions to Gen 2 onRequest

### DIFF
--- a/functions/auth/createTestEmailToken.js
+++ b/functions/auth/createTestEmailToken.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onRequest } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
 const cors = require('cors')({origin: true});
 
 const TEST_EMAIL = 'cypress-pilot@example.com';
 
-exports.createTestEmailToken = functions.region('europe-west1').https.onRequest((req, res) => {
+exports.createTestEmailToken = onRequest({ region: 'europe-west1' }, (req, res) => {
   return cors(req, res, async () => {
     try {
       if (process.env.TESTING_ENABLED !== 'true') {

--- a/functions/auth/createTestEmailToken.spec.js
+++ b/functions/auth/createTestEmailToken.spec.js
@@ -22,10 +22,8 @@ describe('functions/auth/createTestEmailToken', () => {
     mockCreateUser = jest.fn();
     mockCreateCustomToken = jest.fn();
 
-    jest.doMock('firebase-functions/v1', () => ({
-      region: () => ({
-        https: { onRequest: fn => fn },
-      }),
+    jest.doMock('firebase-functions/v2/https', () => ({
+      onRequest: (opts, fn) => fn,
     }));
 
     jest.doMock('firebase-admin', () => ({

--- a/functions/auth/generateAuthenticationOptions.js
+++ b/functions/auth/generateAuthenticationOptions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onRequest } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
 const { generateAuthenticationOptions } = require('@simplewebauthn/server');
@@ -35,7 +35,7 @@ async function loadAllowCredentials(uid) {
   }));
 }
 
-exports.generateWebauthnAuthenticationOptions = functions.region('europe-west1').https.onRequest((req, res) => {
+exports.generateWebauthnAuthenticationOptions = onRequest({ region: 'europe-west1' }, (req, res) => {
   return cors(req, res, async () => {
     try {
       if (req.method !== 'POST') {

--- a/functions/auth/generateAuthenticationOptions.spec.js
+++ b/functions/auth/generateAuthenticationOptions.spec.js
@@ -1,7 +1,6 @@
 describe('functions', () => {
   describe('auth/generateAuthenticationOptions', () => {
     let mockAdmin;
-    let mockFunctions;
     let mockCors;
     let capturedHandler;
     let mockCredentialsRef;
@@ -15,11 +14,6 @@ describe('functions', () => {
       capturedHandler = null;
 
       mockCors = jest.fn().mockImplementation((req, res, cb) => cb());
-
-      mockFunctions = {
-        https: { onRequest: jest.fn().mockImplementation(h => { capturedHandler = h; }) },
-      };
-      mockFunctions.region = jest.fn(() => mockFunctions);
 
       mockCredentialsRef = {
         child: jest.fn().mockReturnThis(),
@@ -46,7 +40,9 @@ describe('functions', () => {
       });
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
+      jest.mock('firebase-functions/v2/https', () => ({
+        onRequest: (opts, handler) => { capturedHandler = handler; },
+      }));
       jest.mock('cors', () => () => mockCors);
       jest.mock('@simplewebauthn/server', () => ({
         generateAuthenticationOptions: mockGenerateAuthenticationOptions,

--- a/functions/auth/generateRegistrationOptions.js
+++ b/functions/auth/generateRegistrationOptions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onRequest } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
 const { generateRegistrationOptions } = require('@simplewebauthn/server');
@@ -23,7 +23,7 @@ async function loadExistingCredentials(uid) {
   }));
 }
 
-exports.generateWebauthnRegistrationOptions = functions.region('europe-west1').https.onRequest((req, res) => {
+exports.generateWebauthnRegistrationOptions = onRequest({ region: 'europe-west1' }, (req, res) => {
   return cors(req, res, async () => {
     try {
       if (req.method !== 'POST') {

--- a/functions/auth/generateRegistrationOptions.spec.js
+++ b/functions/auth/generateRegistrationOptions.spec.js
@@ -1,7 +1,6 @@
 describe('functions', () => {
   describe('auth/generateRegistrationOptions', () => {
     let mockAdmin;
-    let mockFunctions;
     let mockCors;
     let capturedHandler;
     let mockCredentialsRef;
@@ -15,13 +14,6 @@ describe('functions', () => {
       capturedHandler = null;
 
       mockCors = jest.fn().mockImplementation((req, res, cb) => cb());
-
-      mockFunctions = {
-        https: {
-          onRequest: jest.fn().mockImplementation(handler => { capturedHandler = handler; }),
-        },
-      };
-      mockFunctions.region = jest.fn(() => mockFunctions);
 
       mockCredentialsRef = {
         child: jest.fn().mockReturnThis(),
@@ -49,7 +41,9 @@ describe('functions', () => {
       });
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
+      jest.mock('firebase-functions/v2/https', () => ({
+        onRequest: (opts, handler) => { capturedHandler = handler; },
+      }));
       jest.mock('cors', () => () => mockCors);
       jest.mock('@simplewebauthn/server', () => ({
         generateRegistrationOptions: mockGenerateRegistrationOptions,

--- a/functions/auth/generateSignInCode.js
+++ b/functions/auth/generateSignInCode.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onRequest } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
 const crypto = require('crypto');
 const cors = require('cors')({origin: true});
@@ -31,7 +31,7 @@ const validateRequest = (method, body) => {
   return null;
 };
 
-exports.generateSignInCode = functions.region('europe-west1').https.onRequest((req, res) => {
+exports.generateSignInCode = onRequest({ region: 'europe-west1' }, (req, res) => {
   return cors(req, res, async () => {
     try {
       const validationError = validateRequest(req.method, req.body);

--- a/functions/auth/generateSignInCode.spec.js
+++ b/functions/auth/generateSignInCode.spec.js
@@ -1,7 +1,6 @@
 describe('functions', () => {
   describe('auth/generateSignInCode', () => {
     let mockAdmin;
-    let mockFunctions;
     let mockSendSignInEmail;
     let capturedHandler;
     let mockCors;
@@ -22,17 +21,12 @@ describe('functions', () => {
 
       mockCors = jest.fn().mockImplementation((req, res, cb) => cb());
 
-      mockFunctions = {
-        https: {
-          onRequest: jest.fn().mockImplementation(handler => { capturedHandler = handler; })
-        }
-      };
-      mockFunctions.region = jest.fn(() => mockFunctions);
-
       mockSendSignInEmail = jest.fn().mockResolvedValue('msg123');
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
+      jest.mock('firebase-functions/v2/https', () => ({
+        onRequest: (opts, handler) => { capturedHandler = handler; },
+      }));
       jest.mock('cors', () => () => mockCors);
       jest.mock('./sendSignInEmail', () => ({ sendSignInEmail: mockSendSignInEmail }));
 

--- a/functions/auth/generateSignInLink.js
+++ b/functions/auth/generateSignInLink.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions/v1');
+const { onRequest } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
 const cors = require('cors')({origin: true});
 
@@ -26,7 +26,7 @@ const validateRequest = (method, body) => {
   return null;
 };
 
-exports.generateSignInLink = functions.region('europe-west1').https.onRequest((req, res) => {
+exports.generateSignInLink = onRequest({ region: 'europe-west1' }, (req, res) => {
   return cors(req, res, async () => {
     try {
       const validationError = validateRequest(req.method, req.body);

--- a/functions/auth/generateSignInLink.spec.js
+++ b/functions/auth/generateSignInLink.spec.js
@@ -1,7 +1,6 @@
 describe('functions', () => {
   describe('auth/generateSignInLink', () => {
     let mockAdmin;
-    let mockFunctions;
     let capturedHandler;
     let mockCors;
 
@@ -17,15 +16,10 @@ describe('functions', () => {
 
       mockCors = jest.fn().mockImplementation((req, res, cb) => cb());
 
-      mockFunctions = {
-        https: {
-          onRequest: jest.fn().mockImplementation(handler => { capturedHandler = handler; })
-        }
-      };
-      mockFunctions.region = jest.fn(() => mockFunctions);
-
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
+      jest.mock('firebase-functions/v2/https', () => ({
+        onRequest: (opts, handler) => { capturedHandler = handler; },
+      }));
       jest.mock('cors', () => () => mockCors);
 
       require('./generateSignInLink');

--- a/functions/auth/index.js
+++ b/functions/auth/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onRequest: v2OnRequest } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
 const cors = require('cors')({
   origin: true,
@@ -27,7 +27,7 @@ const createAndSendToken = (req, res, uid) => {
 };
 
 const onRequest = (allowed, handler) =>
-  functions.region('europe-west1').https.onRequest((req, res) =>
+  v2OnRequest({ region: 'europe-west1' }, (req, res) =>
     cors(req, res, () => {
       if (allowed.includes(req.method)) {
         return handler(req, res);

--- a/functions/auth/removePasskey.js
+++ b/functions/auth/removePasskey.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onRequest } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
 const {
@@ -8,7 +8,7 @@ const {
   verifyAuthenticatedUser,
 } = require('./webauthnHelpers');
 
-exports.removeWebauthnCredential = functions.region('europe-west1').https.onRequest((req, res) => {
+exports.removeWebauthnCredential = onRequest({ region: 'europe-west1' }, (req, res) => {
   return cors(req, res, async () => {
     try {
       if (req.method !== 'POST') {

--- a/functions/auth/removePasskey.spec.js
+++ b/functions/auth/removePasskey.spec.js
@@ -1,7 +1,6 @@
 describe('functions', () => {
   describe('auth/removePasskey', () => {
     let mockAdmin;
-    let mockFunctions;
     let mockCors;
     let capturedHandler;
     let mockDbRef;
@@ -12,11 +11,6 @@ describe('functions', () => {
       capturedHandler = null;
 
       mockCors = jest.fn().mockImplementation((req, res, cb) => cb());
-
-      mockFunctions = {
-        https: { onRequest: jest.fn().mockImplementation(h => { capturedHandler = h; }) },
-      };
-      mockFunctions.region = jest.fn(() => mockFunctions);
 
       mockDbRef = {
         child: jest.fn().mockReturnThis(),
@@ -31,7 +25,9 @@ describe('functions', () => {
       mockVerifyRecentAuth = jest.fn();
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
+      jest.mock('firebase-functions/v2/https', () => ({
+        onRequest: (opts, handler) => { capturedHandler = handler; },
+      }));
       jest.mock('cors', () => () => mockCors);
       jest.mock('./webauthnHelpers', () => {
         class AuthError extends Error {

--- a/functions/auth/verifyAuthentication.js
+++ b/functions/auth/verifyAuthentication.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onRequest } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
 const { verifyAuthenticationResponse } = require('@simplewebauthn/server');
@@ -38,7 +38,7 @@ async function resolveUserEmail(uid) {
   }
 }
 
-exports.verifyWebauthnAuthentication = functions.region('europe-west1').https.onRequest((req, res) => {
+exports.verifyWebauthnAuthentication = onRequest({ region: 'europe-west1' }, (req, res) => {
   return cors(req, res, async () => {
     try {
       if (req.method !== 'POST') {

--- a/functions/auth/verifyAuthentication.spec.js
+++ b/functions/auth/verifyAuthentication.spec.js
@@ -1,7 +1,6 @@
 describe('functions', () => {
   describe('auth/verifyAuthentication', () => {
     let mockAdmin;
-    let mockFunctions;
     let mockCors;
     let capturedHandler;
     let mockDbRef;
@@ -18,11 +17,6 @@ describe('functions', () => {
       capturedHandler = null;
 
       mockCors = jest.fn().mockImplementation((req, res, cb) => cb());
-
-      mockFunctions = {
-        https: { onRequest: jest.fn().mockImplementation(h => { capturedHandler = h; }) },
-      };
-      mockFunctions.region = jest.fn(() => mockFunctions);
 
       // Per-ref mocks so we can distinguish calls; all ref paths share one mock for simplicity.
       mockDbRef = {
@@ -49,7 +43,9 @@ describe('functions', () => {
       });
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
+      jest.mock('firebase-functions/v2/https', () => ({
+        onRequest: (opts, handler) => { capturedHandler = handler; },
+      }));
       jest.mock('cors', () => () => mockCors);
       jest.mock('@simplewebauthn/server', () => ({
         verifyAuthenticationResponse: mockVerifyAuthenticationResponse,

--- a/functions/auth/verifyRegistration.js
+++ b/functions/auth/verifyRegistration.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onRequest } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
 const { verifyRegistrationResponse } = require('@simplewebauthn/server');
@@ -31,7 +31,7 @@ function toBase64Url(value) {
   return null;
 }
 
-exports.verifyWebauthnRegistration = functions.region('europe-west1').https.onRequest((req, res) => {
+exports.verifyWebauthnRegistration = onRequest({ region: 'europe-west1' }, (req, res) => {
   return cors(req, res, async () => {
     try {
       if (req.method !== 'POST') {

--- a/functions/auth/verifyRegistration.spec.js
+++ b/functions/auth/verifyRegistration.spec.js
@@ -1,7 +1,6 @@
 describe('functions', () => {
   describe('auth/verifyRegistration', () => {
     let mockAdmin;
-    let mockFunctions;
     let mockCors;
     let capturedHandler;
     let mockDbRef;
@@ -19,11 +18,6 @@ describe('functions', () => {
       capturedHandler = null;
 
       mockCors = jest.fn().mockImplementation((req, res, cb) => cb());
-
-      mockFunctions = {
-        https: { onRequest: jest.fn().mockImplementation(h => { capturedHandler = h; }) },
-      };
-      mockFunctions.region = jest.fn(() => mockFunctions);
 
       mockDbRef = {
         child: jest.fn().mockReturnThis(),
@@ -43,7 +37,9 @@ describe('functions', () => {
       });
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
+      jest.mock('firebase-functions/v2/https', () => ({
+        onRequest: (opts, handler) => { capturedHandler = handler; },
+      }));
       jest.mock('cors', () => () => mockCors);
       jest.mock('@simplewebauthn/server', () => ({
         verifyRegistrationResponse: mockVerifyRegistrationResponse,

--- a/functions/auth/verifySignInCode.js
+++ b/functions/auth/verifySignInCode.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const functions = require('firebase-functions/v1');
+const { onRequest } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
 const crypto = require('crypto');
 const cors = require('cors')({origin: true});
@@ -25,7 +25,7 @@ const validateRequest = (method, body) => {
   return null;
 };
 
-exports.verifySignInCode = functions.region('europe-west1').https.onRequest((req, res) => {
+exports.verifySignInCode = onRequest({ region: 'europe-west1' }, (req, res) => {
   return cors(req, res, async () => {
     try {
       const validationError = validateRequest(req.method, req.body);

--- a/functions/auth/verifySignInCode.spec.js
+++ b/functions/auth/verifySignInCode.spec.js
@@ -5,7 +5,6 @@ const hashCode = (code) => crypto.createHash('sha256').update(code).digest('hex'
 describe('functions', () => {
   describe('auth/verifySignInCode', () => {
     let mockAdmin;
-    let mockFunctions;
     let capturedHandler;
     let mockCors;
     let mockCodesRef;
@@ -19,13 +18,6 @@ describe('functions', () => {
       capturedHandler = null;
 
       mockCors = jest.fn().mockImplementation((req, res, cb) => cb());
-
-      mockFunctions = {
-        https: {
-          onRequest: jest.fn().mockImplementation(handler => { capturedHandler = handler; })
-        }
-      };
-      mockFunctions.region = jest.fn(() => mockFunctions);
 
       mockCodesRef = {
         orderByChild: jest.fn().mockReturnThis(),
@@ -50,7 +42,9 @@ describe('functions', () => {
       };
 
       jest.mock('firebase-admin', () => mockAdmin);
-      jest.mock('firebase-functions/v1', () => mockFunctions);
+      jest.mock('firebase-functions/v2/https', () => ({
+        onRequest: (opts, handler) => { capturedHandler = handler; },
+      }));
       jest.mock('cors', () => () => mockCors);
 
       require('./verifySignInCode');


### PR DESCRIPTION
## Summary
- PR 3 of 3 — final step of the Gen 1 → Gen 2 migration of `functions/`. Covers the `auth` dispatcher and the 9 individual HTTPS handlers it sits alongside. After rollout the codebase no longer imports `firebase-functions/v1` and the `engines.node` bump to 24 is unblocked.
- For each handler, swaps `functions.region('europe-west1').https.onRequest(...)` for `onRequest({ region: 'europe-west1' }, ...)` from `firebase-functions/v2/https`. The `auth/index.js` dispatcher does the same on its custom `onRequest` factory.
- Region, cors middleware, request/response handling, and handler bodies are unchanged. The `cloudfunctions.net` URL is preserved by Gen 2's compatibility URL, so `src/util/auth.ts`, `src/util/firebase.ts` and `src/util/webauthn.ts` need no change.
- Specs swap the chained `firebase-functions/v1` mock for the v2 `onRequest` mock that captures the handler.

## Files
- `functions/auth/index.js`
- `functions/auth/createTestEmailToken.js` + spec
- `functions/auth/generateAuthenticationOptions.js` + spec
- `functions/auth/generateRegistrationOptions.js` + spec
- `functions/auth/generateSignInCode.js` + spec
- `functions/auth/generateSignInLink.js` + spec
- `functions/auth/removePasskey.js` + spec
- `functions/auth/verifyAuthentication.js` + spec
- `functions/auth/verifyRegistration.js` + spec
- `functions/auth/verifySignInCode.js` + spec

## Test plan
- [x] `cd functions && npm test` — 314 tests / 36 suites pass
- [x] `node -e "require('./index.js')"` — module loads, all 10 auth exports are functions
- [ ] Per-env rollout (handled separately): `firebase functions:delete auth generateSignInLink generateSignInCode verifySignInCode createTestEmailToken generateWebauthnRegistrationOptions verifyWebauthnRegistration generateWebauthnAuthenticationOptions verifyWebauthnAuthentication removeWebauthnCredential --region europe-west1 --force --project <projectId>` on each env before CI redeploys
- [ ] After deploy on each env: smoke-test sign-in code flow, sign-in link flow, and passkey register/authenticate/remove