### PR TITLE
Fix email-login hint placement on guest login form

### DIFF
--- a/src/components/LoginPage/EmailLoginForm.tsx
+++ b/src/components/LoginPage/EmailLoginForm.tsx
@@ -128,6 +128,9 @@ const EmailLoginForm = props => {
           )}
         </StyledForm>
       )}
+      {!guestOnly && queryToken && (
+        <StyledHint>{t('login.hintEmailLogin')}</StyledHint>
+      )}
       {!guestOnly && passkeysEnabled && isPasskeySupported() && (
         <>
           <StyledOrContainer><StyledOrText>{t('login.or')}</StyledOrText></StyledOrContainer>
@@ -144,7 +147,6 @@ const EmailLoginForm = props => {
           ? <GuestTokenLogin queryToken={queryToken}/>
           : (
             <>
-              <StyledHint>{t('login.hintEmailLogin')}</StyledHint>
               <StyledOrContainer><StyledOrText>{t('login.or')}</StyledOrText></StyledOrContainer>
               <GuestTokenLogin queryToken={queryToken}/>
               <StyledHint>{t('login.hintGuestLogin')}</StyledHint>


### PR DESCRIPTION
## Problem

On the guest-login form, the email-login hint (_"If you log in with your
email address, you can subsequently view and correct your recorded
movements"_) was bundled into the guest-token block, which renders after
the passkey block. So when passkeys are enabled, that hint ended up
stranded directly beneath the **SIGN IN WITH PASSKEY** button — detached
from the email form it actually describes. The result looked confusing,
with three login options and scattered help texts that didn't line up.

Without passkeys the hint happened to sit right under the email form, so
it read correctly.

## Fix

Move `hintEmailLogin` out of the guest block so it always renders
directly under the email form (same `!guestOnly && queryToken` gating as
before). Each login method now keeps its own hint regardless of whether
the passkey option is present:

- Email + LOG IN → _email hint_
- "or" → SIGN IN WITH PASSKEY _(only when passkeys enabled)_
- "or" → LOG IN AS GUEST → _guest hint_

## Verification

- `npm run typecheck` passes
- Rendered the form in a browser with passkeys enabled and a guest token
  present; confirmed the email hint now appears under the email field and
  the section order reads cleanly