### PR TITLE
Bump to Node 24

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -21,13 +21,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: npm ci
       - run: npm run build --project=${{ vars.PROJECT }}
       - uses: w9jds/setup-firebase@main
         with:
           project_id: ${{ vars.FIREBASE_PROJECT }}
-          tools-version: 13
+          tools-version: 14
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: firebase target:apply database main ${{ vars.FIREBASE_RTDB_NAME }}
       - run: firebase deploy --only hosting,database:main
@@ -48,11 +48,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - uses: w9jds/setup-firebase@main
         with:
           project_id: ${{ vars.FIREBASE_PROJECT }}
-          tools-version: 13
+          tools-version: 14
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
       - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -20,13 +20,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: npm ci
       - run: npm run build:prod --project=${{ vars.PROJECT }}
       - uses: w9jds/setup-firebase@main
         with:
           project_id: ${{ vars.FIREBASE_PROJECT }}
-          tools-version: 13
+          tools-version: 14
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: firebase target:apply database main ${{ vars.FIREBASE_RTDB_NAME }}
       - run: firebase deploy --only hosting,database:main
@@ -46,11 +46,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - uses: w9jds/setup-firebase@main
         with:
           project_id: ${{ vars.FIREBASE_PROJECT }}
-          tools-version: 13
+          tools-version: 14
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
       - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: npm ci
       - run: npm run typecheck
       - run: npm run build
@@ -21,6 +21,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: cd functions && npm ci
       - run: cd functions && npm test

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "engines": {
-    "node": "22"
+    "node": "24"
   },
   "dependencies": {
     "@simplewebauthn/browser": "^13.3.0",


### PR DESCRIPTION
## Summary
- Bumps `functions/package.json` `engines.node` from `"22"` to `"24"`. Unblocked by the Gen 1 → Gen 2 migration (PRs #770 / #771 / #772) — Cloud Functions Gen 1 doesn't support `nodejs24`; Gen 2 does.
- Bumps `firebase-tools` from `13` to `14` in `firebase-hosting-dev.yml` and `firebase-hosting-prod.yml`. v13 flags `nodejs24` as beta (firebase-tools#9500); v14 has it GA.
- Bumps `actions/setup-node` `node-version` from `22` to `24` across all four workflows (`firebase-hosting-dev.yml`, `firebase-hosting-prod.yml`, `test-pull-request.yml`, `claude.yml`) so CI matches the runtime that `engines.node` now declares.

## Per-env rollout caveat
This deploy will fail on any env still running Gen 1 sources. Current state:

| Env group | Ready for nodejs24 |
|---|---|
| lszm-test, lsze-test, mfgt-flights (lszt-test), lszo-test, lspv-test | ✓ |
| lspl-test | ❌ still Gen 1 |
| 5 prod envs | ❌ still Gen 1 |

Approve only the 5 ready test envs in the CI run for this PR. Don't approve lspl-test or any prod env until each has had its Gen 1 → Gen 2 rollout (delete-then-redeploy + `roles/iam.serviceAccountTokenCreator` grant).

## Test plan
- [x] `cd functions && npm test` — 314 tests / 36 suites pass (no source changes; engines bump only)
- [ ] PR-check workflow (`test-pull-request.yml`) is now green on Node 24 — verifies `npm run typecheck`, `npm run build`, `npm run test:app`, `npm run cy:test`, and `cd functions && npm test` all work on Node 24
- [ ] CI deploy succeeds on lszm-test, lsze-test, mfgt-flights, lszo-test, lspv-test with `Runtime: nodejs24`
- [ ] Spot-check on one env post-deploy: passkey login + BAZL CSV export still work