### PR TITLE
Preserve original createdBy when a movement is updated

### DIFF
--- a/src/modules/movements/sagas.spec.ts
+++ b/src/modules/movements/sagas.spec.ts
@@ -5,7 +5,7 @@ import * as actions from './actions';
 import * as sagas from './sagas';
 import * as remote from './remote';
 import {addMovementAssociationListener, removeMovementAssociationListener, removeAllAssociationListeners} from './remote';
-import {LIMIT} from './pagination';
+import {LIMIT, toOrderKey} from './pagination';
 import FakeFirebaseSnapshot from '../../../test/FakeFirebaseSnapshot'
 import {loadRemote} from '../profile'
 import {compareDescending, firebaseToLocal} from '../../util/movements'
@@ -627,6 +627,171 @@ describe('modules', () => {
           expect(generator.next(key).value).toEqual(put(actions.saveMovementSuccess(key, formValues)));
 
           expect(generator.next().done).toEqual(true);
+        });
+
+        it('should preserve original createdBy when another user updates the movement', () => {
+          const generator = sagas.saveMovement();
+
+          expect(generator.next().value).toEqual(select(sagas.wizardFormValuesSelector));
+
+          const formValues = {
+            type: 'departure',
+            key: 'existing-departure-key',
+            immatriculation: 'HBABC',
+            date: '2016-10-09',
+            time: '16:00',
+            createdBy: 'pilotA@example.com',
+            createdBy_orderKey: 'pilotA@example.com_8523978399999',
+          };
+
+          expect(generator.next(formValues).value).toEqual(select(sagas.authSelector));
+
+          const auth = {
+            email: 'admin@example.com',
+            admin: true
+          }
+
+          // privacyPolicyUrlSelector is skipped on update (key is set)
+          const effect = generator.next(auth).value;
+          expect(effect).toEqual(
+            call(remote.saveMovement, '/departures', 'existing-departure-key', {
+              immatriculation: 'HBABC',
+              dateTime: '2016-10-09T14:00:00.000Z',
+              negativeTimestamp: -1476021600000,
+              createdBy: 'pilotA@example.com',
+              createdBy_orderKey: 'pilotA@example.com_8523978399999',
+            })
+          );
+
+          const savedMovement = (effect as any).payload.args[2];
+          expect(savedMovement.createdBy).toBe('pilotA@example.com');
+
+          expect(generator.next('existing-departure-key').value)
+            .toEqual(put(actions.saveMovementSuccess('existing-departure-key', formValues)));
+
+          expect(generator.next().done).toEqual(true);
+        });
+
+        it('should recompute createdBy_orderKey from original author when the time changes', () => {
+          const generator = sagas.saveMovement();
+
+          expect(generator.next().value).toEqual(select(sagas.wizardFormValuesSelector));
+
+          // Editor moved the departure to a different time, so the carried
+          // createdBy_orderKey timestamp is now stale.
+          const formValues = {
+            type: 'departure',
+            key: 'existing-departure-key',
+            immatriculation: 'HBABC',
+            date: '2016-10-09',
+            time: '18:00',
+            createdBy: 'pilotA@example.com',
+            createdBy_orderKey: 'pilotA@example.com_8523978399999',
+          };
+
+          expect(generator.next(formValues).value).toEqual(select(sagas.authSelector));
+
+          const auth = { email: 'admin@example.com', admin: true }
+
+          const effect = generator.next(auth).value;
+          const savedMovement = (effect as any).payload.args[2];
+          expect(savedMovement.createdBy).toBe('pilotA@example.com');
+          expect(savedMovement.createdBy_orderKey)
+            .toBe(toOrderKey('pilotA@example.com', savedMovement.negativeTimestamp));
+          // recomputed with the new timestamp, not the stale carried value
+          expect(savedMovement.createdBy_orderKey).not.toBe('pilotA@example.com_8523978399999');
+
+          expect(generator.next('existing-departure-key').value)
+            .toEqual(put(actions.saveMovementSuccess('existing-departure-key', formValues)));
+          expect(generator.next().done).toEqual(true);
+        });
+
+        it('should keep createdBy when the original author updates their own movement', () => {
+          const generator = sagas.saveMovement();
+
+          expect(generator.next().value).toEqual(select(sagas.wizardFormValuesSelector));
+
+          const formValues = {
+            type: 'departure',
+            key: 'existing-departure-key',
+            immatriculation: 'HBABC',
+            date: '2016-10-09',
+            time: '16:00',
+            createdBy: 'pilotA@example.com',
+            createdBy_orderKey: 'pilotA@example.com_8523978399999',
+          };
+
+          expect(generator.next(formValues).value).toEqual(select(sagas.authSelector));
+
+          const auth = { email: 'pilotA@example.com' }
+
+          const effect = generator.next(auth).value;
+          const savedMovement = (effect as any).payload.args[2];
+          expect(savedMovement.createdBy).toBe('pilotA@example.com');
+          expect(savedMovement.createdBy_orderKey).toBe('pilotA@example.com_8523978399999');
+
+          expect(generator.next('existing-departure-key').value)
+            .toEqual(put(actions.saveMovementSuccess('existing-departure-key', formValues)));
+          expect(generator.next().done).toEqual(true);
+        });
+
+        it('should preserve original createdBy when another user updates an arrival', () => {
+          const generator = sagas.saveMovement();
+
+          expect(generator.next().value).toEqual(select(sagas.wizardFormValuesSelector));
+
+          const formValues = {
+            type: 'arrival',
+            key: 'existing-arrival-key',
+            immatriculation: 'HBABC',
+            date: '2016-10-09',
+            time: '16:00',
+            createdBy: 'pilotA@example.com',
+            createdBy_orderKey: 'pilotA@example.com_8523978399999',
+          };
+
+          expect(generator.next(formValues).value).toEqual(select(sagas.authSelector));
+
+          const auth = { email: 'admin@example.com', admin: true }
+
+          const effect = generator.next(auth).value;
+          expect(effect).toEqual(
+            call(remote.saveMovement, '/arrivals', 'existing-arrival-key', {
+              immatriculation: 'HBABC',
+              dateTime: '2016-10-09T14:00:00.000Z',
+              negativeTimestamp: -1476021600000,
+              createdBy: 'pilotA@example.com',
+              createdBy_orderKey: 'pilotA@example.com_8523978399999',
+            })
+          );
+
+          expect(generator.next('existing-arrival-key').value)
+            .toEqual(put(actions.saveMovementSuccess('existing-arrival-key', formValues)));
+          expect(generator.next().done).toEqual(true);
+        });
+
+        it('should not set createdBy fields on create without an email (kiosk)', () => {
+          const generator = sagas.saveMovement();
+
+          expect(generator.next().value).toEqual(select(sagas.wizardFormValuesSelector));
+
+          const formValues = {
+            type: 'departure',
+            immatriculation: 'HBABC',
+            date: '2016-10-09',
+            time: '16:00',
+          };
+
+          expect(generator.next(formValues).value).toEqual(select(sagas.authSelector));
+
+          const auth = {}
+
+          expect(generator.next(auth).value).toEqual(select(sagas.privacyPolicyUrlSelector));
+
+          const effect = generator.next(null).value;
+          const savedMovement = (effect as any).payload.args[2];
+          expect(savedMovement.createdBy).toBeUndefined();
+          expect(savedMovement.createdBy_orderKey).toBeUndefined();
         });
       });
 

--- a/src/modules/movements/sagas.ts
+++ b/src/modules/movements/sagas.ts
@@ -514,9 +514,11 @@ export function* saveMovement() {
   delete movement.type;
   delete movement.associatedMovement;
 
-  if (auth.email) {
+  if (!key && auth.email) {
     movement.createdBy = auth.email
-    movement.createdBy_orderKey = toOrderKey(auth.email, movement.negativeTimestamp as number)
+  }
+  if (typeof movement.createdBy === 'string') {
+    movement.createdBy_orderKey = toOrderKey(movement.createdBy, movement.negativeTimestamp as number)
   }
 
   if (!key) {


### PR DESCRIPTION
## Summary
- `saveMovement` (the shared create+update path) set `createdBy` and `createdBy_orderKey` on **every** save, so when an admin or any other user edited a movement, ownership was reassigned to the editor.
- Fix: set `createdBy` only on create; recompute `createdBy_orderKey` from the preserved author so per-user ordering stays correct even if the editor changed the movement's date/time.

This matters because ownership drives the "my movements" filter (`sagas.ts`), the non-admin edit guard, and per-user pagination (`createdBy_orderKey`).

## Tests
Added 5 cases in `src/modules/movements/sagas.spec.ts`:
- original `createdBy` preserved when an admin edits (departure + arrival)
- `createdBy_orderKey` recomputed with the new timestamp on a time-edit
- self-edit leaves `createdBy` unchanged
- kiosk create (no email) omits the author fields

The 3 admin-edit cases were verified to **fail against the unfixed code** (genuine regression coverage).

## Test plan
- [x] `npm test` — 2190/2190 pass
- [x] `npm run typecheck` — clean
- [x] new tests fail without the fix, pass with it
- [ ] Manual: create a departure as pilot A, edit/save as an admin, confirm `/departures/<key>/createdBy` is still pilot A and it stays in A's "my movements"