### PR TITLE
Restrict cash payment to kiosk for lszt

### DIFF
--- a/projects/lszt.json
+++ b/projects/lszt.json
@@ -113,9 +113,12 @@
       "authCondition": "kiosk"
     },
     {
+      "name": "cash",
+      "authCondition": "kiosk"
+    },
+    {
       "name": "checkout",
       "authCondition": "notKiosk"
-    },
-    "cash"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Gate `cash` payment method to kiosk for lszt (previously always enabled)
- Result: kiosk users get `card` + `cash`; non-kiosk users get `checkout` only

## Test plan
- [ ] Kiosk session shows card + cash, not checkout
- [ ] Non-kiosk session shows checkout only