### PR TITLE
Add checkout payment method to lszt

### DIFF
--- a/projects/lszt.json
+++ b/projects/lszt.json
@@ -107,6 +107,16 @@
   "title": "Flightbox - Flugplatz Lommis",
   "themeColor": "#003863",
   "shortName": "Flightbox LSZT",
-  "paymentMethods": ["cash", "card"],
+  "paymentMethods": [
+    {
+      "name": "card",
+      "authCondition": "kiosk"
+    },
+    {
+      "name": "checkout",
+      "authCondition": "notKiosk"
+    },
+    "cash"
+  ],
   "memberManagement": true
 }


### PR DESCRIPTION
## Summary
- Add `checkout` as a non-kiosk payment method for lszt.
- Resolves to: kiosk → `card`, `cash`; non-kiosk → `checkout`, `cash`.
- Uses the `authCondition` gating pattern already used by lsze.

## Test plan
- [ ] Verify kiosk login on lszt shows `card` and `cash`.
- [ ] Verify non-kiosk login on lszt shows `checkout` and `cash`.