### PR TITLE
Disable member management for lszt

### DIFF
--- a/projects/lszt.json
+++ b/projects/lszt.json
@@ -117,6 +117,5 @@
       "authCondition": "notKiosk"
     },
     "cash"
-  ],
-  "memberManagement": true
+  ]
 }


### PR DESCRIPTION
## Summary
- Remove the `memberManagement` flag from lszt config so it falls back to the default (off).

## Test plan
- [ ] Verify lszt no longer surfaces member-management features.