### PR TITLE
Deploy the test email-token function only to cypress-testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log
 firebase-debug.log
 .runtimeconfig.json
 functions/privacy-config.generated.js
+functions/test-config.generated.js

--- a/cypress/CYPRESS_TESTING_SETUP.md
+++ b/cypress/CYPRESS_TESTING_SETUP.md
@@ -17,16 +17,26 @@ Auth endpoint: `https://europe-west1-cypress-testing.cloudfunctions.net/auth`
 ## Email user login (for `loginEmail` command)
 
 The `cy.loginEmail()` command authenticates as `cypress-pilot@example.com` via the
-`createTestEmailToken` Cloud Function. This function is gated behind a config flag
-that must be enabled on the `cypress-testing` project:
+`createTestEmailToken` Cloud Function. Because it mints a custom token for a fixed
+user, it is deployed **only** to the `cypress-testing` project, gated twice:
+
+1. **Deploy gate:** `functions/index.js` exports it only when
+   `functions/test-config.generated.js` exists and is truthy. That file is
+   gitignored and is written by the `deploy:cypress` script, so the function is
+   never deployed to any other environment.
+2. **Runtime gate:** the function returns 403 unless `TESTING_ENABLED=true` is
+   set in its environment. This must be present in `functions/.env.cypress-testing`.
+
+Deploy it with:
 
 ```bash
-firebase functions:config:set testing.enabled=true --project cypress-testing
-firebase deploy --only functions --project cypress-testing
+cd functions && npm run deploy:cypress
 ```
 
-The function always creates a token for the hardcoded email `cypress-pilot@example.com`
-and returns 403 on any project where `testing.enabled` is not set.
+This writes `test-config.generated.js` and runs
+`firebase deploy --only functions --project cypress-testing`. Make sure
+`functions/.env.cypress-testing` contains `TESTING_ENABLED=true` first, or the
+deployed function will return 403.
 
 ## Aerodrome settings (already in place)
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -18,7 +18,6 @@ const { generateSignInLink } = require('./auth/generateSignInLink');
 const { generateSignInCode } = require('./auth/generateSignInCode');
 const { verifySignInCode } = require('./auth/verifySignInCode');
 const { cleanupExpiredSignInCodes } = require('./auth/cleanupExpiredSignInCodes');
-const { createTestEmailToken } = require('./auth/createTestEmailToken');
 const { generateWebauthnRegistrationOptions } = require('./auth/generateRegistrationOptions');
 const { verifyWebauthnRegistration } = require('./auth/verifyRegistration');
 const { generateWebauthnAuthenticationOptions } = require('./auth/generateAuthenticationOptions');
@@ -37,7 +36,6 @@ exports.generateSignInLink = generateSignInLink;
 exports.generateSignInCode = generateSignInCode;
 exports.verifySignInCode = verifySignInCode;
 exports.cleanupExpiredSignInCodes = cleanupExpiredSignInCodes;
-exports.createTestEmailToken = createTestEmailToken;
 exports.generateWebauthnRegistrationOptions = generateWebauthnRegistrationOptions;
 exports.verifyWebauthnRegistration = verifyWebauthnRegistration;
 exports.generateWebauthnAuthenticationOptions = generateWebauthnAuthenticationOptions;
@@ -79,4 +77,21 @@ if (privacyFunctionsEnabled) {
   const { scheduledCleanupMessages } = require('./cleanupMessages');
   exports.scheduledAnonymizeMovements = scheduledAnonymizeMovements;
   exports.scheduledCleanupMessages = scheduledCleanupMessages;
+}
+
+// The test email-token endpoint mints a custom token for a fixed test
+// user, so it must only ever be deployed to the cypress-testing project.
+// The generated flag is read at module load (during deploy source
+// analysis), unlike process.env which is applied only at runtime; see
+// functions/package.json `deploy:cypress`.
+let testFunctionsEnabled = false;
+try {
+  testFunctionsEnabled = require('./test-config.generated.js');
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') throw e;
+}
+
+if (testFunctionsEnabled) {
+  const { createTestEmailToken } = require('./auth/createTestEmailToken');
+  exports.createTestEmailToken = createTestEmailToken;
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,6 +25,7 @@
     "shell": "firebase functions:config:get > .runtimeconfig.json && firebase experimental:functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
+    "deploy:cypress": "echo 'module.exports = true;' > test-config.generated.js && firebase deploy --only functions --project cypress-testing",
     "logs": "firebase functions:log"
   }
 }


### PR DESCRIPTION
Export createTestEmailToken only when a generated flag file is present, written by the deploy:cypress script, so it is not deployed to other environments. Documents the cypress-testing deploy step.