### PR TITLE
Make start-page hints panel dismissible

### DIFF
--- a/src/components/StartPage/Header.tsx
+++ b/src/components/StartPage/Header.tsx
@@ -10,6 +10,7 @@ const StyledHeader = styled.header`
   width: 100%;
   top: 0;
   left: 0;
+  z-index: 1;
   background-color: ${props => props.theme.colors.background};
   padding: 10px;
   box-sizing: border-box;

--- a/src/components/StartPage/Hints.spec.tsx
+++ b/src/components/StartPage/Hints.spec.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {renderWithTheme, fireEvent} from '../../../test/renderWithTheme';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+}));
+
+jest.mock('../MaterialIcon', () => {
+  const React = require('react');
+  return function MockMaterialIcon({icon}: {icon: string}) {
+    return <span data-testid="material-icon" data-icon={icon}/>;
+  };
+});
+
+import Hints from './Hints';
+
+const STORAGE_KEY = 'startPageHintsDismissed';
+
+describe('components', () => {
+  describe('StartPage', () => {
+    describe('Hints', () => {
+      beforeEach(() => {
+        window.localStorage.clear();
+      });
+
+      it('renders the hint list for a regular user', () => {
+        const {getByText} = renderWithTheme(<Hints/>);
+        expect(getByText('hints.departureBeforeStart_text')).toBeTruthy();
+        expect(getByText('hints.arrivalAfterLanding_text')).toBeTruthy();
+      });
+
+      it('shows the dismiss button for a regular user', () => {
+        const {container} = renderWithTheme(<Hints/>);
+        expect(container.querySelector('[data-icon="close"]')).toBeTruthy();
+      });
+
+      it('does not show the dismiss button for a guest', () => {
+        const {container} = renderWithTheme(<Hints guest={true}/>);
+        expect(container.querySelector('[data-icon="close"]')).toBeNull();
+        expect(container.querySelector('ul')).toBeTruthy();
+      });
+
+      it('does not show the dismiss button for a kiosk', () => {
+        const {container} = renderWithTheme(<Hints kiosk={true}/>);
+        expect(container.querySelector('[data-icon="close"]')).toBeNull();
+        expect(container.querySelector('ul')).toBeTruthy();
+      });
+
+      it('does not show the dismiss button when hintsDismissable is false', () => {
+        const {container} = renderWithTheme(<Hints hintsDismissable={false}/>);
+        expect(container.querySelector('[data-icon="close"]')).toBeNull();
+        expect(container.querySelector('ul')).toBeTruthy();
+      });
+
+      it('hides the panel and persists the choice when dismissed', () => {
+        const {container, getByText, queryByText, getByLabelText} = renderWithTheme(<Hints/>);
+        fireEvent.click(getByLabelText('hints.dismiss'));
+        expect(queryByText('hints.departureBeforeStart_text')).toBeNull();
+        expect(getByText('hints.show')).toBeTruthy();
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true');
+        expect(container.querySelector('[data-icon="help_outline"]')).toBeTruthy();
+      });
+
+      it('restores the persisted dismissed state on mount', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'true');
+        const {getByText, queryByText} = renderWithTheme(<Hints/>);
+        expect(queryByText('hints.departureBeforeStart_text')).toBeNull();
+        expect(getByText('hints.show')).toBeTruthy();
+      });
+
+      it('brings the panel back and clears the flag when show is clicked', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'true');
+        const {getByText} = renderWithTheme(<Hints/>);
+        fireEvent.click(getByText('hints.show'));
+        expect(getByText('hints.departureBeforeStart_text')).toBeTruthy();
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('false');
+      });
+
+      it('ignores a persisted dismissed flag for guest sessions', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'true');
+        const {getByText, container} = renderWithTheme(<Hints guest={true}/>);
+        expect(getByText('hints.departureBeforeStart_text')).toBeTruthy();
+        expect(container.querySelector('[data-icon="close"]')).toBeNull();
+      });
+
+      it('ignores a persisted dismissed flag when hintsDismissable is false', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'true');
+        const {getByText, container} = renderWithTheme(<Hints hintsDismissable={false}/>);
+        expect(getByText('hints.departureBeforeStart_text')).toBeTruthy();
+        expect(container.querySelector('[data-icon="close"]')).toBeNull();
+      });
+    });
+  });
+});

--- a/src/components/StartPage/Hints.tsx
+++ b/src/components/StartPage/Hints.tsx
@@ -1,10 +1,32 @@
-import React from 'react';
+import React, {useState} from 'react';
 import styled from 'styled-components';
 import {Link} from 'react-router-dom';
 import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next';
+import MaterialIcon from '../MaterialIcon';
+
+// The dismiss choice is remembered across visits so the hints do not reappear
+// on their own once a pilot who knows the app has hidden them.
+const STORAGE_KEY = 'startPageHintsDismissed';
+
+const readStoredDismissed = () => {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch (e) {
+    return false;
+  }
+};
+
+const writeStoredDismissed = (value: boolean) => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(value));
+  } catch (e) {
+    // ignore (e.g. storage disabled in private mode)
+  }
+};
 
 const Wrapper = styled.div`
+  position: relative;
   border-radius: 10px;
   background-color: ${props => props.theme.colors.background};
   margin: 1em auto;
@@ -39,10 +61,80 @@ const StyledLink = styled(Link)`
   text-decoration: underline;
 `;
 
-const Hints = ({ guest, kiosk }: any) => {
+const CloseButton = styled.button`
+  position: absolute;
+  top: 0.5em;
+  right: 0.5em;
+  display: flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.6;
+
+  &:hover {
+    opacity: 1;
+  }
+`;
+
+const ShowHintsButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  margin: 1em auto;
+  padding: 0;
+  border: none;
+  background: none;
+  /* Muted grey matching the footer font, so restoring the hints stays a quiet,
+     unobtrusive affordance rather than a prominent call to action. */
+  color: #666;
+  font: inherit;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+const Hints = ({ guest, kiosk, hintsDismissable }: any) => {
   const { t } = useTranslation();
+
+  // Guest and kiosk sessions run on shared/public devices where every visitor
+  // is effectively a first-time user, so onboarding must always stay visible.
+  // A per-login flag (hintsDismissable === false) opts specific accounts (e.g.
+  // the lspv terminal user) out of dismissing too.
+  const dismissable = guest !== true && kiosk !== true && hintsDismissable !== false;
+
+  const [dismissed, setDismissed] = useState(() => dismissable && readStoredDismissed());
+
+  const dismiss = () => {
+    writeStoredDismissed(true);
+    setDismissed(true);
+  };
+
+  const show = () => {
+    writeStoredDismissed(false);
+    setDismissed(false);
+  };
+
+  if (dismissable && dismissed) {
+    return (
+      <ShowHintsButton type="button" onClick={show} aria-label={t('hints.show')}>
+        <MaterialIcon icon="help_outline" size={20}/>
+        {t('hints.show')}
+      </ShowHintsButton>
+    );
+  }
+
   return (
     <Wrapper>
+      {dismissable && (
+        <CloseButton type="button" onClick={dismiss} aria-label={t('hints.dismiss')}>
+          <MaterialIcon icon="close" size={20}/>
+        </CloseButton>
+      )}
       <ul>
         <Hint>{t('hints.departureBeforeStart_pre')} <Strong>{t('hints.departureBeforeStart_text')}</Strong>.</Hint>
         <Hint>{t('hints.arrivalAfterLanding_pre')} <Strong>{t('hints.arrivalAfterLanding_text')}</Strong>.</Hint>
@@ -55,7 +147,8 @@ const Hints = ({ guest, kiosk }: any) => {
 
 Hints.propTypes = {
   guest: PropTypes.bool,
-  kiosk: PropTypes.bool
+  kiosk: PropTypes.bool,
+  hintsDismissable: PropTypes.bool
 }
 
 export default Hints;

--- a/src/components/StartPage/Main.tsx
+++ b/src/components/StartPage/Main.tsx
@@ -22,7 +22,7 @@ const Promotions = styled.div`
 const Main = ({ auth }: any) => (
   <Wrapper>
     <AerodromeStatusBanner/>
-    <Hints guest={auth.data.guest} kiosk={auth.data.kiosk}/>
+    <Hints guest={auth.data.guest} kiosk={auth.data.kiosk} hintsDismissable={auth.data.hintsDismissable}/>
     <EntryPoints admin={auth.data.admin} guest={auth.data.guest} kiosk={auth.data.kiosk}/>
     <Promotions>
       <PostLoginPasskeyPrompt/>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -68,7 +68,9 @@
     "arrivalAfterLanding_pre": "Bitte erfassen Sie Ihre",
     "associatedMovement_pre": "Möchten Sie eine Ankunft für einen bereits erfassten Abflug erfassen (oder umgekehrt), nutzen Sie den Link",
     "associatedMovement_mid": "(bzw.",
-    "associatedMovement_post": ") bei der bereits"
+    "associatedMovement_post": ") bei der bereits",
+    "dismiss": "Hinweise ausblenden",
+    "show": "Hinweise anzeigen"
   },
   "admin": {
     "title": "Administration",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -68,7 +68,9 @@
     "arrivalAfterLanding_pre": "Please record your",
     "associatedMovement_pre": "To record an arrival for an already recorded departure (or vice versa), use the link",
     "associatedMovement_mid": "(or",
-    "associatedMovement_post": ") on the already"
+    "associatedMovement_post": ") on the already",
+    "dismiss": "Hide hints",
+    "show": "Show hints"
   },
   "admin": {
     "title": "Administration",

--- a/src/modules/auth/sagas.spec.ts
+++ b/src/modules/auth/sagas.spec.ts
@@ -132,11 +132,43 @@ describe('modules', () => {
             admin: true,
             allMovements: false,
             links: false,
+            hintsDismissable: true,
             expiration: 1000,
             token: 'validtoken',
             uid: 'myadminuser',
             name: 'Hans Muster',
             email: 'admin@example.com',
+            guest: false,
+            kiosk: false,
+            local: false
+          })));
+
+          expectDoneWithoutReturn(generator);
+        });
+
+        it('should put firebaseAuthenticationEvent with hintsDismissable false when login disables it', () => {
+          const generator = sagas.doListenFirebaseAuthentication(actions.firebaseAuthentication({
+            uid: 'terminaluser',
+            expires: 1,
+            token: 'validtoken',
+            email: 'terminal@example.com'
+          }));
+
+          expect(generator.next().value).toEqual(call(sagas.getLoginData, 'terminaluser'));
+          expect(generator.next({
+            links: false,
+            hintsDismissable: false
+          }).value).toEqual(call(sagas.getName, 'terminaluser'));
+          expect(generator.next('Hans Muster').value).toEqual(put(actions.firebaseAuthenticationEvent({
+            admin: false,
+            allMovements: false,
+            links: false,
+            hintsDismissable: false,
+            expiration: 1000,
+            token: 'validtoken',
+            uid: 'terminaluser',
+            name: 'Hans Muster',
+            email: 'terminal@example.com',
             guest: false,
             kiosk: false,
             local: false
@@ -161,6 +193,7 @@ describe('modules', () => {
             admin: false,
             allMovements: false,
             links: true,
+            hintsDismissable: true,
             expiration: 1000,
             token: 'validtoken',
             uid: 'testuser',
@@ -191,6 +224,7 @@ describe('modules', () => {
             admin: false,
             allMovements: true,
             links: true,
+            hintsDismissable: true,
             expiration: 1000,
             token: 'validtoken',
             uid: 'vieweruser',

--- a/src/modules/auth/sagas.ts
+++ b/src/modules/auth/sagas.ts
@@ -238,6 +238,7 @@ export function* doListenFirebaseAuthentication(action: any) {
       kiosk,
       local,
       links: !loginData || loginData.links !== false,
+      hintsDismissable: !loginData || loginData.hintsDismissable !== false,
       name: yield call(getName, uid),
       email
     }


### PR DESCRIPTION
## Summary
- Adds a close button to the start-page hints panel so pilots who know the app can hide it; the choice is persisted in `localStorage` and a quiet, footer-grey "Show hints" link restores it.
- Guest and kiosk sessions keep the hints always visible (shared/public devices). A new per-login `hintsDismissable` flag — read from `/logins`, mirroring the existing `links` flag — lets specific accounts (e.g. the lspv terminal user) opt out of dismissing too; set `hintsDismissable: false` on that login to force the panel non-dismissible.
- Gives the fixed start-page header a `z-index` so the now-positioned hints panel no longer paints over it on scroll.

## Testing
- `npm test` — full suite green (new `Hints.spec.tsx`, updated auth saga spec)
- `npm run typecheck` — clean

## Notes
- The Firebase-side data edit (`hintsDismissable: false` on the lspv terminal login) is done in the console; the code only honors the flag.