### PR TITLE
Add allMovements flag to view all movements

### DIFF
--- a/src/modules/auth/sagas.spec.ts
+++ b/src/modules/auth/sagas.spec.ts
@@ -130,6 +130,7 @@ describe('modules', () => {
           }).value).toEqual(call(sagas.getName, 'myadminuser'));
           expect(generator.next('Hans Muster').value).toEqual(put(actions.firebaseAuthenticationEvent({
             admin: true,
+            allMovements: false,
             links: false,
             expiration: 1000,
             token: 'validtoken',
@@ -158,12 +159,43 @@ describe('modules', () => {
           }).value).toEqual(call(sagas.getName, 'testuser'));
           expect(generator.next('Hans Muster').value).toEqual(put(actions.firebaseAuthenticationEvent({
             admin: false,
+            allMovements: false,
             links: true,
             expiration: 1000,
             token: 'validtoken',
             uid: 'testuser',
             name: 'Hans Muster',
             email: 'testuser@example.com',
+            guest: false,
+            kiosk: false,
+            local: false
+          })));
+
+          expectDoneWithoutReturn(generator);
+        });
+
+        it('should put firebaseAuthenticationEvent with allMovements flag for non-admin allMovements user', () => {
+          const generator = sagas.doListenFirebaseAuthentication(actions.firebaseAuthentication({
+            uid: 'vieweruser',
+            expires: 1,
+            token: 'validtoken',
+            email: 'viewer@example.com'
+          }));
+
+          expect(generator.next().value).toEqual(call(sagas.getLoginData, 'vieweruser'));
+          expect(generator.next({
+            admin: false,
+            allMovements: true
+          }).value).toEqual(call(sagas.getName, 'vieweruser'));
+          expect(generator.next('Hans Muster').value).toEqual(put(actions.firebaseAuthenticationEvent({
+            admin: false,
+            allMovements: true,
+            links: true,
+            expiration: 1000,
+            token: 'validtoken',
+            uid: 'vieweruser',
+            name: 'Hans Muster',
+            email: 'viewer@example.com',
             guest: false,
             kiosk: false,
             local: false

--- a/src/modules/auth/sagas.ts
+++ b/src/modules/auth/sagas.ts
@@ -233,6 +233,7 @@ export function* doListenFirebaseAuthentication(action: any) {
       expiration: expires * 1000,
       token,
       admin: loginData && loginData.admin === true,
+      allMovements: loginData && loginData.allMovements === true,
       guest,
       kiosk,
       local,

--- a/src/modules/movements/sagas.spec.ts
+++ b/src/modules/movements/sagas.spec.ts
@@ -357,6 +357,35 @@ describe('modules', () => {
           expect(next.value).toEqual(expectedResult);
           expect(next.done).toEqual(true);
         });
+
+        it('should not filter by email for non-admin allMovements users', () => {
+          const state = {
+            loading: false,
+            data: new ImmutableItemsArray()
+          };
+
+          const generator = sagas.loadLatestDeparturesAndArrivalsPaged(state, false);
+
+          expect(generator.next().value)
+            .toEqual(select(sagas.authSelector));
+
+          const auth = {
+            admin: false,
+            allMovements: true,
+            email: 'viewer@example.com'
+          }
+
+          expect(generator.next(auth).value)
+            .toEqual(call(remote.loadLimited, '/departures', undefined, LIMIT, undefined, undefined));
+
+          const departuresResult = {
+            snapshot: new FakeFirebaseSnapshot(null, []),
+            ref: { name: 'depRef' }
+          };
+
+          expect(generator.next(departuresResult).value)
+            .toEqual(call(remote.loadLimited, '/arrivals', undefined, LIMIT, undefined, undefined));
+        });
       });
 
       describe('monitorRef', () => {
@@ -1299,6 +1328,44 @@ describe('modules', () => {
 
           expect(generator.next().done).toEqual(true);
         });
+
+        it('should include other users movements for non-admin allMovements users', () => {
+          const channel = { put: jest.fn() };
+
+          const departuresSnapshot = new FakeFirebaseSnapshot(null, [
+            new FakeFirebaseSnapshot('dep1', {
+              immatriculation: 'HBABC',
+              dateTime: '2017-05-03T09:00:00.000Z',
+              negativeTimestamp: -1493802000000,
+              createdBy: 'viewer@example.com'
+            })
+          ]);
+
+          const arrivalsSnapshot = new FakeFirebaseSnapshot(null, [
+            new FakeFirebaseSnapshot('arr1', {
+              immatriculation: 'HBKOF',
+              dateTime: '2017-05-03T10:00:00.000Z',
+              negativeTimestamp: -1493798400000,
+              createdBy: 'other@example.com'
+            })
+          ]);
+
+          const existingMovements = new ImmutableItemsArray();
+          const generator = sagas.addMovements(
+            departuresSnapshot, arrivalsSnapshot, existingMovements, channel
+          );
+
+          expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+          const auth = { admin: false, allMovements: true, email: 'viewer@example.com' };
+          expect(generator.next(auth).value).toEqual(
+            call(sagas.monitorAssociations, expect.anything(), existingMovements, channel)
+          );
+
+          generator.next();
+          const setMovementsAction = channel.put.mock.calls[0][0];
+          expect(setMovementsAction.payload.movements.array).toHaveLength(2);
+        });
       });
 
       describe('monitorAssociations', () => {
@@ -1488,6 +1555,33 @@ describe('modules', () => {
           const auth = { admin: false, email: 'pilot@example.com' };
           expect(generator.next(auth).done).toEqual(true);
           expect(channel.put).not.toHaveBeenCalled();
+        });
+
+        it('should add other users movement for non-admin allMovements users', () => {
+          const channel = { put: jest.fn() };
+          const existingData = new ImmutableItemsArray([]);
+          const snapshot = new FakeFirebaseSnapshot('dep1', {
+            immatriculation: 'HBABC',
+            dateTime: '2017-05-03T09:00:00.000Z',
+            negativeTimestamp: -1493802000000,
+            createdBy: 'other@example.com'
+          });
+
+          const generator = sagas.addMovementToState(
+            snapshot, 'departure', { data: existingData }, channel
+          );
+
+          expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+          const auth = { admin: false, allMovements: true, email: 'viewer@example.com' };
+          expect(generator.next(auth).value).toEqual(
+            call(sagas.monitorAssociation, expect.anything(), channel)
+          );
+
+          generator.next();
+          expect(channel.put).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'SET_MOVEMENTS' })
+          );
         });
 
         it('should call monitorAssociation and set movements when movement is new and not last element', () => {

--- a/src/modules/movements/sagas.ts
+++ b/src/modules/movements/sagas.ts
@@ -22,6 +22,8 @@ export const wizardFormValuesSelector = (state: any) => state.ui.wizard.values;
 
 export const authSelector = (state: any) => state.auth.data;
 
+export const canSeeAllMovements = (auth: any) => !!(auth && (auth.admin || auth.allMovements));
+
 export const privacyPolicyUrlSelector = (state: any) => state.settings.privacyPolicyUrl.url;
 
 export function* getProfileDefaultValues() {
@@ -282,7 +284,7 @@ export function* loadLatestDeparturesAndArrivalsPaged(movements: any, clear: boo
     pagination.start,
     pagination.limit,
     undefined,
-    !auth.admin ? auth.email : undefined
+    !canSeeAllMovements(auth) ? auth.email : undefined
   );
 
   const arrivals = yield call(
@@ -291,7 +293,7 @@ export function* loadLatestDeparturesAndArrivalsPaged(movements: any, clear: boo
     pagination.start,
     pagination.limit,
     undefined,
-    !auth.admin ? auth.email : undefined
+    !canSeeAllMovements(auth) ? auth.email : undefined
   );
 
   const loadedMovements: any = {
@@ -308,7 +310,7 @@ export function* loadLatestDeparturesAndArrivalsPaged(movements: any, clear: boo
       pagination.start,
       undefined,
       reloadParams.reloadEnd,
-      !auth.admin ? auth.email : undefined
+      !canSeeAllMovements(auth) ? auth.email : undefined
     )
   }
 
@@ -323,7 +325,7 @@ export function* addMovements(departuresSnapshot: any, arrivalsSnapshot: any, ex
 
   const auth = yield select(authSelector);
 
-  const filteredMovements = auth.admin || !auth.email
+  const filteredMovements = canSeeAllMovements(auth) || !auth.email
     ? movements
     : movements.filter((movement: any) => movement.createdBy === auth.email)
 
@@ -399,7 +401,7 @@ export function* addMovementToState(snapshot: any, movementType: string, current
 
     const auth = yield select(authSelector);
     if (!auth) return;
-    if (!auth.admin && auth.email && movement.createdBy !== auth.email) {
+    if (!canSeeAllMovements(auth) && auth.email && movement.createdBy !== auth.email) {
       return;
     }
 


### PR DESCRIPTION
## Context

For lszt, email/passkey login was activated, so non-admin users now see only their own movements while admins see all. Some users need to see **all** arrivals and departures without being granted admin privileges.

The "own movements only" restriction is client-side (Firebase rules already allow any authenticated user to read all movements); the gate is the `admin` boolean on the `/logins/{uid}` record. This adds a sibling `allMovements` boolean that grants the full view only.

## Changes

- **`auth/sagas.ts`** — read `allMovements` from `/logins/{uid}` into auth state, alongside `admin`/`links`.
- **`movements/sagas.ts`** — add a `canSeeAllMovements(auth)` helper (`admin || allMovements`) and route all five visibility gates through it: the three `loadLimited` query filters, the `addMovements` client filter, and the real-time `addMovementToState` filter.
- Tests for both modules covering the new flag.

## Granting the flag

Set `allMovements: true` on a user's `/logins/{uid}` node in the Firebase console (same as `admin`). `/logins` is `".write": false`, so users cannot self-grant. Unset/false preserves current own-movements-only behavior.

## Notes

- `allMovements` does **not** grant any admin capability — AdminPage, admin nav, wizard edit, the date-filter UI, payment/contact info, and aerodrome-status writes all remain gated on `admin`.
- This remains a UI/privacy filter, not a hard security boundary (consistent with the existing `admin` model). No security-rule change required.

## Verification

- `npm run typecheck` — clean
- `npm test` — 2209 passed