### PR TITLE
Scope movement reads to their owner on personal-login projects

### DIFF
--- a/firebase-rules-template.json
+++ b/firebase-rules-template.json
@@ -1,7 +1,7 @@
 {
   "rules": {
     "departures": {
-      ".read": "auth !== null",
+      ".read": "{movementListRead}",
       ".indexOn": [
         "dateTime",
         "negativeTimestamp",
@@ -9,6 +9,7 @@
         "createdBy_orderKey"
       ],
       "$departure_id": {
+        ".read": "{movementItemRead}",
         ".write": "auth !== null && (!root.child('settings/lockDate').exists() || (!data.exists() && newData.exists() && newData.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24) || (data.exists() && !newData.exists() && data.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24) || (data.exists() && newData.exists() && data.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24 && newData.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24)){movementOwnership}",
         ".validate": "newData.hasChildren(['aircraftType', 'dateTime', 'departureRoute', 'duration', 'email', 'firstname', 'flightType', 'immatriculation', 'lastname', 'location', 'mtow', 'aircraftCategory', 'negativeTimestamp'])",
         "aircraftType": {
@@ -101,7 +102,7 @@
       }
     },
     "arrivals": {
-      ".read": "auth !== null",
+      ".read": "{movementListRead}",
       ".indexOn": [
         "dateTime",
         "negativeTimestamp",
@@ -109,6 +110,7 @@
         "createdBy_orderKey"
       ],
       "$arrival_id": {
+        ".read": "{movementItemRead}",
         ".write": "auth !== null && (!root.child('settings/lockDate').exists() || (!data.exists() && newData.exists() && newData.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24) || (data.exists() && !newData.exists() && data.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24) || (data.exists() && newData.exists() && data.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24 && newData.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24)){movementOwnership}",
         ".validate": "newData.hasChildren(['aircraftType', 'arrivalRoute', 'dateTime', 'email', 'firstname', 'flightType', 'immatriculation', 'landingCount', 'lastname', 'location', 'mtow', 'aircraftCategory', 'negativeTimestamp'])",
         "aircraftType": {

--- a/src/modules/movements/actions.ts
+++ b/src/modules/movements/actions.ts
@@ -7,6 +7,7 @@ export const MOVEMENT_CHANGED = 'MOVEMENT_CHANGED' as const;
 export const MOVEMENT_DELETED = 'MOVEMENT_DELETED' as const;
 export const LOAD_MOVEMENT = 'LOAD_MOVEMENT' as const;
 export const ADD_MOVEMENT_BY_KEY = 'ADD_MOVEMENT_BY_KEY' as const;
+export const MOVEMENT_BY_KEY_UNAVAILABLE = 'MOVEMENT_BY_KEY_UNAVAILABLE' as const;
 export const CLEAR_MOVEMENTS_BY_KEY = 'CLEAR_MOVEMENTS_BY_KEY' as const;
 export const DELETE_MOVEMENT = 'DELETE_MOVEMENT' as const;
 export const INIT_NEW_MOVEMENT = 'INIT_NEW_MOVEMENT' as const;
@@ -32,6 +33,7 @@ export type MovementsAction =
   | { type: typeof MOVEMENT_DELETED; payload: { snapshot: unknown; movementType: string } }
   | { type: typeof LOAD_MOVEMENT; payload: { key: string; type: string } }
   | { type: typeof ADD_MOVEMENT_BY_KEY; payload: { movement: unknown } }
+  | { type: typeof MOVEMENT_BY_KEY_UNAVAILABLE; payload: { key: string } }
   | { type: typeof CLEAR_MOVEMENTS_BY_KEY }
   | { type: typeof DELETE_MOVEMENT; payload: { movementType: string; key: string; successAction: () => unknown } }
   | { type: typeof INIT_NEW_MOVEMENT; payload: { movementType: string } }
@@ -122,6 +124,19 @@ export function addMovementByKey(movement: unknown) {
     type: ADD_MOVEMENT_BY_KEY,
     payload: {
       movement
+    }
+  };
+}
+
+// Marks a by-key movement as unavailable (not found, or not readable because it
+// belongs to another pilot — e.g. an associated return flight on a shared
+// aircraft). Resolves the associated-movement view to its "not found" state
+// instead of leaving it spinning.
+export function movementByKeyUnavailable(key: string) {
+  return {
+    type: MOVEMENT_BY_KEY_UNAVAILABLE,
+    payload: {
+      key
     }
   };
 }

--- a/src/modules/movements/reducer.spec.ts
+++ b/src/modules/movements/reducer.spec.ts
@@ -85,6 +85,17 @@ describe('modules', () => {
         });
       });
 
+      describe('movementByKeyUnavailable', () => {
+        it('should set the by-key entry to null so the view stops loading', () => {
+          const state = { byKey: { existing: { key: 'existing' } } };
+
+          const newState = reducer(state as any, actions.movementByKeyUnavailable('foreign-key'));
+
+          expect(newState.byKey['foreign-key']).toBeNull();
+          expect(newState.byKey['existing']).toEqual({ key: 'existing' });
+        });
+      });
+
       describe('setLoading', () => {
         it('should set loading to true and loadingFailed to false', () => {
           const state = {

--- a/src/modules/movements/reducer.ts
+++ b/src/modules/movements/reducer.ts
@@ -58,6 +58,14 @@ export const addMovementByKey = (state: MovementsState, action: any) => ({
   }
 });
 
+export const movementByKeyUnavailable = (state: MovementsState, action: any) => ({
+  ...state,
+  byKey: {
+    ...state.byKey,
+    [action.payload.key]: null
+  }
+});
+
 export const clearMovementsByKey = (state: MovementsState) => ({
   ...state,
   byKey: {}
@@ -85,6 +93,7 @@ const ACTION_HANDLERS: Record<string, (state: MovementsState, action: any) => Mo
   [actions.LOAD_MOVEMENTS_FAILURE]: setLoadingFailure,
   [actions.SET_MOVEMENTS_FILTER]: setFilter,
   [actions.ADD_MOVEMENT_BY_KEY]: addMovementByKey,
+  [actions.MOVEMENT_BY_KEY_UNAVAILABLE]: movementByKeyUnavailable,
   [actions.CLEAR_MOVEMENTS_BY_KEY]: clearMovementsByKey,
   [actions.SET_ASSOCIATED_MOVEMENT]: setAssociatedMovement,
   [actions.CLEAR_ASSOCIATED_MOVEMENTS]: clearAssociatedMovements,

--- a/src/modules/movements/remote.spec.ts
+++ b/src/modules/movements/remote.spec.ts
@@ -16,6 +16,7 @@ jest.mock('firebase/database', () => ({
 import firebase from '../../util/firebase';
 import {get, child, query, orderByChild, startAt, limitToFirst, endAt, onValue, remove, update, push} from 'firebase/database';
 import {loadLimited, loadByKey, removeMovement, saveMovement, addMovementAssociationListener, removeMovementAssociationListener} from './remote';
+import {toOrderKey} from './pagination';
 
 describe('modules', () => {
   describe('movements/remote', () => {
@@ -58,6 +59,19 @@ describe('modules', () => {
       it('uses createdBy ordering when provided', async () => {
         await loadLimited('/departures', null, 5, null, 'user123');
         expect(orderByChild).toHaveBeenCalledWith('createdBy_orderKey');
+      });
+
+      it('bounds createdBy queries to the user prefix (start, end and limit)', async () => {
+        await loadLimited('/departures', null, 5, null, 'user123');
+        expect(startAt).toHaveBeenCalledWith('user123_');
+        expect(endAt).toHaveBeenCalledWith('user123_');
+        expect(limitToFirst).toHaveBeenCalledWith(5);
+      });
+
+      it('aligns numeric createdBy start/end bounds to the order key', async () => {
+        await loadLimited('/departures', -100, null, -50, 'user123');
+        expect(startAt).toHaveBeenCalledWith(toOrderKey('user123', -100));
+        expect(endAt).toHaveBeenCalledWith(toOrderKey('user123', -50));
       });
     });
 

--- a/src/modules/movements/remote.ts
+++ b/src/modules/movements/remote.ts
@@ -7,18 +7,34 @@ import {toOrderKey} from './pagination'
 
 const associationListeners = new Map<string, () => void>();
 
+// High code point used as the inclusive upper bound of a createdBy prefix.
+const PREFIX_END = '\uf8ff'
+
 export function loadLimited(path: string, start: any, limit: number | null | undefined, endAt: any, createdBy?: string) {
-  const startAtParam = createdBy ? `${createdBy}_${typeof start === 'number' ? start : ''}`: start
-  const endAtParam = createdBy && endAt ? toOrderKey(createdBy, endAt) : createdBy ? createdBy : endAt
+  if (createdBy) {
+    // Non-admin reads are bounded to the caller's own createdBy_orderKey prefix
+    // so the query satisfies the read rules and cannot return other pilots'
+    // rows. Both bounds are aligned to the orderKey format via toOrderKey.
+    const startAtParam = typeof start === 'number' ? toOrderKey(createdBy, start) : `${createdBy}_`
+    const endAtParam = endAt ? toOrderKey(createdBy, endAt) : `${createdBy}_${PREFIX_END}`
+    const boundedQuery = query(
+      firebase(path),
+      orderByChild('createdBy_orderKey'),
+      startAt(startAtParam),
+      fbEndAt(endAtParam)
+    );
+    const limitedQuery = limit ? query(boundedQuery, limitToFirst(limit)) : boundedQuery;
+    return get(limitedQuery).then(snapshot => ({snapshot, ref: limitedQuery}));
+  }
 
   const baseQuery = query(
     firebase(path),
-    orderByChild(createdBy ? 'createdBy_orderKey' : 'negativeTimestamp'),
-    startAt(startAtParam)
+    orderByChild('negativeTimestamp'),
+    startAt(start)
   );
   const limitedQuery = limit
     ? query(baseQuery, limitToFirst(limit))
-    : query(baseQuery, fbEndAt(endAtParam));
+    : query(baseQuery, fbEndAt(endAt));
 
   return get(limitedQuery).then(snapshot => ({snapshot, ref: limitedQuery}));
 }

--- a/src/modules/movements/sagas.spec.ts
+++ b/src/modules/movements/sagas.spec.ts
@@ -1094,7 +1094,7 @@ describe('modules', () => {
           expect(generator.next().done).toEqual(true);
         });
 
-        it('should return early when movement not found', () => {
+        it('should mark the movement unavailable when not found', () => {
           const action = actions.loadMovement('deleted-key', 'departure');
           const generator = sagas.loadMovement(action);
 
@@ -1104,7 +1104,26 @@ describe('modules', () => {
 
           const snapshot = new FakeFirebaseSnapshot('deleted-key', null);
 
-          expect(generator.next(snapshot).done).toEqual(true);
+          expect(generator.next(snapshot).value).toEqual(
+            put(actions.movementByKeyUnavailable('deleted-key'))
+          );
+          expect(generator.next().done).toEqual(true);
+        });
+
+        it('should mark the movement unavailable when the read is rejected', () => {
+          // e.g. an associated return flight owned by another pilot, denied by
+          // the read rules.
+          const action = actions.loadMovement('foreign-key', 'arrival');
+          const generator = sagas.loadMovement(action);
+
+          expect(generator.next().value).toEqual(
+            call(remote.loadByKey, '/arrivals', 'foreign-key')
+          );
+
+          expect(generator.throw(new Error('permission_denied')).value).toEqual(
+            put(actions.movementByKeyUnavailable('foreign-key'))
+          );
+          expect(generator.next().done).toEqual(true);
         });
       });
 
@@ -1141,7 +1160,7 @@ describe('modules', () => {
       });
 
       describe('loadDeparturesAndArrivalsFiltered', () => {
-        it('should call remote.loadLimited for departures and arrivals with date range', () => {
+        it('should scope loadLimited to the user for a non-admin', () => {
           const movements = {
             filter: { date: { start: '2017-05-01', end: '2017-05-31' } }
           };
@@ -1151,13 +1170,16 @@ describe('modules', () => {
           const start = dates.negativeTimestampEndOfDay('2017-05-31');
           const end = dates.negativeTimestampStartOfDay('2017-05-01');
 
-          expect(generator.next().value).toEqual(
-            call(remote.loadLimited, '/departures', start, null, end)
+          expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+          const auth = { admin: false, allMovements: false, email: 'pilot@example.com' };
+          expect(generator.next(auth).value).toEqual(
+            call(remote.loadLimited, '/departures', start, null, end, 'pilot@example.com')
           );
 
           const departuresResult = { snapshot: {}, ref: {} };
           expect(generator.next(departuresResult).value).toEqual(
-            call(remote.loadLimited, '/arrivals', start, null, end)
+            call(remote.loadLimited, '/arrivals', start, null, end, 'pilot@example.com')
           );
 
           const arrivalsResult = { snapshot: {}, ref: {} };
@@ -1165,6 +1187,45 @@ describe('modules', () => {
 
           expect(result.value).toEqual({ departures: departuresResult, arrivals: arrivalsResult });
           expect(result.done).toEqual(true);
+        });
+
+        it('should not scope loadLimited for an admin / all-movements user', () => {
+          const movements = {
+            filter: { date: { start: '2017-05-01', end: '2017-05-31' } }
+          };
+
+          const generator = sagas.loadDeparturesAndArrivalsFiltered(movements);
+
+          const start = dates.negativeTimestampEndOfDay('2017-05-31');
+          const end = dates.negativeTimestampStartOfDay('2017-05-01');
+
+          expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+          const auth = { admin: true, email: 'admin@example.com' };
+          expect(generator.next(auth).value).toEqual(
+            call(remote.loadLimited, '/departures', start, null, end, undefined)
+          );
+        });
+
+        it('should not scope loadLimited for a shared-access user without an email (lspv)', () => {
+          // Static/flightnet logins have no Firebase email, so createdBy is
+          // undefined and the unbounded query is used — shared-access projects
+          // keep showing all movements.
+          const movements = {
+            filter: { date: { start: '2017-05-01', end: '2017-05-31' } }
+          };
+
+          const generator = sagas.loadDeparturesAndArrivalsFiltered(movements);
+
+          const start = dates.negativeTimestampEndOfDay('2017-05-31');
+          const end = dates.negativeTimestampStartOfDay('2017-05-01');
+
+          expect(generator.next().value).toEqual(select(sagas.authSelector));
+
+          const auth = { admin: false, allMovements: false };
+          expect(generator.next(auth).value).toEqual(
+            call(remote.loadLimited, '/departures', start, null, end, undefined)
+          );
         });
       });
 

--- a/src/modules/movements/sagas.ts
+++ b/src/modules/movements/sagas.ts
@@ -215,6 +215,11 @@ export function* loadDeparturesAndArrivals(movements: any, clear: boolean) {
 }
 
 export function* loadDeparturesAndArrivalsFiltered(movements: any) {
+  const auth = yield select(authSelector);
+  // Non-admins read only their own movements; the bound also satisfies the
+  // read rules, which deny unbounded (non-owner) queries.
+  const createdBy = !canSeeAllMovements(auth) ? auth.email : undefined;
+
   // start and end is the other way round because we're sorting (ascending) by negative timestamp
   const start = dates.negativeTimestampEndOfDay(movements.filter.date.end);
   const end = dates.negativeTimestampStartOfDay(movements.filter.date.start);
@@ -224,7 +229,8 @@ export function* loadDeparturesAndArrivalsFiltered(movements: any) {
     '/departures',
     start,
     null,
-    end
+    end,
+    createdBy
   );
 
   const arrivals = yield call(
@@ -232,7 +238,8 @@ export function* loadDeparturesAndArrivalsFiltered(movements: any) {
     '/arrivals',
     start,
     null,
-    end
+    end,
+    createdBy
   );
 
   return {departures, arrivals};
@@ -443,16 +450,29 @@ export function* loadMovement(action: any) {
   const {key, type} = action.payload;
 
   const path = getPathByMovementType(type);
-  const snapshot = yield call(remote.loadByKey, path, key);
 
-  const val = snapshot.val();
-  if (!val) return;
+  try {
+    const snapshot = yield call(remote.loadByKey, path, key);
 
-  const movement = firebaseToLocal(val);
-  movement.key = snapshot.key;
-  movement.type = type;
+    const val = snapshot.val();
+    if (!val) {
+      yield put(actions.movementByKeyUnavailable(key));
+      return;
+    }
 
-  yield put(actions.addMovementByKey(movement));
+    const movement = firebaseToLocal(val);
+    movement.key = snapshot.key;
+    movement.type = type;
+
+    yield put(actions.addMovementByKey(movement));
+  } catch (e) {
+    // The movement may belong to another pilot (e.g. an associated return
+    // flight on a shared aircraft) and be denied by the read rules, or the read
+    // may fail transiently. Mark it unavailable so the associated-movement view
+    // resolves instead of spinning. Do not rethrow — that would restart the
+    // movements saga.
+    yield put(actions.movementByKeyUnavailable(key));
+  }
 }
 
 export function* deleteMovement(action: any) {
@@ -489,7 +509,15 @@ export function* editMovement(action: any) {
   let movement = yield(select(movementSelector, key));
   if (!movement) {
     const path = getPathByMovementType(movementType);
-    const snapshot = yield(call(remote.loadByKey, path, key));
+    let snapshot;
+    try {
+      snapshot = yield(call(remote.loadByKey, path, key));
+    } catch (e) {
+      // Not readable (another pilot's movement) or a transient failure — send
+      // the user home rather than letting the rejection restart the saga.
+      history.push('/');
+      return;
+    }
     const val = snapshot.val();
     if (!val) {
       history.push('/');

--- a/tasks/processFirebaseRules.js
+++ b/tasks/processFirebaseRules.js
@@ -37,6 +37,36 @@ function processMovementOwnership(config) {
   return " && (" + IS_ADMIN + " || " + MOVEMENT_OWNERSHIP + ")";
 }
 
+// Read scoping for movements. On personal-access projects a list/query read is
+// only allowed when bounded to the caller's own createdBy_orderKey prefix
+// (their email), and a single-record read only for the record's owner; admins
+// read everything. Guest/kiosk (no email) read nothing. Shared-access projects
+// keep the permissive rule.
+const readProcessors = {
+  movementListRead: processMovementListRead,
+  movementItemRead: processMovementItemRead,
+};
+
+// Who may read every movement — must mirror the client's canSeeAllMovements
+// (admin || allMovements). `admin` is kept in sync with /admins; `allMovements`
+// is an operator flag stored only under /logins/$uid.
+const CAN_SEE_ALL_MOVEMENTS =
+  IS_ADMIN + " || root.child('logins/' + auth.uid + '/allMovements').val() === true";
+
+function processMovementListRead(config) {
+  if (config.loginForm !== 'email') {
+    return "auth !== null";
+  }
+  return "auth !== null && (" + CAN_SEE_ALL_MOVEMENTS + " || (query.orderByChild === 'createdBy_orderKey' && query.startAt.beginsWith(auth.token.email + '_') && query.endAt.beginsWith(auth.token.email + '_')))";
+}
+
+function processMovementItemRead(config) {
+  if (config.loginForm !== 'email') {
+    return "auth !== null";
+  }
+  return "auth !== null && (" + CAN_SEE_ALL_MOVEMENTS + " || data.child('createdBy').val() === auth.token.email)";
+}
+
 function newValEquals(val) {
   return "newData.val() === '" + val + "'";
 }
@@ -86,6 +116,11 @@ function process(rules, config) {
       processValidationString(rules, config, key, value);
     } else if (key === '.write' && typeof value === 'string' && value.indexOf('{movementOwnership}') !== -1) {
       rules[key] = value.replace('{movementOwnership}', processMovementOwnership(config));
+    } else if (key === '.read' && typeof value === 'string' && /^\{([a-zA-Z]+)}$/.test(value)) {
+      const token = value.slice(1, -1);
+      if (readProcessors[token]) {
+        rules[key] = readProcessors[token](config);
+      }
     } else if (typeof value === 'object') {
       process(value, config);
     }

--- a/test/rules/movementWrite.rules.js
+++ b/test/rules/movementWrite.rules.js
@@ -1,12 +1,13 @@
 /**
- * Emulator-based security-rules test for movement write ownership.
+ * Emulator-based security-rules test for movement read/write scoping.
  *
  * Run via: npm run test:rules  (starts the RTDB emulator, then runs this).
  *
  * Verifies, against the *built* rules:
- *  - personal-access projects (loginForm === 'email'): pilots write only their
- *    own movements, guest/kiosk create/edit ownerless ones, admins write all;
- *  - shared-access projects (e.g. lspv): any authenticated user writes anything.
+ *  - personal-access projects (loginForm === 'email'): pilots read/write only
+ *    their own movements (reads via email-bounded queries or owner key reads),
+ *    guest/kiosk create/edit ownerless ones and read none, admins read/write all;
+ *  - shared-access projects (e.g. lspv): any authenticated user reads/writes all.
  */
 'use strict';
 
@@ -15,7 +16,20 @@ const {
   assertSucceeds,
   assertFails,
 } = require('@firebase/rules-unit-testing');
-const { ref, set, update, remove } = require('firebase/database');
+const {
+  ref, set, update, remove,
+  query, orderByChild, startAt, endAt, limitToFirst, get,
+} = require('firebase/database');
+
+const SENTINEL = '\uf8ff'; // Firebase high-codepoint upper bound
+
+// A pilot's own movements: createdBy_orderKey values all start with `${email}_`.
+function ownQuery(db, path, email) {
+  return query(ref(db, path), orderByChild('createdBy_orderKey'), startAt(email + '_'), endAt(email + '_' + SENTINEL), limitToFirst(20));
+}
+function unboundedQuery(db, path) {
+  return query(ref(db, path), orderByChild('negativeTimestamp'), startAt(-9999999999999), limitToFirst(20));
+}
 
 const projects = require('../../projects');
 const { buildRules } = require('../../tasks/processFirebaseRules');
@@ -85,16 +99,20 @@ async function testPersonalAccess() {
   await env.withSecurityRulesDisabled(async (ctx) => {
     const db = ctx.database();
     await set(ref(db, 'admins/admin-uid'), true);
+    await set(ref(db, 'logins/operator-uid/allMovements'), true);
     await set(ref(db, 'departures/alice_edit'), validDeparture(config, 'alice@example.com'));
     await set(ref(db, 'departures/alice_delete'), validDeparture(config, 'alice@example.com'));
     await set(ref(db, 'departures/ownerless_edit'), validDeparture(config));
     await set(ref(db, 'departures/owned_for_guest'), validDeparture(config, 'alice@example.com'));
+    await set(ref(db, 'departures/alice_read'), validDeparture(config, 'alice@example.com'));
+    await set(ref(db, 'departures/bob_read'), validDeparture(config, 'bob@example.com'));
   });
 
   const alice = env.authenticatedContext('alice-uid', { email: 'alice@example.com' }).database();
   const bob = env.authenticatedContext('bob-uid', { email: 'bob@example.com' }).database();
   const guest = env.authenticatedContext('guest').database();
   const admin = env.authenticatedContext('admin-uid').database();
+  const operator = env.authenticatedContext('operator-uid', { email: 'operator@example.com' }).database();
   const anon = env.unauthenticatedContext().database();
 
   // pilot
@@ -116,6 +134,19 @@ async function testPersonalAccess() {
   await expect('admin deletes any movement', true, remove(ref(admin, 'departures/owned_for_guest')));
   await expect('unauthenticated cannot write', false, set(ref(anon, 'departures/new_anon'), validDeparture(config, 'x@example.com')));
 
+  // reads
+  await expect('pilot reads own movements (bounded query)', true, get(ownQuery(alice, 'departures', 'alice@example.com')));
+  await expect('pilot cannot read all movements (unbounded query)', false, get(unboundedQuery(alice, 'departures')));
+  await expect('pilot cannot query another pilot prefix', false, get(ownQuery(alice, 'departures', 'bob@example.com')));
+  await expect('pilot reads own movement by key', true, get(ref(alice, 'departures/alice_read')));
+  await expect('pilot cannot read another movement by key', false, get(ref(alice, 'departures/bob_read')));
+  await expect('guest cannot read movements', false, get(ownQuery(guest, 'departures', 'alice@example.com')));
+  await expect('admin reads all movements (unbounded query)', true, get(unboundedQuery(admin, 'departures')));
+  await expect('admin reads any movement by key', true, get(ref(admin, 'departures/bob_read')));
+  await expect('allMovements operator reads all (unbounded query)', true, get(unboundedQuery(operator, 'departures')));
+  await expect('allMovements operator reads any movement by key', true, get(ref(operator, 'departures/bob_read')));
+  await expect('unauthenticated cannot read movements', false, get(ownQuery(anon, 'departures', 'alice@example.com')));
+
   await env.cleanup();
 }
 
@@ -130,6 +161,7 @@ async function testSharedAccess() {
   await env.withSecurityRulesDisabled(async (ctx) => {
     const db = ctx.database();
     await set(ref(db, 'departures/someone'), validDeparture(config, 'alice@example.com'));
+    await set(ref(db, 'departures/shared_read'), validDeparture(config, 'alice@example.com'));
   });
 
   const bob = env.authenticatedContext('bob-uid', { email: 'bob@example.com' }).database();
@@ -139,6 +171,9 @@ async function testSharedAccess() {
   await expect('any authed user edits another movement', true, update(ref(bob, 'departures/someone'), { remarks: 'shared' }));
   await expect('any authed user deletes another movement', true, remove(ref(bob, 'departures/someone')));
   await expect('unauthenticated cannot write', false, set(ref(anon, 'departures/new_anon'), validDeparture(config, 'x@example.com')));
+  await expect('any authed user reads all movements (unbounded query)', true, get(unboundedQuery(bob, 'departures')));
+  await expect('any authed user reads any movement by key', true, get(ref(bob, 'departures/shared_read')));
+  await expect('unauthenticated cannot read movements', false, get(unboundedQuery(anon, 'departures')));
 
   await env.cleanup();
 }
@@ -150,7 +185,7 @@ async function testSharedAccess() {
     console.error(`\n${failures} rule assertion(s) failed`);
     process.exit(1);
   }
-  console.log('\nAll movement-write rule assertions passed');
+  console.log('\nAll movement read/write rule assertions passed');
 })().catch((e) => {
   console.error(e);
   process.exit(1);


### PR DESCRIPTION
Companion to the write-ownership change. On projects with email/passkey login (loginForm: email), movement reads are scoped in the rules: a pilot reads only their own movements (email-bounded list queries and owner-only single-record reads), admins and all-movements operators read all, guest/kiosk read none. The client movement queries are bounded to the caller's own createdBy prefix so they satisfy the rules. Shared-access projects (lspv) are unchanged. Emulator rules test extended with read cases (npm run test:rules).