### PR TITLE
Switch lszt to email/passkey login on test env

### DIFF
--- a/projects/lszt.json
+++ b/projects/lszt.json
@@ -91,7 +91,9 @@
   "environments": {
     "test": {
       "firebaseProjectId": "mfgt-flights",
-      "firebaseApiKey": "AIzaSyDy63Y8GP6GExoP07KWJ6qneAeQalu9pK8"
+      "firebaseApiKey": "AIzaSyDy63Y8GP6GExoP07KWJ6qneAeQalu9pK8",
+      "passkeysEnabled": true,
+      "disableIpAuthentication": true
     },
     "production": {
       "firebaseProjectId": "project-8979611309653332047",
@@ -99,7 +101,8 @@
       "firebaseApiKey": "AIzaSyBNL_8OjB26xYYmjWbTCiPcxKgHs73FxGc"
     }
   },
-  "flightnetCompany": "mfgt",
+  "loginForm": "email",
+  "maskContactInformation": false,
   "theme": "lszt",
   "title": "Flightbox - Flugplatz Lommis",
   "themeColor": "#003863",


### PR DESCRIPTION
## Summary
- Switch lszt **test** env from IP auth + Flightnet username/password to email OTP + passkey login.
- Adopt the personal access model: non-admin pilots see only their own movements; admins/operators see all. Contact-info masking disabled accordingly.
- Test env: `passkeysEnabled: true`, `disableIpAuthentication: true`, `loginForm: "email"`; remove now-unused `flightnetCompany`.
- **Production env block is unchanged** — prod is a separate rollout.

## Notes / required ops (test env, `mfgt-flights`)
- SMTP config at RTDB `/settings/emailSmtp` — done.
- GitHub `lszt_test` WebAuthn vars set: `WEBAUTHN_RPID=mfgt-flights.web.app`, `WEBAUTHN_ORIGINS=https://mfgt-flights.web.app` (take effect on next functions deploy).
- IAM `serviceAccountTokenCreator` on the functions runtime SA (validated via working email login).
- First admin must be provisioned in RTDB (`/admins/<uid>` + `/logins/<uid>`) after first email login; then generate kiosk/guest tokens in the AdminPage.

## Test plan
- [ ] Deploy to `mfgt-flights`; login page shows email form + passkey button, no auto IP login.
- [ ] Email OTP sign-in works; non-admin sees only own movements, admin sees all.
- [ ] Register + log in with a passkey on `mfgt-flights.web.app`.
- [ ] Kiosk (`?kt=`) and guest (`?t=`) URLs authenticate correctly.