### PR TITLE
Gate privacy functions via generated config file

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -55,13 +55,16 @@ jobs:
           tools-version: 14
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
-      - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars
+      - name: Generate functions/privacy-config.generated.js from project config
         run: |
           PRIVACY_FUNCTIONS_ENABLED=$(node -e "
             const def = require('./projects/default.json');
             const proj = require('./projects/${{ vars.PROJECT }}.json');
             process.stdout.write(({ ...def, ...proj }).privacySettings === true ? 'true' : 'false');
           ")
+          echo "module.exports = $PRIVACY_FUNCTIONS_ENABLED;" > functions/privacy-config.generated.js
+      - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars
+        run: |
           cat > functions/.env.${{ vars.FIREBASE_PROJECT }} <<EOF
           RTDB_URL=${{ vars.FIREBASE_RTDB_URL }}
           RTDB_INSTANCE=${{ vars.FIREBASE_RTDB_NAME }}
@@ -73,6 +76,5 @@ jobs:
           WEBAUTHN_RPID=${{ vars.WEBAUTHN_RPID }}
           WEBAUTHN_RPNAME=${{ vars.WEBAUTHN_RPNAME }}
           WEBAUTHN_ORIGINS=${{ vars.WEBAUTHN_ORIGINS }}
-          PRIVACY_FUNCTIONS_ENABLED=${PRIVACY_FUNCTIONS_ENABLED}
           EOF
       - run: firebase deploy --only functions

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -53,13 +53,16 @@ jobs:
           tools-version: 14
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
       - run: cd functions && npm ci && cd ..
-      - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars
+      - name: Generate functions/privacy-config.generated.js from project config
         run: |
           PRIVACY_FUNCTIONS_ENABLED=$(node -e "
             const def = require('./projects/default.json');
             const proj = require('./projects/${{ vars.PROJECT }}.json');
             process.stdout.write(({ ...def, ...proj }).privacySettings === true ? 'true' : 'false');
           ")
+          echo "module.exports = $PRIVACY_FUNCTIONS_ENABLED;" > functions/privacy-config.generated.js
+      - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars
+        run: |
           cat > functions/.env.${{ vars.FIREBASE_PROJECT }} <<EOF
           RTDB_URL=${{ vars.FIREBASE_RTDB_URL }}
           RTDB_INSTANCE=${{ vars.FIREBASE_RTDB_NAME }}
@@ -71,6 +74,5 @@ jobs:
           WEBAUTHN_RPID=${{ vars.WEBAUTHN_RPID }}
           WEBAUTHN_RPNAME=${{ vars.WEBAUTHN_RPNAME }}
           WEBAUTHN_ORIGINS=${{ vars.WEBAUTHN_ORIGINS }}
-          PRIVACY_FUNCTIONS_ENABLED=${PRIVACY_FUNCTIONS_ENABLED}
           EOF
       - run: firebase deploy --only functions

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules/
 npm-debug.log
 firebase-debug.log
 .runtimeconfig.json
+functions/privacy-config.generated.js

--- a/functions/index.js
+++ b/functions/index.js
@@ -65,7 +65,16 @@ exports.enrichArrivalOnUpdate = enrichMovements.enrichArrivalOnUpdate;
 
 exports.updateArrivalPaymentStatusOnCardPaymentUpdate = updateArrivalPaymentStatus.updateArrivalPaymentStatusOnCardPaymentUpdate;
 
-if (process.env.PRIVACY_FUNCTIONS_ENABLED === 'true') {
+let privacyFunctionsEnabled = false;
+try {
+  privacyFunctionsEnabled = require('./privacy-config.generated.js');
+} catch (e) {
+  // Generated file is written by the deploy workflow; absent in local
+  // dev and unit tests, where the retention jobs should stay disabled.
+  if (e.code !== 'MODULE_NOT_FOUND') throw e;
+}
+
+if (privacyFunctionsEnabled) {
   const { scheduledAnonymizeMovements } = require('./anonymizeMovements');
   const { scheduledCleanupMessages } = require('./cleanupMessages');
   exports.scheduledAnonymizeMovements = scheduledAnonymizeMovements;


### PR DESCRIPTION
## Summary
- `functions/index.js` gates `scheduledAnonymizeMovements` / `scheduledCleanupMessages` at module load. The previous `process.env.PRIVACY_FUNCTIONS_ENABLED` check (introduced in v4.39.0) didn't work: firebase-tools loads `functions/.env.<projectId>` **after** source analysis, and the analyzer subprocess is spawned with an explicit hand-built env that does not inherit arbitrary process.env vars (verified in `firebase-tools/lib/deploy/functions/runtimes/node/index.js:98`). The flag was therefore always undefined at analysis time and the two functions were never exported, even for projects with `privacySettings: true`.
- Surfaced on lspl-test's v4.39.0 deploy as: `The following functions are found in your project but do not exist in your local source code: scheduledCleanupMessages`.
- Fix: deploy workflows write `functions/privacy-config.generated.js` (gitignored) with the boolean value derived from `projects/<name>.json`; `index.js` `require()`s it. File reads happen against the local source tree, which the analyzer subprocess can see, so the conditional evaluates correctly at analysis time. `PRIVACY_FUNCTIONS_ENABLED` is dropped from the `.env.<projectId>` file write — the deployed function runtime doesn't read it anymore.

## Test plan
- [x] `npm run test:functions` — all 309 tests pass
- [x] Verified module-load behaviour locally with the generated file set to `true`, `false`, and missing — privacy functions exported only when `true`
- [ ] After merge, deploy to lspl-test → confirm `scheduledAnonymizeMovements` + `scheduledCleanupMessages` are recreated as Gen 2
- [ ] Spot-check one privacySettings: false env (e.g. lszm-test) on the same release → both functions should remain absent