### PR TITLE
Prevent deselecting required date in single date picker

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -57,6 +57,7 @@ const DatePicker = (props: any) => {
     return (
       <DayPicker
         mode="single"
+        required={!clearable}
         selected={date}
         defaultMonth={date}
         onSelect={handleDayClick}


### PR DESCRIPTION
## Summary
The single-mode date picker (`src/components/DatePicker/DatePicker.tsx`) let the user toggle the selected day **off** by clicking it again, clearing the value via react-day-picker's default single-mode behavior.

For mandatory date fields — notably the movement wizard, where a new movement is initialised with `date: dates.localDate()` (today) — this allowed ending up with no date. It also made three E2E specs **flaky on the last day of the month**: their "select the last selectable day of the month" step (`.rdp-day:not(.rdp-disabled) .rdp-day_button` `.last()`) clicks the already-selected *today*, toggling it off and clearing the date, so the page fails validation and the location-confirmation dialog never appears.

## Fix
Pass react-day-picker's `required` to the `DayPicker` **when the picker is not clearable** (`required={!clearable}`):
- Non-clearable pickers (movement wizard date) — the selected day can no longer be toggled off.
- Clearable pickers (movement filter, settings lock date) — unchanged; they keep their explicit clear (X) button.

## Verification
- `npm run typecheck` — clean
- `npm test` (Jest) — all pass (`DatePicker` suite 20/20)
- Cypress E2E (cypress-testing project), run locally on the last day of the month:
  - `create_departure`, `create_arrival`, `email_user_movement_list` — were failing on month-end, now pass
  - `edit_movement`, `settings/lock_date` (sets **and** clears) — still pass

## Context
This surfaced as a red `build` job on the dependency-update PR (#791), but it is **not** caused by those dependency changes — the specs fail identically on clean `develop` when run on a month-end date. Merging this first unblocks #791 (and fixes month-end CI for all branches).