### PR TITLE
Add aerodrome status banner to the start page

### DIFF
--- a/firebase-rules-template.json
+++ b/firebase-rules-template.json
@@ -310,6 +310,11 @@
         ".write": "auth !== null && root.child('admins/' + auth.uid).exists()",
         ".validate": "newData.isNumber() && newData.val() > 0"
       },
+      "aerodromeStatusBannerEnabled": {
+        ".read": true,
+        ".write": "auth !== null && root.child('admins/' + auth.uid).exists()",
+        ".validate": "newData.isBoolean()"
+      },
       "$other": {
         ".validate": false
       }

--- a/src/components/AdminPage/subpages/AdminAerodromeStatusPage.tsx
+++ b/src/components/AdminPage/subpages/AdminAerodromeStatusPage.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import LabeledBox from '../../LabeledBox';
 import AerodromeStatusForm from '../../../containers/AerodromeStatusFormContainer';
+import AerodromeStatusBannerToggle from '../../AerodromeStatusBannerToggle';
 import { useTranslation } from 'react-i18next';
 
 const AdminAerodromeStatusPage = () => {
   const { t } = useTranslation();
   return (
     <LabeledBox label={t('admin.aerodromeStatus')} contentPadding={0}>
+      <AerodromeStatusBannerToggle/>
       <AerodromeStatusForm/>
     </LabeledBox>
   );

--- a/src/components/AerodromeStatusBanner/AerodromeStatusBanner.spec.tsx
+++ b/src/components/AerodromeStatusBanner/AerodromeStatusBanner.spec.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react';
+import {renderWithTheme} from '../../../test/renderWithTheme';
+import {ThemeProvider} from 'styled-components';
+import {BrowserRouter} from 'react-router-dom';
+
+const theme: any = {colors: {main: '#003863', background: '#fafafa', danger: '#e00f00'}};
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+}));
+
+jest.mock('../AerodromeStatusForm/StatusOptions', () => ({
+  getLabel: (key: string) => `label.${key}`,
+}));
+
+jest.mock('../../util/dates', () => ({
+  formatDateTime: (ts: number) => `formatted:${ts}`,
+}));
+
+jest.mock('../MaterialIcon', () => {
+  const React = require('react');
+  return function MockMaterialIcon({icon}: {icon: string}) {
+    return <span data-testid="material-icon" data-icon={icon}/>;
+  };
+});
+
+import AerodromeStatusBanner from './AerodromeStatusBanner';
+
+describe('components', () => {
+  describe('AerodromeStatusBanner', () => {
+    it('dispatches watchCurrentAerodromeStatus on mount', () => {
+      const watch = jest.fn();
+      renderWithTheme(
+        <AerodromeStatusBanner enabled={true} status={null} watchCurrentAerodromeStatus={watch}/>
+      );
+      expect(watch).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders nothing when disabled, even with a status', () => {
+      const {container} = renderWithTheme(
+        <AerodromeStatusBanner
+          enabled={false}
+          status={{status: 'closed', details: 'Runway works', timestamp: 1717500000000}}
+          watchCurrentAerodromeStatus={jest.fn()}
+        />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing while status is loading (undefined)', () => {
+      const {container} = renderWithTheme(
+        <AerodromeStatusBanner enabled={true} status={undefined} watchCurrentAerodromeStatus={jest.fn()}/>
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when no status has been set (null)', () => {
+      const {container} = renderWithTheme(
+        <AerodromeStatusBanner enabled={true} status={null} watchCurrentAerodromeStatus={jest.fn()}/>
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('auto-expands a non-open status that loads asynchronously after mount', () => {
+      const wrap = (status: any) => (
+        <BrowserRouter>
+          <ThemeProvider theme={theme}>
+            <AerodromeStatusBanner enabled={true} status={status} watchCurrentAerodromeStatus={jest.fn()}/>
+          </ThemeProvider>
+        </BrowserRouter>
+      );
+      // Mounts before the live status arrives (current === undefined).
+      const {rerender, queryByText, getByText} = render(wrap(undefined));
+      expect(queryByText('Runway works')).toBeNull();
+
+      // Status arrives via the real-time listener -> should be expanded by default.
+      rerender(wrap({status: 'closed', details: 'Runway works', timestamp: 1717500000000}));
+      expect(getByText('Runway works')).toBeTruthy();
+    });
+
+    it('expands a non-open status by default, showing details and timestamp', () => {
+      const {getByText} = renderWithTheme(
+        <AerodromeStatusBanner
+          enabled={true}
+          status={{status: 'closed', details: 'Runway works', timestamp: 1717500000000}}
+          watchCurrentAerodromeStatus={jest.fn()}
+        />
+      );
+      expect(getByText('label.closed')).toBeTruthy();
+      expect(getByText('Runway works')).toBeTruthy();
+      expect(getByText('formatted:1717500000000')).toBeTruthy();
+      expect(document.querySelector('[data-icon="block"]')).toBeTruthy();
+    });
+
+    it('collapses the open status by default, hiding the details', () => {
+      const {getByText, queryByText} = renderWithTheme(
+        <AerodromeStatusBanner
+          enabled={true}
+          status={{status: 'open', details: 'All good', timestamp: 1717500000000}}
+          watchCurrentAerodromeStatus={jest.fn()}
+        />
+      );
+      expect(getByText('label.open')).toBeTruthy();
+      expect(queryByText('All good')).toBeNull();
+      expect(document.querySelector('[data-icon="expand_more"]')).toBeTruthy();
+    });
+
+    it('toggles the details when the summary is clicked', () => {
+      const {getByText, queryByText, getByRole} = renderWithTheme(
+        <AerodromeStatusBanner
+          enabled={true}
+          status={{status: 'open', details: 'All good', timestamp: 1717500000000}}
+          watchCurrentAerodromeStatus={jest.fn()}
+        />
+      );
+      expect(queryByText('All good')).toBeNull();
+      fireEvent.click(getByRole('button'));
+      expect(getByText('All good')).toBeTruthy();
+      expect(document.querySelector('[data-icon="expand_less"]')).toBeTruthy();
+    });
+
+    it('does not link out to a separate status page', () => {
+      const {container} = renderWithTheme(
+        <AerodromeStatusBanner
+          enabled={true}
+          status={{status: 'closed', details: 'Runway works', timestamp: 1717500000000}}
+          watchCurrentAerodromeStatus={jest.fn()}
+        />
+      );
+      expect(container.querySelector('a')).toBeNull();
+    });
+
+    it('uses the warning icon for the restricted status', () => {
+      renderWithTheme(
+        <AerodromeStatusBanner
+          enabled={true}
+          status={{status: 'restricted', details: ''}}
+          watchCurrentAerodromeStatus={jest.fn()}
+        />
+      );
+      expect(document.querySelector('[data-icon="warning"]')).toBeTruthy();
+    });
+
+    it('falls back to the info icon for an unknown status', () => {
+      renderWithTheme(
+        <AerodromeStatusBanner
+          enabled={true}
+          status={{status: 'maintenance', details: ''}}
+          watchCurrentAerodromeStatus={jest.fn()}
+        />
+      );
+      expect(document.querySelector('[data-icon="info"]')).toBeTruthy();
+    });
+
+    it('omits the details element when details is empty', () => {
+      const {getByText} = renderWithTheme(
+        <AerodromeStatusBanner
+          enabled={true}
+          status={{status: 'open', details: ''}}
+          watchCurrentAerodromeStatus={jest.fn()}
+        />
+      );
+      expect(getByText('label.open')).toBeTruthy();
+      expect(document.querySelector('[data-icon="check_circle"]')).toBeTruthy();
+    });
+  });
+});

--- a/src/components/AerodromeStatusBanner/AerodromeStatusBanner.tsx
+++ b/src/components/AerodromeStatusBanner/AerodromeStatusBanner.tsx
@@ -1,0 +1,138 @@
+import React, {useEffect, useState} from 'react';
+import PropTypes from 'prop-types';
+import styled, {useTheme} from 'styled-components';
+import {useTranslation} from 'react-i18next';
+import MaterialIcon from '../MaterialIcon';
+import {getLabel} from '../AerodromeStatusForm/StatusOptions';
+import newLineToBr from '../../util/newLineToBr';
+import dates from '../../util/dates';
+
+const icons: { [key: string]: string } = {
+  open: 'check_circle',
+  restricted: 'warning',
+  closed: 'block',
+};
+
+// Severity accents kept deliberately muted and used only on the status icon and
+// label, so the banner adopts the project's neutral card background instead of a
+// saturated fill that would clash with the logo or theme color.
+const accentFor = (status: string, theme: any) => {
+  switch (status) {
+    case 'open':
+      return '#2e7d32';
+    case 'restricted':
+      return '#b26a00';
+    case 'closed':
+      return theme.colors.danger;
+    default:
+      return theme.colors.main;
+  }
+};
+
+const Wrapper = styled.div`
+  width: 80%;
+  margin: 1em auto 0;
+  padding: 0.75em 1em;
+  border-radius: 10px;
+  background-color: ${props => props.theme.colors.background};
+  font-size: 1.2em;
+  line-height: 1.3;
+`;
+
+const Summary = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+`;
+
+const StatusIcon = styled(MaterialIcon)<{ $accent: string }>`
+  color: ${props => props.$accent};
+`;
+
+const Label = styled.span<{ $accent: string }>`
+  font-weight: bold;
+  flex: 1;
+  color: ${props => props.$accent};
+`;
+
+const Body = styled.div`
+  margin-top: 0.35em;
+  padding-left: 1.75em;
+  font-size: 0.85em;
+`;
+
+const Timestamp = styled.div`
+  margin-top: 0.35em;
+  font-size: 0.85em;
+  font-style: italic;
+  opacity: 0.8;
+`;
+
+const AerodromeStatusBanner = (props: any) => {
+  const {t} = useTranslation();
+  const theme = useTheme();
+  const {status, enabled, watchCurrentAerodromeStatus} = props;
+
+  // null = follow the status severity; a boolean is the user's explicit choice.
+  const [expandedOverride, setExpandedOverride] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    watchCurrentAerodromeStatus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (enabled !== true || status === undefined || status === null) {
+    return null;
+  }
+
+  const accent = accentFor(status.status, theme);
+
+  // Expand by default when the aerodrome is not open, so restrictions and
+  // closures are immediately visible; collapse the reassuring "open" state.
+  // Derived from the current status (which loads asynchronously) so the default
+  // is correct even though the banner mounts before the status arrives.
+  const expanded = expandedOverride !== null ? expandedOverride : status.status !== 'open';
+
+  return (
+    <Wrapper
+      role="status"
+      aria-label={t('admin.aerodromeStatus')}
+    >
+      <Summary
+        type="button"
+        onClick={() => setExpandedOverride(!expanded)}
+        aria-expanded={expanded}
+      >
+        <StatusIcon icon={icons[status.status] || 'info'} $accent={accent}/>
+        <Label $accent={accent}>{getLabel(status.status)}</Label>
+        <MaterialIcon icon={expanded ? 'expand_less' : 'expand_more'}/>
+      </Summary>
+      {expanded && (
+        <Body>
+          {status.details && <div>{newLineToBr(status.details)}</div>}
+          {status.timestamp && <Timestamp>{dates.formatDateTime(status.timestamp)}</Timestamp>}
+        </Body>
+      )}
+    </Wrapper>
+  );
+};
+
+(AerodromeStatusBanner as any).propTypes = {
+  status: PropTypes.shape({
+    status: PropTypes.string.isRequired,
+    details: PropTypes.string,
+    timestamp: PropTypes.number,
+  }),
+  enabled: PropTypes.bool,
+  watchCurrentAerodromeStatus: PropTypes.func.isRequired,
+};
+
+export default AerodromeStatusBanner;

--- a/src/components/AerodromeStatusBanner/index.tsx
+++ b/src/components/AerodromeStatusBanner/index.tsx
@@ -1,0 +1,3 @@
+import AerodromeStatusBanner from '../../containers/AerodromeStatusBannerContainer';
+
+export default AerodromeStatusBanner;

--- a/src/components/AerodromeStatusBannerToggle/AerodromeStatusBannerToggle.spec.tsx
+++ b/src/components/AerodromeStatusBannerToggle/AerodromeStatusBannerToggle.spec.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {fireEvent} from '@testing-library/react';
+import {renderWithTheme} from '../../../test/renderWithTheme';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+}));
+
+import AerodromeStatusBannerToggle from './AerodromeStatusBannerToggle';
+
+describe('components', () => {
+  describe('AerodromeStatusBannerToggle', () => {
+    it('reflects the enabled state in the checkbox', () => {
+      const {container} = renderWithTheme(
+        <AerodromeStatusBannerToggle enabled={true} setAerodromeStatusBannerEnabled={jest.fn()}/>
+      );
+      expect((container.querySelector('input[type="checkbox"]') as HTMLInputElement).checked).toBe(true);
+    });
+
+    it('is unchecked when disabled by default', () => {
+      const {container} = renderWithTheme(
+        <AerodromeStatusBannerToggle enabled={false} setAerodromeStatusBannerEnabled={jest.fn()}/>
+      );
+      expect((container.querySelector('input[type="checkbox"]') as HTMLInputElement).checked).toBe(false);
+    });
+
+    it('dispatches setAerodromeStatusBannerEnabled with the new value on change', () => {
+      const setEnabled = jest.fn();
+      const {container} = renderWithTheme(
+        <AerodromeStatusBannerToggle enabled={false} setAerodromeStatusBannerEnabled={setEnabled}/>
+      );
+      fireEvent.click(container.querySelector('input[type="checkbox"]') as HTMLInputElement);
+      expect(setEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('disables the checkbox while saving', () => {
+      const {container} = renderWithTheme(
+        <AerodromeStatusBannerToggle enabled={false} disabled={true} setAerodromeStatusBannerEnabled={jest.fn()}/>
+      );
+      expect((container.querySelector('input[type="checkbox"]') as HTMLInputElement).disabled).toBe(true);
+    });
+  });
+});

--- a/src/components/AerodromeStatusBannerToggle/AerodromeStatusBannerToggle.tsx
+++ b/src/components/AerodromeStatusBannerToggle/AerodromeStatusBannerToggle.tsx
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+import {useTranslation} from 'react-i18next';
+
+const Wrapper = styled.div`
+  padding: 1em;
+  border-bottom: 1px solid #ddd;
+`;
+
+const Label = styled.label`
+  cursor: pointer;
+`;
+
+const Input = styled.input`
+  margin-right: 1em;
+  cursor: pointer;
+`;
+
+const AerodromeStatusBannerToggle = (props: any) => {
+  const {t} = useTranslation();
+  const {enabled, disabled, setAerodromeStatusBannerEnabled} = props;
+
+  return (
+    <Wrapper>
+      <Label>
+        <Input
+          type="checkbox"
+          checked={enabled === true}
+          disabled={disabled}
+          onChange={e => setAerodromeStatusBannerEnabled(e.target.checked)}
+        />
+        {t('aerodromeStatus.showOnStartPage')}
+      </Label>
+    </Wrapper>
+  );
+};
+
+(AerodromeStatusBannerToggle as any).propTypes = {
+  enabled: PropTypes.bool,
+  disabled: PropTypes.bool,
+  setAerodromeStatusBannerEnabled: PropTypes.func.isRequired,
+};
+
+export default AerodromeStatusBannerToggle;

--- a/src/components/AerodromeStatusBannerToggle/index.tsx
+++ b/src/components/AerodromeStatusBannerToggle/index.tsx
@@ -1,0 +1,3 @@
+import AerodromeStatusBannerToggle from '../../containers/AerodromeStatusBannerToggleContainer';
+
+export default AerodromeStatusBannerToggle;

--- a/src/components/StartPage/Main.tsx
+++ b/src/components/StartPage/Main.tsx
@@ -4,10 +4,11 @@ import styled from 'styled-components';
 import Hints from './Hints';
 import EntryPoints from './EntryPoints';
 import InstallCard from './InstallCard';
+import AerodromeStatusBanner from '../AerodromeStatusBanner';
 import PostLoginPasskeyPrompt from '../../containers/PostLoginPasskeyPromptContainer';
 
 const Wrapper = styled.div`
-  padding-top: 100px;
+  padding-top: 70px;
 `;
 
 const Promotions = styled.div`
@@ -20,6 +21,7 @@ const Promotions = styled.div`
 
 const Main = ({ auth }: any) => (
   <Wrapper>
+    <AerodromeStatusBanner/>
     <Hints guest={auth.data.guest} kiosk={auth.data.kiosk}/>
     <EntryPoints admin={auth.data.admin} guest={auth.data.guest} kiosk={auth.data.kiosk}/>
     <Promotions>

--- a/src/containers/AerodromeStatusBannerContainer.tsx
+++ b/src/containers/AerodromeStatusBannerContainer.tsx
@@ -1,0 +1,15 @@
+import {connect} from 'react-redux';
+import {watchCurrentAerodromeStatus} from '../modules/settings/aerodromeStatus';
+import AerodromeStatusBanner from '../components/AerodromeStatusBanner/AerodromeStatusBanner';
+import {RootState} from '../modules';
+
+const mapStateToProps = (state: RootState) => ({
+  status: state.settings.aerodromeStatus.current,
+  enabled: state.settings.aerodromeStatusBannerEnabled.enabled,
+});
+
+const mapActionCreators = {
+  watchCurrentAerodromeStatus
+};
+
+export default connect(mapStateToProps, mapActionCreators)(AerodromeStatusBanner);

--- a/src/containers/AerodromeStatusBannerToggleContainer.tsx
+++ b/src/containers/AerodromeStatusBannerToggleContainer.tsx
@@ -1,0 +1,15 @@
+import {connect} from 'react-redux';
+import {setAerodromeStatusBannerEnabled} from '../modules/settings/aerodromeStatusBannerEnabled';
+import AerodromeStatusBannerToggle from '../components/AerodromeStatusBannerToggle/AerodromeStatusBannerToggle';
+import {RootState} from '../modules';
+
+const mapStateToProps = (state: RootState) => ({
+  enabled: state.settings.aerodromeStatusBannerEnabled.enabled,
+  disabled: state.settings.aerodromeStatusBannerEnabled.saving === true,
+});
+
+const mapActionCreators = {
+  setAerodromeStatusBannerEnabled
+};
+
+export default connect(mapStateToProps, mapActionCreators)(AerodromeStatusBannerToggle);

--- a/src/containers/containers.spec.tsx
+++ b/src/containers/containers.spec.tsx
@@ -131,6 +131,8 @@ describe('container mount dispatches', () => {
   let LandingsReportFormContainer: any;
   let AirstatReportFormContainer: any;
   let InvoicesReportFormContainer: any;
+  let AerodromeStatusBannerContainer: any;
+  let AerodromeStatusBannerToggleContainer: any;
 
   beforeAll(() => {
     InvoiceRecipientsListContainer =
@@ -150,6 +152,12 @@ describe('container mount dispatches', () => {
     AirstatReportFormContainer = require('./AirstatReportFormContainer').default;
     InvoicesReportFormContainer = require(
       './InvoicesReportFormContainer'
+    ).default;
+    AerodromeStatusBannerContainer = require(
+      './AerodromeStatusBannerContainer'
+    ).default;
+    AerodromeStatusBannerToggleContainer = require(
+      './AerodromeStatusBannerToggleContainer'
     ).default;
   });
 
@@ -266,6 +274,32 @@ describe('container mount dispatches', () => {
     const inits = store.actions.filter(a => a.type === 'INIT_REPORT');
     expect(inits.length).toBe(1);
     expect(inits[0].payload.name).toBe('invoices');
+  });
+
+  it('AerodromeStatusBannerContainer dispatches WATCH_CURRENT_AERODROME_STATUS exactly once on mount', () => {
+    const store = makeStore({
+      settings: {
+        aerodromeStatus: { current: undefined },
+        aerodromeStatusBannerEnabled: { enabled: false },
+      },
+    });
+    render(wrap(store, <AerodromeStatusBannerContainer />));
+    expect(countOf(store, 'WATCH_CURRENT_AERODROME_STATUS')).toBe(1);
+  });
+
+  it('AerodromeStatusBannerToggleContainer reflects the enabled flag from the store', () => {
+    const store = makeStore({
+      settings: {
+        aerodromeStatusBannerEnabled: { enabled: true, saving: false },
+      },
+    });
+    const { container } = render(
+      wrap(store, <AerodromeStatusBannerToggleContainer />)
+    );
+    expect(
+      (container.querySelector('input[type="checkbox"]') as HTMLInputElement)
+        .checked
+    ).toBe(true);
   });
 
   it('does not re-dispatch init actions when the container re-renders with same props', () => {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -346,7 +346,8 @@
     "restricted": "Eingeschränkt",
     "closed": "Geschlossen",
     "unavailable": "Flugplatzstatus nicht verfügbar",
-    "active": "Aktiv"
+    "active": "Aktiv",
+    "showOnStartPage": "Statusleiste auf der Startseite anzeigen"
   },
   "airstatReport": {
     "includeInternal": "Zusätzliche Informationen inkludieren (nur für internen Gebrauch)",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -346,7 +346,8 @@
     "restricted": "Restricted",
     "closed": "Closed",
     "unavailable": "Aerodrome status unavailable",
-    "active": "Active"
+    "active": "Active",
+    "showOnStartPage": "Show status bar on the start page"
   },
   "airstatReport": {
     "includeInternal": "Include additional information (for internal use only)",

--- a/src/modules/settings/aerodromeStatusBannerEnabled/actions.ts
+++ b/src/modules/settings/aerodromeStatusBannerEnabled/actions.ts
@@ -1,0 +1,40 @@
+export const AERODROME_STATUS_BANNER_ENABLED_LOADED = 'AERODROME_STATUS_BANNER_ENABLED_LOADED' as const;
+export const SET_AERODROME_STATUS_BANNER_ENABLED = 'SET_AERODROME_STATUS_BANNER_ENABLED' as const;
+export const SET_AERODROME_STATUS_BANNER_ENABLED_SAVING = 'SET_AERODROME_STATUS_BANNER_ENABLED_SAVING' as const;
+export const SET_AERODROME_STATUS_BANNER_ENABLED_SUCCESS = 'SET_AERODROME_STATUS_BANNER_ENABLED_SUCCESS' as const;
+
+export type AerodromeStatusBannerEnabledAction =
+  | { type: typeof AERODROME_STATUS_BANNER_ENABLED_LOADED; payload: { enabled: boolean } }
+  | { type: typeof SET_AERODROME_STATUS_BANNER_ENABLED; payload: { enabled: boolean } }
+  | { type: typeof SET_AERODROME_STATUS_BANNER_ENABLED_SAVING }
+  | { type: typeof SET_AERODROME_STATUS_BANNER_ENABLED_SUCCESS };
+
+export function aerodromeStatusBannerEnabledLoaded(enabled: boolean) {
+  return {
+    type: AERODROME_STATUS_BANNER_ENABLED_LOADED,
+    payload: {
+      enabled
+    }
+  };
+}
+
+export function setAerodromeStatusBannerEnabled(enabled: boolean) {
+  return {
+    type: SET_AERODROME_STATUS_BANNER_ENABLED,
+    payload: {
+      enabled,
+    },
+  };
+}
+
+export function setAerodromeStatusBannerEnabledSaving() {
+  return {
+    type: SET_AERODROME_STATUS_BANNER_ENABLED_SAVING,
+  };
+}
+
+export function setAerodromeStatusBannerEnabledSuccess() {
+  return {
+    type: SET_AERODROME_STATUS_BANNER_ENABLED_SUCCESS,
+  };
+}

--- a/src/modules/settings/aerodromeStatusBannerEnabled/index.ts
+++ b/src/modules/settings/aerodromeStatusBannerEnabled/index.ts
@@ -1,0 +1,9 @@
+import { setAerodromeStatusBannerEnabled } from './actions';
+import reducer from './reducer';
+import sagas from './sagas';
+
+export { setAerodromeStatusBannerEnabled };
+
+export { sagas };
+
+export default reducer;

--- a/src/modules/settings/aerodromeStatusBannerEnabled/reducer.spec.ts
+++ b/src/modules/settings/aerodromeStatusBannerEnabled/reducer.spec.ts
@@ -1,0 +1,75 @@
+import reducer from './reducer';
+import * as actions from './actions';
+
+const INITIAL_STATE = {
+  enabled: false,
+  saving: false,
+};
+
+describe('modules', () => {
+  describe('settings', () => {
+    describe('aerodromeStatusBannerEnabled', () => {
+      describe('reducer', () => {
+        it('should handle initial state', () => {
+          expect(
+            reducer(undefined, {} as any)
+          ).toEqual(INITIAL_STATE);
+        });
+
+        describe('AERODROME_STATUS_BANNER_ENABLED_LOADED', () => {
+          it('should set enabled to true', () => {
+            expect(
+              reducer({
+                enabled: false,
+                saving: false,
+              }, actions.aerodromeStatusBannerEnabledLoaded(true))
+            ).toEqual({
+              enabled: true,
+              saving: false,
+            });
+          });
+
+          it('should set enabled to false', () => {
+            expect(
+              reducer({
+                enabled: true,
+                saving: false,
+              }, actions.aerodromeStatusBannerEnabledLoaded(false))
+            ).toEqual({
+              enabled: false,
+              saving: false,
+            });
+          });
+        });
+
+        describe('SET_AERODROME_STATUS_BANNER_ENABLED_SAVING', () => {
+          it('should set saving to true', () => {
+            expect(
+              reducer({
+                enabled: true,
+                saving: false,
+              }, actions.setAerodromeStatusBannerEnabledSaving())
+            ).toEqual({
+              enabled: true,
+              saving: true,
+            });
+          });
+        });
+
+        describe('SET_AERODROME_STATUS_BANNER_ENABLED_SUCCESS', () => {
+          it('should set saving to false', () => {
+            expect(
+              reducer({
+                enabled: true,
+                saving: true,
+              }, actions.setAerodromeStatusBannerEnabledSuccess())
+            ).toEqual({
+              enabled: true,
+              saving: false,
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/modules/settings/aerodromeStatusBannerEnabled/reducer.ts
+++ b/src/modules/settings/aerodromeStatusBannerEnabled/reducer.ts
@@ -1,0 +1,43 @@
+import * as actions from './actions';
+import { AerodromeStatusBannerEnabledAction } from './actions';
+import reducer from '../../../util/reducer';
+
+interface AerodromeStatusBannerEnabledState {
+  enabled: boolean;
+  saving: boolean;
+}
+
+function enabledLoaded(state: AerodromeStatusBannerEnabledState, action: AerodromeStatusBannerEnabledAction & { type: typeof actions.AERODROME_STATUS_BANNER_ENABLED_LOADED }) {
+  return {
+    ...state,
+    enabled: action.payload.enabled
+  }
+}
+
+function saving(state: AerodromeStatusBannerEnabledState) {
+  return {
+    ...state,
+    saving: true,
+  };
+}
+
+function saveSuccess(state: AerodromeStatusBannerEnabledState) {
+  return {
+    ...state,
+    saving: false,
+  };
+}
+
+const ACTION_HANDLERS = {
+  [actions.AERODROME_STATUS_BANNER_ENABLED_LOADED]: enabledLoaded,
+  [actions.SET_AERODROME_STATUS_BANNER_ENABLED_SAVING]: saving,
+  [actions.SET_AERODROME_STATUS_BANNER_ENABLED_SUCCESS]: saveSuccess,
+};
+
+const INITIAL_STATE: AerodromeStatusBannerEnabledState = {
+  enabled: false,
+  saving: false,
+};
+
+export type { AerodromeStatusBannerEnabledState };
+export default reducer<AerodromeStatusBannerEnabledState, AerodromeStatusBannerEnabledAction>(INITIAL_STATE, ACTION_HANDLERS);

--- a/src/modules/settings/aerodromeStatusBannerEnabled/sagas.spec.ts
+++ b/src/modules/settings/aerodromeStatusBannerEnabled/sagas.spec.ts
@@ -1,0 +1,78 @@
+import {call, put} from 'redux-saga/effects';
+import * as actions from './actions';
+import * as sagas from './sagas';
+import firebase from '../../../util/firebase';
+import {onValue, set} from 'firebase/database';
+import FakeFirebaseSnapshot from '../../../../test/FakeFirebaseSnapshot';
+
+jest.mock('../../../util/firebase');
+jest.mock('firebase/database', () => ({
+  onValue: jest.fn(),
+  set: jest.fn(),
+}));
+
+describe('modules', () => {
+  describe('settings', () => {
+    describe('aerodromeStatusBannerEnabled', () => {
+      describe('sagas', () => {
+        beforeEach(() => {
+          jest.clearAllMocks();
+          (firebase as jest.Mock).mockReturnValue({});
+        });
+
+        describe('loadAerodromeStatusBannerEnabled', () => {
+          it('should register onValue listener', () => {
+            const channel = {put: jest.fn()};
+            sagas.loadAerodromeStatusBannerEnabled(channel);
+            expect(onValue).toHaveBeenCalledWith(expect.anything(), expect.any(Function));
+          });
+
+          it('should put aerodromeStatusBannerEnabledLoaded(true) when value is true', () => {
+            const channel = {put: jest.fn()};
+            sagas.loadAerodromeStatusBannerEnabled(channel);
+
+            const callback = (onValue as jest.Mock).mock.calls[0][1];
+            callback(new FakeFirebaseSnapshot('aerodromeStatusBannerEnabled', true));
+
+            expect(channel.put).toHaveBeenCalledWith(actions.aerodromeStatusBannerEnabledLoaded(true));
+          });
+
+          it('should coerce a missing value to false', () => {
+            const channel = {put: jest.fn()};
+            sagas.loadAerodromeStatusBannerEnabled(channel);
+
+            const callback = (onValue as jest.Mock).mock.calls[0][1];
+            callback(new FakeFirebaseSnapshot('aerodromeStatusBannerEnabled', null));
+
+            expect(channel.put).toHaveBeenCalledWith(actions.aerodromeStatusBannerEnabledLoaded(false));
+          });
+        });
+
+        describe('setAerodromeStatusBannerEnabled', () => {
+          it('should dispatch saving, save the value, and dispatch success', () => {
+            const action = actions.setAerodromeStatusBannerEnabled(true);
+            const generator = sagas.setAerodromeStatusBannerEnabled(action);
+
+            expect(generator.next().value).toEqual(put(actions.setAerodromeStatusBannerEnabledSaving()));
+            expect(generator.next().value).toEqual(call(sagas.saveAerodromeStatusBannerEnabled, true));
+            expect(generator.next().value).toEqual(put(actions.setAerodromeStatusBannerEnabledSuccess()));
+            expect(generator.next().done).toEqual(true);
+          });
+        });
+
+        describe('saveAerodromeStatusBannerEnabled', () => {
+          it('calls set with the value', async () => {
+            const mockRef = {};
+            (firebase as jest.Mock).mockReturnValue(mockRef);
+            (set as jest.Mock).mockResolvedValue(undefined);
+
+            await sagas.saveAerodromeStatusBannerEnabled(true);
+
+            expect(firebase).toHaveBeenCalledWith('/settings/aerodromeStatusBannerEnabled');
+            expect(set).toHaveBeenCalledWith(mockRef, true);
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/modules/settings/aerodromeStatusBannerEnabled/sagas.ts
+++ b/src/modules/settings/aerodromeStatusBannerEnabled/sagas.ts
@@ -1,0 +1,30 @@
+import {all, call, fork, put, takeEvery} from 'redux-saga/effects';
+import {onValue, set} from 'firebase/database';
+import * as actions from './actions';
+import createChannel, {monitor} from '../../../util/createChannel';
+import firebase from '../../../util/firebase';
+
+export function loadAerodromeStatusBannerEnabled(channel: any) {
+  onValue(firebase('/settings/aerodromeStatusBannerEnabled'), (snapshot) => {
+    channel.put(actions.aerodromeStatusBannerEnabledLoaded(snapshot.val() === true));
+  });
+}
+
+export function* setAerodromeStatusBannerEnabled(action: any) {
+  yield put(actions.setAerodromeStatusBannerEnabledSaving());
+  yield call(saveAerodromeStatusBannerEnabled, action.payload.enabled);
+  yield put(actions.setAerodromeStatusBannerEnabledSuccess());
+}
+
+export function saveAerodromeStatusBannerEnabled(enabled: boolean) {
+  return set(firebase('/settings/aerodromeStatusBannerEnabled'), enabled);
+}
+
+export default function* sagas() {
+  const channel = createChannel();
+  yield all([
+    fork(monitor, channel),
+    fork(loadAerodromeStatusBannerEnabled, channel),
+    takeEvery(actions.SET_AERODROME_STATUS_BANNER_ENABLED, setAerodromeStatusBannerEnabled),
+  ])
+}

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -2,6 +2,7 @@ import {combineReducers} from 'redux';
 import {all, fork} from 'redux-saga/effects'
 
 import aerodromeStatus, {sagas as aerodromeStatusSagas} from './aerodromeStatus';
+import aerodromeStatusBannerEnabled, {sagas as aerodromeStatusBannerEnabledSagas} from './aerodromeStatusBannerEnabled';
 import aircrafts, {sagas as aircraftsSagas} from './aircrafts';
 import lockDate, {sagas as lockDateSagas} from './lockDate';
 import guestAccessToken, {sagas as guestAccessTokenSagas} from './guestAccessToken';
@@ -13,6 +14,7 @@ import messageRetentionDays, {sagas as messageRetentionDaysSagas} from './messag
 
 const reducer = combineReducers({
   aerodromeStatus,
+  aerodromeStatusBannerEnabled,
   aircrafts,
   lockDate,
   guestAccessToken,
@@ -26,6 +28,7 @@ const reducer = combineReducers({
 export function* sagas() {
   yield all([
     fork(aerodromeStatusSagas),
+    fork(aerodromeStatusBannerEnabledSagas),
     fork(aircraftsSagas),
     fork(lockDateSagas),
     fork(guestAccessTokenSagas),


### PR DESCRIPTION
## Summary

Surfaces the current aerodrome status directly inside the Flightbox app, so pilots see it when they open the app to enter their movements — previously the status was only visible on the admin page and the dedicated fullscreen `/aerodrome-status` page.

- Adds a collapsible **status banner** to the top of the start page showing the current status (open / restricted / closed) and its details. A non-open status is expanded by default; the open state stays collapsed to keep things quiet.
- Reuses the existing real-time `watchCurrentAerodromeStatus` listener — no new read path for the status itself.
- Severity is conveyed by a colored icon + label on a neutral theme-card background (no saturated fill), so it doesn't clash with per-aerodrome logos/themes. `closed` reuses the theme `danger` color.

## Admin control

Not all aerodromes use the status feature, so admins can enable/disable the banner:

- New runtime setting `aerodromeStatusBannerEnabled` (mirrors the `privacyPolicyUrl` pattern), stored at `/settings/aerodromeStatusBannerEnabled`.
- A checkbox on the existing aerodrome-status admin page toggles it.
- **Defaults to off** — aerodromes that don't use the feature are unaffected.
- Adds the matching RTDB security rule: public read (like `/status`), admin-only write, boolean validation.

## Tests

- Banner: gating, async-load default-expand, collapse/toggle, per-severity icons, unknown-status fallback.
- Toggle: checked/unchecked/change/disabled states.
- New settings module: reducer + sagas specs.
- Container wiring added to `containers.spec.tsx` (mount dispatch + state-path reads).
- `npm run typecheck` clean; full suite 2237 tests pass.