### PR TITLE
Constrain card-payment writes to creation and cancellation

### DIFF
--- a/firebase-rules-template.json
+++ b/firebase-rules-template.json
@@ -405,7 +405,7 @@
     "card-payments": {
       "$card_payment_id": {
         ".read": "auth !== null",
-        ".write": "auth !== null && newData.exists()",
+        ".write": "auth !== null && newData.exists() && (root.child('admins/' + auth.uid).exists() || (!data.exists() && newData.child('status').val() === 'pending') || (data.exists() && data.child('status').val() === 'pending' && newData.child('status').val() === 'cancelled'))",
         ".validate": "newData.hasChildren(['amount', 'currency', 'arrivalReference', 'refNr', 'timestamp', 'status'])",
         "currency": {
           ".validate": "newData.isString() && newData.val().length > 0"

--- a/functions/updateArrivalPaymentStatus.js
+++ b/functions/updateArrivalPaymentStatus.js
@@ -25,6 +25,7 @@ const handleUpdate = async (change) => {
     logger.info(
       `Unable to set arrival payment status for card-payment ${cardPaymentKey}, because arrivalReference is missing`
     );
+    return
   }
 
   try {
@@ -34,6 +35,13 @@ const handleUpdate = async (change) => {
       .once('value');
 
     const arrivalValues = arrivalSnapshot.val()
+
+    if (!arrivalValues) {
+      logger.info(
+        `Unable to set arrival payment status for card-payment ${cardPaymentKey}, because arrival ${afterValue.arrivalReference} does not exist`
+      );
+      return
+    }
 
     if (arrivalValues.paymentMethod && arrivalValues.paymentMethod.status === 'pending') {
       logger.info(

--- a/functions/updateArrivalPaymentStatus.spec.js
+++ b/functions/updateArrivalPaymentStatus.spec.js
@@ -72,11 +72,19 @@ describe('functions', () => {
       expect(mockAdmin.database).not.toHaveBeenCalled();
     });
 
-    it('logs info when arrivalReference is missing', async () => {
+    it('logs info and returns early when arrivalReference is missing', async () => {
+      const change = makeChange(
+        { status: 'pending' },
+        { status: 'success' }  // no arrivalReference
+      );
+      await mockCapturedHandler({ data: change });
+      expect(mockLogger.info).toHaveBeenCalled();
+      expect(mockAdmin.database).not.toHaveBeenCalled();
+    });
+
+    it('logs info and returns early when the arrival does not exist', async () => {
       const mockRef = {
-        once: jest.fn().mockResolvedValue({
-          val: () => ({ paymentMethod: { status: 'pending' } })
-        }),
+        once: jest.fn().mockResolvedValue({ val: () => null }),
         update: jest.fn()
       };
       mockAdmin.database.mockReturnValue({
@@ -87,10 +95,11 @@ describe('functions', () => {
 
       const change = makeChange(
         { status: 'pending' },
-        { status: 'success' }  // no arrivalReference
+        { status: 'success', arrivalReference: 'gone' }
       );
       await mockCapturedHandler({ data: change });
       expect(mockLogger.info).toHaveBeenCalled();
+      expect(mockRef.update).not.toHaveBeenCalled();
     });
 
     it('updates arrival payment status when status changes to success', async () => {


### PR DESCRIPTION
Client writes are limited to creating pending payments and cancelling them; the success status is set by the payment service. The arrival payment trigger returns early when the reference is missing or the arrival no longer exists.