### PR TITLE
Add min-release-age=3 to npm config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+min-release-age=3

--- a/functions/.npmrc
+++ b/functions/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
## Summary

Adds `min-release-age=3` to `.npmrc` (root and `functions/`) to refuse
installation of package versions published less than 3 days ago.

Mitigates rapid-spread supply-chain attacks (Shai-Hulud worm, recent
Tanstack-related compromises) where a compromised version is published
and reaches builds before the community detects and yanks it.

### Tradeoff

- Legitimate fixes are delayed up to 3 days when resolving new versions.
- `npm ci` from lockfile is **unaffected** — pinned versions install
  regardless of age, so existing pipelines keep working.
- Per-install override available for urgent CVE patches:
  `npm install <pkg> --min-release-age=0`.
- `npm outdated` / `npm update` / `npm view <pkg> version` will also
  hide too-young versions from their output (same code path).

### Scope

- `min-release-age` was added in npm 11.5.1. Current Node 24.x bundles
  npm 11.12.1, so this works in CI (`actions/setup-node@v4` with
  `node-version: 24`) and locally on up-to-date 24.x installations.
- No CI changes needed.
- Renovate (if/when configured) should mirror this setting.

## Test plan

- [ ] `npm ci` succeeds at repo root
- [ ] `cd functions && npm ci` succeeds
- [ ] `npm config get before` shows a date ~3 days in the past in both
      directories (confirms `min-release-age` is flattened correctly)
- [ ] CI passes on this PR