### PR TITLE
Enable passkey login for lszt prod

### DIFF
--- a/projects/lszt.json
+++ b/projects/lszt.json
@@ -98,7 +98,9 @@
     "production": {
       "firebaseProjectId": "project-8979611309653332047",
       "firebaseDatabaseName": "lszt",
-      "firebaseApiKey": "AIzaSyBNL_8OjB26xYYmjWbTCiPcxKgHs73FxGc"
+      "firebaseApiKey": "AIzaSyBNL_8OjB26xYYmjWbTCiPcxKgHs73FxGc",
+      "passkeysEnabled": true,
+      "disableIpAuthentication": true
     }
   },
   "loginForm": "email",


### PR DESCRIPTION
## Summary
- Add `passkeysEnabled: true` and `disableIpAuthentication: true` to the
  lszt `production` env block, matching the `test` env
- Brings lszt prod login in line with test (email/passkey, no IP auth)

## Test plan
- [ ] After deploy, lszt prod offers passkey/email login
- [ ] IP-based authentication no longer applied on lszt prod