### PR TITLE
Self-heal shared Cypress DB before each spec run

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,6 +29,35 @@ Cypress.Commands.add('logout', () => {
   })
 });
 
+// Removes every child under `path` individually. The security rules grant write
+// access at `/departures/$id` (not at the `/departures` parent), so the whole
+// collection cannot be cleared in a single remove() — each movement must go on
+// its own. Must run while authenticated as admin and after lockDate is cleared.
+const removeAllChildren = (win, path) =>
+  win.firebase.getRef(path).once('value').then(snapshot => {
+    const val = snapshot.val();
+    if (!val) {
+      return undefined;
+    }
+    return Promise.all(
+      Object.keys(val).map(key => win.firebase.getRef(`${path}/${key}`).remove())
+    );
+  });
+
+// Resets the shared cypress-testing database to a clean movement state so an
+// interrupted run cannot wedge later runs. A leftover /settings/lockDate blocks
+// both writing AND deleting movements (see firebase-rules-template.json), which
+// is why it is cleared first — otherwise the movement deletes below would be
+// denied. Deleting the movements triggers onDelete, which clears the matching
+// /movementAssociations records (that path is .write:false for clients).
+Cypress.Commands.add('resetMovementsTestData', () => {
+  cy.window().then(win =>
+    win.firebase.getRef('/settings/lockDate').remove()
+      .then(() => removeAllChildren(win, '/departures'))
+      .then(() => removeAllChildren(win, '/arrivals'))
+  );
+});
+
 Cypress.Commands.add('waitForAssociation', (movementType, movementKey, expectedType) => {
   const path = `/movementAssociations/${movementType}s/${movementKey}`;
   const attempt = (retries) => {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -22,5 +22,18 @@ Cypress.on('window:before:load', (win) => {
   win.localStorage.setItem('flightbox_language', 'de');
 });
 
+// The Cypress suite runs against a shared, persistent Firebase project, so an
+// interrupted run can leave a lock date and/or stray movements behind. A
+// leftover lockDate blocks both writing and deleting movements, which wedges
+// every subsequent run (PERMISSION_DENIED on movement writes, wrong-key
+// associations from stale data). Reset to a clean movement state before each
+// spec so the suite is self-healing and no longer needs manual DB cleanup.
+before(() => {
+  cy.visit('#/');
+  cy.loginAdmin();
+  cy.resetMovementsTestData();
+  cy.logout();
+});
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
## Problem
The E2E suite started failing in CI (`associated_movements_spec`, cascading into `create_arrival_spec` and intermittently `lock_date_spec`) with `PERMISSION_DENIED` on movement writes and wrong-key association assertions — despite **no change to the specs or the association Cloud Function** (last touched 2026-03-02 and 2026-05-12 respectively).

## Root cause
The Cypress suite runs against a **shared, persistent** Firebase project (`cypress-testing`), not an ephemeral emulator. The `/departures` and `/arrivals` write rules (`firebase-rules-template.json`) allow writes only when `!settings/lockDate.exists()` *or* the movement is more than 24h past the lock date — and the **same rule gates deletes**.

An interrupted run left a `/settings/lockDate` in the shared DB. From then on every run was wedged:
- A clean DB can never produce `PERMISSION_DENIED` (no lock date ⇒ writes allowed), so the errors prove leftover lock state.
- With the lock present, the suite could neither create nor **delete** today's movements, so stray movements accumulated → homebase departures linked to the wrong arrival (push-ID mismatches) and `create_arrival`'s "exactly 1 arrival" assertion saw 2.

## Fix
A global `before` hook (`cypress/support/e2e.js`) resets the shared DB to a clean movement state before each spec, via a new `cy.resetMovementsTestData()` command:
1. Clear `/settings/lockDate` **first** (so the movement deletes below are permitted).
2. Remove each leftover `/departures` and `/arrivals` child individually (the rule grants write at `/<col>/$id`, not the parent).
3. `onDelete` triggers clean the matching `/movementAssociations` records.

The suite is now self-healing: it recovers from a leftover lock date / stray movements without manual DB cleanup. Because it clears the lock date first, **this branch's own CI run repairs the currently-dirty shared DB** — green CI here is both the fix and the verification.

## Notes
- Merge this before the hints PR (#799), whose CI is red only due to this shared-DB issue.