### PR TITLE
Add last_update_user to aerodrome status API and admin UI

### DIFF
--- a/firebase-rules-template.json
+++ b/firebase-rules-template.json
@@ -380,6 +380,18 @@
         "by": {
           ".validate": "newData.isString() && newData.val().length > 0"
         },
+        "uid": {
+          ".validate": "newData.isString() && newData.val().length > 0"
+        },
+        "firstname": {
+          ".validate": "newData.isString()"
+        },
+        "lastname": {
+          ".validate": "newData.isString()"
+        },
+        "email": {
+          ".validate": "newData.isString()"
+        },
         "$other": {
           ".validate": false
         }

--- a/functions/api/fetchAerodromeStatus.js
+++ b/functions/api/fetchAerodromeStatus.js
@@ -10,12 +10,22 @@ const fetchAerodromeStatus = async firebase => {
 
   if (arr.length > 0) {
     const status = arr[0]
-    return {
+    const user = {}
+    if (status.uid) user.uid = status.uid
+    if (status.firstname) user.firstname = status.firstname
+    if (status.lastname) user.lastname = status.lastname
+    if (status.email) user.email = status.email
+
+    const response = {
       status: status.status,
       last_update_date: new Date(status.timestamp).toISOString(),
       last_update_by: status.by,
       message: status.details
     }
+    if (Object.keys(user).length > 0) {
+      response.last_update_user = user
+    }
+    return response
   }
 
   return {}

--- a/functions/api/fetchAerodromeStatus.spec.js
+++ b/functions/api/fetchAerodromeStatus.spec.js
@@ -14,6 +14,37 @@ describe('functions/api/fetchAerodromeStatus', () => {
   it('returns formatted status when data exists', async () => {
     const timestamp = new Date('2026-01-15T10:00:00Z').getTime();
     const firebase = makeFirebase({
+      abc: {
+        status: 'open',
+        timestamp,
+        by: 'Hans Meier',
+        uid: 'uid-123',
+        firstname: 'Hans',
+        lastname: 'Meier',
+        email: 'hans@example.ch',
+        details: 'All clear',
+      },
+    });
+
+    const result = await fetchAerodromeStatus(firebase);
+
+    expect(result).toEqual({
+      status: 'open',
+      last_update_date: '2026-01-15T10:00:00.000Z',
+      last_update_by: 'Hans Meier',
+      last_update_user: {
+        uid: 'uid-123',
+        firstname: 'Hans',
+        lastname: 'Meier',
+        email: 'hans@example.ch',
+      },
+      message: 'All clear',
+    });
+  });
+
+  it('omits last_update_user for legacy records without user fields', async () => {
+    const timestamp = new Date('2026-01-15T10:00:00Z').getTime();
+    const firebase = makeFirebase({
       abc: { status: 'open', timestamp, by: 'pilot@example.com', details: 'All clear' },
     });
 
@@ -25,6 +56,27 @@ describe('functions/api/fetchAerodromeStatus', () => {
       last_update_by: 'pilot@example.com',
       message: 'All clear',
     });
+    expect(result.last_update_user).toBeUndefined();
+  });
+
+  it('includes only uid in last_update_user when profile fields are missing', async () => {
+    const timestamp = new Date('2026-01-15T10:00:00Z').getTime();
+    const firebase = makeFirebase({
+      abc: {
+        status: 'closed',
+        timestamp,
+        by: 'uid-123',
+        uid: 'uid-123',
+        firstname: null,
+        lastname: null,
+        email: null,
+        details: '',
+      },
+    });
+
+    const result = await fetchAerodromeStatus(firebase);
+
+    expect(result.last_update_user).toEqual({ uid: 'uid-123' });
   });
 
   it('returns empty object when no data exists', async () => {

--- a/src/components/AerodromeStatusForm/StatusContent.tsx
+++ b/src/components/AerodromeStatusForm/StatusContent.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import StatusShape from './StatusShape';
 import newLineToBr from '../../util/newLineToBr';
+import formatUpdatedBy from '../../util/formatUpdatedBy';
 
 const Wrapper = styled.div`
   padding: 1em;
@@ -17,12 +18,15 @@ const Author = styled.div`
   font-style: italic;
 `
 
-const StatusContent = props => (
-  <Wrapper>
-    {props.item.details && <div>{newLineToBr(props.item.details)}</div>}
-    {props.item.by && <Author>von {props.item.by}</Author>}
-  </Wrapper>
-);
+const StatusContent = props => {
+  const author = formatUpdatedBy(props.item);
+  return (
+    <Wrapper>
+      {props.item.details && <div>{newLineToBr(props.item.details)}</div>}
+      {author && <Author>von {author}</Author>}
+    </Wrapper>
+  );
+};
 
 StatusContent.propTypes = {
   item: StatusShape.isRequired

--- a/src/components/AerodromeStatusForm/StatusShape.tsx
+++ b/src/components/AerodromeStatusForm/StatusShape.tsx
@@ -4,5 +4,10 @@ export default PropTypes.shape({
   key: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
   details: PropTypes.string.isRequired,
-  timestamp: PropTypes.number.isRequired
+  timestamp: PropTypes.number.isRequired,
+  by: PropTypes.string,
+  uid: PropTypes.string,
+  firstname: PropTypes.string,
+  lastname: PropTypes.string,
+  email: PropTypes.string
 })

--- a/src/modules/settings/aerodromeStatus/sagas.spec.ts
+++ b/src/modules/settings/aerodromeStatus/sagas.spec.ts
@@ -81,15 +81,24 @@ describe('modules', () => {
             const auth = {
               admin: true,
               uid: '30004',
-              name: 'Hans Meier'
+              name: 'Hans Meier',
+              email: 'hans@example.ch'
             }
 
-            const saveEffect = generator.next(auth).value
+            expect(generator.next(auth).value).toEqual(select(sagas.profileSelector));
+
+            const profile = { firstname: 'Hans', lastname: 'Meier' };
+
+            const saveEffect = generator.next(profile).value
             const data = (saveEffect as any).payload.args[0]
 
             expect(data.status).toEqual('restricted');
             expect(data.details).toEqual('Eine Landung pro Person pro Tag.');
             expect(data.by).toEqual('Hans Meier');
+            expect(data.uid).toEqual('30004');
+            expect(data.firstname).toEqual('Hans');
+            expect(data.lastname).toEqual('Meier');
+            expect(data.email).toEqual('hans@example.ch');
             expect(data.timestamp).toEqual(now.getTime());
 
             expect(generator.next().value).toEqual(put(actions.saveAerodromeStatusSuccess()));
@@ -97,7 +106,7 @@ describe('modules', () => {
             expect(generator.next().done).toEqual(true);
           });
 
-          it('should use uid as by when name is not set', () => {
+          it('should use uid as by when name is not set and persist null profile fields', () => {
             const action = actions.saveAerodromeStatus({
               status: 'open',
               details: ''
@@ -109,10 +118,16 @@ describe('modules', () => {
             expect(generator.next().value).toEqual(select(sagas.authSelector));
 
             const auth = { admin: true, uid: 'user-123' };
-            const saveEffect = generator.next(auth).value;
+            expect(generator.next(auth).value).toEqual(select(sagas.profileSelector));
+
+            const saveEffect = generator.next({}).value;
             const data = (saveEffect as any).payload.args[0];
 
             expect(data.by).toEqual('user-123');
+            expect(data.uid).toEqual('user-123');
+            expect(data.firstname).toBeNull();
+            expect(data.lastname).toBeNull();
+            expect(data.email).toBeNull();
           });
 
           it('should handle error silently when auth check fails', () => {
@@ -122,8 +137,11 @@ describe('modules', () => {
             expect(generator.next().value).toEqual(put(actions.setAerodromeStatusSaving()));
             expect(generator.next().value).toEqual(select(sagas.authSelector));
 
-            // auth is null -> will throw
-            const result = generator.next(null);
+            // After auth select, saga continues with profile select before the admin check.
+            expect(generator.next(null).value).toEqual(select(sagas.profileSelector));
+
+            // Profile resolved -> admin check throws because auth is null.
+            const result = generator.next({});
             expect(result.done).toEqual(true);
           });
         });

--- a/src/modules/settings/aerodromeStatus/sagas.ts
+++ b/src/modules/settings/aerodromeStatus/sagas.ts
@@ -7,6 +7,8 @@ import createChannel, {monitor} from '../../../util/createChannel';
 import firebase from '../../../util/firebase';
 
 export const authSelector = (state: any) => state.auth.data;
+export const profileSelector = (state: any) =>
+  (state.profile && state.profile.profile) || {};
 
 export function* loadAerodromeStatus() {
   try {
@@ -49,6 +51,7 @@ export function* saveAerodromeStatus(action: any) {
     yield put(actions.setAerodromeStatusSaving());
 
     const auth = yield select(authSelector);
+    const profile = yield select(profileSelector);
 
     if (!auth || auth.admin !== true) {
       throw new Error('Current user is not authenticated as admin');
@@ -57,7 +60,11 @@ export function* saveAerodromeStatus(action: any) {
     const data = {
       ...action.payload.data,
       timestamp: new Date().getTime(),
-      by: auth.name ? auth.name : auth.uid
+      by: auth.name ? auth.name : auth.uid,
+      uid: auth.uid,
+      firstname: profile.firstname || null,
+      lastname: profile.lastname || null,
+      email: auth.email || null,
     };
 
     yield call(remote.save, data);

--- a/src/util/formatUpdatedBy.spec.ts
+++ b/src/util/formatUpdatedBy.spec.ts
@@ -1,0 +1,67 @@
+import formatUpdatedBy from './formatUpdatedBy';
+
+describe('formatUpdatedBy', () => {
+  it('returns "name (email)" when both name and email are present', () => {
+    expect(formatUpdatedBy({
+      firstname: 'Hans',
+      lastname: 'Meier',
+      email: 'hans@example.ch',
+      uid: 'uid-1',
+      by: 'Hans Meier',
+    })).toEqual('Hans Meier (hans@example.ch)');
+  });
+
+  it('returns just the name when email is missing', () => {
+    expect(formatUpdatedBy({
+      firstname: 'Hans',
+      lastname: 'Meier',
+      uid: 'uid-1',
+      by: 'uid-1',
+    })).toEqual('Hans Meier');
+  });
+
+  it('returns the email when name parts are missing', () => {
+    expect(formatUpdatedBy({
+      firstname: null,
+      lastname: null,
+      email: 'hans@example.ch',
+      uid: 'uid-1',
+      by: 'uid-1',
+    })).toEqual('hans@example.ch');
+  });
+
+  it('returns the uid when name and email are missing on a new record', () => {
+    expect(formatUpdatedBy({
+      firstname: null,
+      lastname: null,
+      email: null,
+      uid: 'uid-1',
+      by: 'uid-1',
+    })).toEqual('uid-1');
+  });
+
+  it('falls back to `by` for a legacy record with no uid', () => {
+    expect(formatUpdatedBy({
+      by: 'Some Old Admin',
+    })).toEqual('Some Old Admin');
+  });
+
+  it('returns null when nothing is usable', () => {
+    expect(formatUpdatedBy({})).toBeNull();
+  });
+
+  it('treats empty / whitespace name parts as missing', () => {
+    expect(formatUpdatedBy({
+      firstname: '   ',
+      lastname: '',
+      email: 'hans@example.ch',
+    })).toEqual('hans@example.ch');
+  });
+
+  it('returns only firstname when lastname is missing', () => {
+    expect(formatUpdatedBy({
+      firstname: 'Hans',
+      lastname: null,
+    })).toEqual('Hans');
+  });
+});

--- a/src/util/formatUpdatedBy.ts
+++ b/src/util/formatUpdatedBy.ts
@@ -1,0 +1,20 @@
+type UpdatedByItem = {
+  by?: string | null;
+  uid?: string | null;
+  firstname?: string | null;
+  lastname?: string | null;
+  email?: string | null;
+};
+
+export default function formatUpdatedBy(item: UpdatedByItem): string | null {
+  const name = [item.firstname, item.lastname]
+    .filter(s => typeof s === 'string' && s.trim().length > 0)
+    .join(' ')
+    .trim();
+
+  if (name && item.email) return `${name} (${item.email})`;
+  if (name) return name;
+  if (item.email) return item.email;
+  if (item.uid) return item.uid;
+  return item.by || null;
+}


### PR DESCRIPTION
## Summary

- Persist `uid`, `firstname`, `lastname` and `email` on `/status` writes alongside the existing `by` string. firstname/lastname come from the loaded `/profiles` slice; email from the auth payload.
- Expose them on `GET /api/aerodrome/status` as a new `last_update_user` object. `last_update_by` keeps its existing string shape for **backwards compatibility**; legacy records (no new fields stored) omit `last_update_user` entirely.
- Render the new metadata on the admin status page (e.g. `"von Hans Meier (hans@example.ch)"`) via a new `formatUpdatedBy` helper with fallback chain `name+email → name → email → uid → legacy by → none`.
- Extend RTDB rules under `/status/$status_id` with **optional** validators for the four new fields. `hasChildren` is unchanged so the rule change is deploy-order tolerant and rollback-safe.

Response shape on a new record:

```json
{
  "status": "closed",
  "last_update_date": "2026-05-23T18:01:55.278Z",
  "last_update_by": "Hans Meier",
  "last_update_user": {
    "uid": "4SJI...",
    "firstname": "Hans",
    "lastname": "Meier",
    "email": "hans@example.ch"
  },
  "message": "..."
}
```

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 2200/2200 passing
- [x] `npm run test:functions` — passing (includes new `fetchAerodromeStatus.spec.js` cases for full record, legacy record, and uid-only)
- [ ] Manual on a test env after deploy:
  - [ ] Log in as an admin with a populated `/profiles/{uid}` row and update the status; confirm the admin page shows `"von <firstname lastname> (<email>)"` for the new entry.
  - [ ] Confirm older entries in the same list still render their legacy `by` string.
  - [ ] `curl https://<aerodrome>.flightbox.aero/api/aerodrome/status` → verify `last_update_user` is present with all four fields.
  - [ ] Confirm the API still returns the legacy shape (no `last_update_user`) for environments still serving a pre-change record.