### PR TITLE
Remember status banner expand state across visits

### DIFF
--- a/src/components/AerodromeStatusBanner/AerodromeStatusBanner.spec.tsx
+++ b/src/components/AerodromeStatusBanner/AerodromeStatusBanner.spec.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
-import {render, fireEvent} from '@testing-library/react';
+import {fireEvent} from '@testing-library/react';
 import {renderWithTheme} from '../../../test/renderWithTheme';
-import {ThemeProvider} from 'styled-components';
-import {BrowserRouter} from 'react-router-dom';
-
-const theme: any = {colors: {main: '#003863', background: '#fafafa', danger: '#e00f00'}};
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({t: (key: string) => key}),
@@ -27,8 +23,14 @@ jest.mock('../MaterialIcon', () => {
 
 import AerodromeStatusBanner from './AerodromeStatusBanner';
 
+const STORAGE_KEY = 'aerodromeStatusBannerExpanded';
+
 describe('components', () => {
   describe('AerodromeStatusBanner', () => {
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
     it('dispatches watchCurrentAerodromeStatus on mount', () => {
       const watch = jest.fn();
       renderWithTheme(
@@ -62,25 +64,8 @@ describe('components', () => {
       expect(container.firstChild).toBeNull();
     });
 
-    it('auto-expands a non-open status that loads asynchronously after mount', () => {
-      const wrap = (status: any) => (
-        <BrowserRouter>
-          <ThemeProvider theme={theme}>
-            <AerodromeStatusBanner enabled={true} status={status} watchCurrentAerodromeStatus={jest.fn()}/>
-          </ThemeProvider>
-        </BrowserRouter>
-      );
-      // Mounts before the live status arrives (current === undefined).
-      const {rerender, queryByText, getByText} = render(wrap(undefined));
-      expect(queryByText('Runway works')).toBeNull();
-
-      // Status arrives via the real-time listener -> should be expanded by default.
-      rerender(wrap({status: 'closed', details: 'Runway works', timestamp: 1717500000000}));
-      expect(getByText('Runway works')).toBeTruthy();
-    });
-
-    it('expands a non-open status by default, showing details and timestamp', () => {
-      const {getByText} = renderWithTheme(
+    it('is collapsed by default, showing the label but hiding the details', () => {
+      const {getByText, queryByText} = renderWithTheme(
         <AerodromeStatusBanner
           enabled={true}
           status={{status: 'closed', details: 'Runway works', timestamp: 1717500000000}}
@@ -88,36 +73,50 @@ describe('components', () => {
         />
       );
       expect(getByText('label.closed')).toBeTruthy();
-      expect(getByText('Runway works')).toBeTruthy();
-      expect(getByText('formatted:1717500000000')).toBeTruthy();
-      expect(document.querySelector('[data-icon="block"]')).toBeTruthy();
-    });
-
-    it('collapses the open status by default, hiding the details', () => {
-      const {getByText, queryByText} = renderWithTheme(
-        <AerodromeStatusBanner
-          enabled={true}
-          status={{status: 'open', details: 'All good', timestamp: 1717500000000}}
-          watchCurrentAerodromeStatus={jest.fn()}
-        />
-      );
-      expect(getByText('label.open')).toBeTruthy();
-      expect(queryByText('All good')).toBeNull();
+      expect(queryByText('Runway works')).toBeNull();
       expect(document.querySelector('[data-icon="expand_more"]')).toBeTruthy();
     });
 
-    it('toggles the details when the summary is clicked', () => {
+    it('reveals the details and timestamp when the summary is clicked', () => {
       const {getByText, queryByText, getByRole} = renderWithTheme(
         <AerodromeStatusBanner
           enabled={true}
-          status={{status: 'open', details: 'All good', timestamp: 1717500000000}}
+          status={{status: 'closed', details: 'Runway works', timestamp: 1717500000000}}
           watchCurrentAerodromeStatus={jest.fn()}
         />
       );
-      expect(queryByText('All good')).toBeNull();
+      expect(queryByText('Runway works')).toBeNull();
       fireEvent.click(getByRole('button'));
-      expect(getByText('All good')).toBeTruthy();
+      expect(getByText('Runway works')).toBeTruthy();
+      expect(getByText('formatted:1717500000000')).toBeTruthy();
       expect(document.querySelector('[data-icon="expand_less"]')).toBeTruthy();
+    });
+
+    it('restores the persisted expanded state on mount', () => {
+      window.localStorage.setItem(STORAGE_KEY, 'true');
+      const {getByText} = renderWithTheme(
+        <AerodromeStatusBanner
+          enabled={true}
+          status={{status: 'closed', details: 'Runway works', timestamp: 1717500000000}}
+          watchCurrentAerodromeStatus={jest.fn()}
+        />
+      );
+      // Expanded without any interaction because the choice was remembered.
+      expect(getByText('Runway works')).toBeTruthy();
+    });
+
+    it('persists the expand/collapse choice when toggled', () => {
+      const {getByRole} = renderWithTheme(
+        <AerodromeStatusBanner
+          enabled={true}
+          status={{status: 'closed', details: 'Runway works', timestamp: 1717500000000}}
+          watchCurrentAerodromeStatus={jest.fn()}
+        />
+      );
+      fireEvent.click(getByRole('button'));
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true');
+      fireEvent.click(getByRole('button'));
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe('false');
     });
 
     it('does not link out to a separate status page', () => {
@@ -153,7 +152,7 @@ describe('components', () => {
       expect(document.querySelector('[data-icon="info"]')).toBeTruthy();
     });
 
-    it('omits the details element when details is empty', () => {
+    it('shows the open status with its icon', () => {
       const {getByText} = renderWithTheme(
         <AerodromeStatusBanner
           enabled={true}

--- a/src/components/AerodromeStatusBanner/AerodromeStatusBanner.tsx
+++ b/src/components/AerodromeStatusBanner/AerodromeStatusBanner.tsx
@@ -13,6 +13,26 @@ const icons: { [key: string]: string } = {
   closed: 'block',
 };
 
+// The expand/collapse choice is remembered across visits so the banner does not
+// re-expand on its own after a pilot has collapsed it (and vice versa).
+const STORAGE_KEY = 'aerodromeStatusBannerExpanded';
+
+const readStoredExpanded = () => {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch (e) {
+    return false;
+  }
+};
+
+const writeStoredExpanded = (value: boolean) => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(value));
+  } catch (e) {
+    // ignore (e.g. storage disabled in private mode)
+  }
+};
+
 // Severity accents kept deliberately muted and used only on the status icon and
 // label, so the banner adopts the project's neutral card background instead of a
 // saturated fill that would clash with the logo or theme color.
@@ -81,8 +101,10 @@ const AerodromeStatusBanner = (props: any) => {
   const theme = useTheme();
   const {status, enabled, watchCurrentAerodromeStatus} = props;
 
-  // null = follow the status severity; a boolean is the user's explicit choice.
-  const [expandedOverride, setExpandedOverride] = useState<boolean | null>(null);
+  // Collapsed by default; the pilot's choice persists across visits. The status
+  // word and colored icon stay visible while collapsed, so nothing important is
+  // hidden -- expanding just reveals the details and timestamp.
+  const [expanded, setExpanded] = useState(readStoredExpanded);
 
   useEffect(() => {
     watchCurrentAerodromeStatus();
@@ -95,11 +117,13 @@ const AerodromeStatusBanner = (props: any) => {
 
   const accent = accentFor(status.status, theme);
 
-  // Expand by default when the aerodrome is not open, so restrictions and
-  // closures are immediately visible; collapse the reassuring "open" state.
-  // Derived from the current status (which loads asynchronously) so the default
-  // is correct even though the banner mounts before the status arrives.
-  const expanded = expandedOverride !== null ? expandedOverride : status.status !== 'open';
+  const toggle = () => {
+    setExpanded(prev => {
+      const next = !prev;
+      writeStoredExpanded(next);
+      return next;
+    });
+  };
 
   return (
     <Wrapper
@@ -108,7 +132,7 @@ const AerodromeStatusBanner = (props: any) => {
     >
       <Summary
         type="button"
-        onClick={() => setExpandedOverride(!expanded)}
+        onClick={toggle}
         aria-expanded={expanded}
       >
         <StatusIcon icon={icons[status.status] || 'info'} $accent={accent}/>


### PR DESCRIPTION
## Summary

Follow-up to #797. The start-page aerodrome status banner used a status-based default (open → collapsed, restricted/closed → expanded). That felt inconsistent, and worse, it re-expanded on its own every time a pilot reopened Flightbox even after they had collapsed it.

This changes the behavior to:

- **Collapsed by default** — consistent and compact. The status word and colored icon stay visible in the collapsed bar, so nothing important is hidden; expanding only reveals the details and timestamp.
- **Persisted choice** — the pilot's expand/collapse state is stored in `localStorage` (`aerodromeStatusBannerExpanded`) and restored on the next visit, so the banner no longer re-expands by itself.

Removing the status-dependent default also eliminates the async-load edge case (the banner mounts before the live status arrives), since the initial state no longer depends on the status value.

## Tests

- Replaced the severity-based default tests with: collapsed-by-default, reveal-on-click, restore persisted state on mount, and persist-on-toggle.
- `npm run typecheck` clean; full suite 2237 tests pass; `build --project=lszm` succeeds.