### PR TITLE
Gate privacy retention functions on per-project flag

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -57,6 +57,11 @@ jobs:
       - run: cd functions && npm ci && cd ..
       - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars
         run: |
+          PRIVACY_FUNCTIONS_ENABLED=$(node -e "
+            const def = require('./projects/default.json');
+            const proj = require('./projects/${{ vars.PROJECT }}.json');
+            process.stdout.write(({ ...def, ...proj }).privacySettings === true ? 'true' : 'false');
+          ")
           cat > functions/.env.${{ vars.FIREBASE_PROJECT }} <<EOF
           RTDB_URL=${{ vars.FIREBASE_RTDB_URL }}
           RTDB_INSTANCE=${{ vars.FIREBASE_RTDB_NAME }}
@@ -68,5 +73,6 @@ jobs:
           WEBAUTHN_RPID=${{ vars.WEBAUTHN_RPID }}
           WEBAUTHN_RPNAME=${{ vars.WEBAUTHN_RPNAME }}
           WEBAUTHN_ORIGINS=${{ vars.WEBAUTHN_ORIGINS }}
+          PRIVACY_FUNCTIONS_ENABLED=${PRIVACY_FUNCTIONS_ENABLED}
           EOF
       - run: firebase deploy --only functions

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -55,6 +55,11 @@ jobs:
       - run: cd functions && npm ci && cd ..
       - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars
         run: |
+          PRIVACY_FUNCTIONS_ENABLED=$(node -e "
+            const def = require('./projects/default.json');
+            const proj = require('./projects/${{ vars.PROJECT }}.json');
+            process.stdout.write(({ ...def, ...proj }).privacySettings === true ? 'true' : 'false');
+          ")
           cat > functions/.env.${{ vars.FIREBASE_PROJECT }} <<EOF
           RTDB_URL=${{ vars.FIREBASE_RTDB_URL }}
           RTDB_INSTANCE=${{ vars.FIREBASE_RTDB_NAME }}
@@ -66,5 +71,6 @@ jobs:
           WEBAUTHN_RPID=${{ vars.WEBAUTHN_RPID }}
           WEBAUTHN_RPNAME=${{ vars.WEBAUTHN_RPNAME }}
           WEBAUTHN_ORIGINS=${{ vars.WEBAUTHN_ORIGINS }}
+          PRIVACY_FUNCTIONS_ENABLED=${PRIVACY_FUNCTIONS_ENABLED}
           EOF
       - run: firebase deploy --only functions

--- a/functions/index.js
+++ b/functions/index.js
@@ -31,8 +31,6 @@ const associatedMovementsTriggers = require('./associatedMovements/setAssociated
 const invoiceRecipientsTrigger = require('./invoiceRecipients/invoiceRecipientsTrigger');
 const homebasedAircraftTrigger = require('./homebasedAircraft/homebasedAircraftTrigger');
 const updateArrivalPaymentStatus = require('./updateArrivalPaymentStatus');
-const { scheduledAnonymizeMovements } = require('./anonymizeMovements');
-const { scheduledCleanupMessages } = require('./cleanupMessages');
 
 exports.auth = auth;
 exports.generateSignInLink = generateSignInLink;
@@ -67,5 +65,9 @@ exports.enrichArrivalOnUpdate = enrichMovements.enrichArrivalOnUpdate;
 
 exports.updateArrivalPaymentStatusOnCardPaymentUpdate = updateArrivalPaymentStatus.updateArrivalPaymentStatusOnCardPaymentUpdate;
 
-exports.scheduledAnonymizeMovements = scheduledAnonymizeMovements;
-exports.scheduledCleanupMessages = scheduledCleanupMessages;
+if (process.env.PRIVACY_FUNCTIONS_ENABLED === 'true') {
+  const { scheduledAnonymizeMovements } = require('./anonymizeMovements');
+  const { scheduledCleanupMessages } = require('./cleanupMessages');
+  exports.scheduledAnonymizeMovements = scheduledAnonymizeMovements;
+  exports.scheduledCleanupMessages = scheduledCleanupMessages;
+}


### PR DESCRIPTION
## Summary
- Conditionally export `scheduledAnonymizeMovements` and `scheduledCleanupMessages` from `functions/index.js`, gated on `process.env.PRIVACY_FUNCTIONS_ENABLED`.
- Deploy workflows derive that flag from the existing `projects/<name>.json` (merged over `default.json`) and inject it into `functions/.env.<projectId>`, so the existing `privacySettings` flag now also governs whether the two scheduled Cloud Functions and their Cloud Scheduler jobs exist in each project.
- Saves ~CHF 2/month on the Cloud Scheduler bill by removing no-op scheduler jobs from every project that doesn't actually use retention.

## Background
The two scheduled functions were added on 2026-03-20 (commit `efdd6ad`) but only `lspl-test` configures retention via `/settings/{movementRetentionDays,messageRetentionDays}` in RTDB. Everywhere else they early-return on each daily fire. Cloud Scheduler bills per job *existence* (\$0.10/job/month), not per execution — so 2 new daily jobs × ~10 flightbox projects ≈ \$2/month of pure waste. That is the source of the April–May 2026 Cloud Scheduler cost step.

## Manual cleanup required before first deploy
After this merge, the next functions deploy in every non-privacy project will detect two functions to delete. `firebase deploy --only functions` prompts interactively for deletions and will hang in CI. Run the cleanup before merging so the deploy has nothing to delete:

```bash
for proj in mfgt-flights lszm-prod lspv-prod lsze-prod lszo-prod \
            lszm-test lspv-test lsze-test lszo-test; do
  firebase functions:delete scheduledAnonymizeMovements scheduledCleanupMessages \
    --project=$proj --region=europe-west1 --force
done
firebase functions:delete scheduledCleanupMessages \
  --project=cypress-testing --region=europe-west1 --force
```

## Test plan
- [x] Flag derivation verified for all projects (only `lspl` resolves to `true`)
- [x] Conditional export verified locally with `PRIVACY_FUNCTIONS_ENABLED=true` and `=false`
- [x] `npm run test:functions` — 35 suites / 309 tests pass
- [ ] Manual cleanup commands run before merging
- [ ] After dev deploy: `gcloud functions list --project=<each test project> --regions=europe-west1` shows the two functions gone from every project except `lspl-test`
- [ ] After dev deploy: `gcloud scheduler jobs list --project=<each test project> --location=europe-west1` shows the corresponding `firebase-schedule-*` jobs gone
- [ ] Repeat verification after prod deploy