### PR TITLE
Note associated movements recorded by another pilot

### DIFF
--- a/src/components/MovementList/AssociatedMovement.spec.tsx
+++ b/src/components/MovementList/AssociatedMovement.spec.tsx
@@ -46,6 +46,7 @@ jest.mock('./Action', () => ({
 }));
 
 import AssociatedMovement from './AssociatedMovement';
+import {FORBIDDEN_MOVEMENT} from '../../modules/movements/reducer';
 
 const makeProps = (overrides: any = {}) => ({
   movementType: 'departure',
@@ -101,6 +102,21 @@ describe('<AssociatedMovement>', () => {
             {...makeProps({
               loadMovement,
               associatedMovementData: null,
+            })}
+          />
+        )
+      );
+      expect(loadMovement).not.toHaveBeenCalled();
+    });
+
+    it('does NOT dispatch loadMovement when data is forbidden', () => {
+      const loadMovement = jest.fn();
+      render(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              loadMovement,
+              associatedMovementData: FORBIDDEN_MOVEMENT,
             })}
           />
         )
@@ -196,6 +212,22 @@ describe('<AssociatedMovement>', () => {
         )
       );
       expect(getByTestId('movement-details')).toBeTruthy();
+    });
+
+    it('shows a not-accessible note and no create action when data is forbidden', () => {
+      const { queryByTestId, getByText } = render(
+        wrap(
+          <AssociatedMovement
+            {...makeProps({
+              associatedMovementData: FORBIDDEN_MOVEMENT,
+            })}
+          />
+        )
+      );
+      expect(getByText('movement.associated.arrivalNotAccessible')).toBeTruthy();
+      expect(queryByTestId('action')).toBeNull();
+      expect(queryByTestId('movement-details')).toBeNull();
+      expect(queryByTestId('material-icon')).toBeNull();
     });
 
     it('shows create action when data is null', () => {

--- a/src/components/MovementList/AssociatedMovement.tsx
+++ b/src/components/MovementList/AssociatedMovement.tsx
@@ -6,6 +6,7 @@ import MaterialIcon from '../MaterialIcon';
 import MovementDetails from './MovementDetails';
 import Action from './Action';
 import {ACTION_LABELS} from './labels';
+import {FORBIDDEN_MOVEMENT} from '../../modules/movements/reducer';
 
 const Wrapper = styled.div`
   padding: 1em;
@@ -58,23 +59,30 @@ const AssociatedMovement = React.memo((props: any) => {
     createMovementFromMovement(movementType, movementKey);
   };
 
+  const forbidden = associatedMovementData === FORBIDDEN_MOVEMENT;
+  const hasData = !!associatedMovementData && !forbidden;
+
   let label;
   let text;
 
   if (movementType === 'departure') {
     label = t('movement.associated.arrivalLabel');
-    text = associatedMovementData
+    text = hasData
       ? t('movement.associated.arrivalFound')
-      : associatedMovementData === null
-        ? t('movement.associated.arrivalNotFound')
-        : null;
+      : forbidden
+        ? t('movement.associated.arrivalNotAccessible')
+        : associatedMovementData === null
+          ? t('movement.associated.arrivalNotFound')
+          : null;
   } else {
     label = t('movement.associated.departureLabel');
-    text = associatedMovementData
+    text = hasData
       ? t('movement.associated.departureFound')
-      : associatedMovementData === null
-        ? t('movement.associated.departureNotFound')
-        : null;
+      : forbidden
+        ? t('movement.associated.departureNotAccessible')
+        : associatedMovementData === null
+          ? t('movement.associated.departureNotFound')
+          : null;
   }
 
   return (
@@ -82,21 +90,23 @@ const AssociatedMovement = React.memo((props: any) => {
       <div>
         <Label>{label}</Label>
         {text && <div>{text}</div>}
-        {associatedMovementData
+        {hasData
           ? <StyledDetails data={associatedMovementData} isHomeBase={isHomeBase} isAdmin={isAdmin}/>
-          : associatedMovementData === undefined
-            ? <MaterialIcon icon="sync" rotate="left"/>
-            : (
-              <ActionsContainer>
-                <ActionContainer>
-                  <Action
-                    label={ACTION_LABELS[movementType].label}
-                    icon={ACTION_LABELS[movementType].icon}
-                    onClick={handleCreateMovement}
-                  />
-                </ActionContainer>
-              </ActionsContainer>
-            )}
+          : forbidden
+            ? null
+            : associatedMovementData === undefined
+              ? <MaterialIcon icon="sync" rotate="left"/>
+              : (
+                <ActionsContainer>
+                  <ActionContainer>
+                    <Action
+                      label={ACTION_LABELS[movementType].label}
+                      icon={ACTION_LABELS[movementType].icon}
+                      onClick={handleCreateMovement}
+                    />
+                  </ActionContainer>
+                </ActionsContainer>
+              )}
       </div>
     </Wrapper>
   );

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -172,7 +172,9 @@
       "arrivalFound": "Die folgende Ankunft wurde diesem Abflug automatisch zugeordnet:",
       "departureFound": "Der folgende Abflug wurde dieser Ankunft automatisch zugeordnet:",
       "arrivalNotFound": "Es konnte keine Ankunft zugeordnet werden.",
-      "departureNotFound": "Es konnte kein Abflug zugeordnet werden."
+      "departureNotFound": "Es konnte kein Abflug zugeordnet werden.",
+      "arrivalNotAccessible": "Die zugeordnete Ankunft wurde von einer anderen Person erfasst und kann hier nicht angezeigt werden.",
+      "departureNotAccessible": "Der zugeordnete Abflug wurde von einer anderen Person erfasst und kann hier nicht angezeigt werden."
     },
     "homeBase": {
       "yes": "Dieses Flugzeug ist in {{name}} stationiert",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -172,7 +172,9 @@
       "arrivalFound": "The following arrival has been automatically associated with this departure:",
       "departureFound": "The following departure has been automatically associated with this arrival:",
       "arrivalNotFound": "No arrival could be associated.",
-      "departureNotFound": "No departure could be associated."
+      "departureNotFound": "No departure could be associated.",
+      "arrivalNotAccessible": "The associated arrival was recorded by another person and cannot be shown here.",
+      "departureNotAccessible": "The associated departure was recorded by another person and cannot be shown here."
     },
     "homeBase": {
       "yes": "This aircraft is based at {{name}}",

--- a/src/modules/movements/actions.ts
+++ b/src/modules/movements/actions.ts
@@ -8,6 +8,7 @@ export const MOVEMENT_DELETED = 'MOVEMENT_DELETED' as const;
 export const LOAD_MOVEMENT = 'LOAD_MOVEMENT' as const;
 export const ADD_MOVEMENT_BY_KEY = 'ADD_MOVEMENT_BY_KEY' as const;
 export const MOVEMENT_BY_KEY_UNAVAILABLE = 'MOVEMENT_BY_KEY_UNAVAILABLE' as const;
+export const MOVEMENT_BY_KEY_FORBIDDEN = 'MOVEMENT_BY_KEY_FORBIDDEN' as const;
 export const CLEAR_MOVEMENTS_BY_KEY = 'CLEAR_MOVEMENTS_BY_KEY' as const;
 export const DELETE_MOVEMENT = 'DELETE_MOVEMENT' as const;
 export const INIT_NEW_MOVEMENT = 'INIT_NEW_MOVEMENT' as const;
@@ -34,6 +35,7 @@ export type MovementsAction =
   | { type: typeof LOAD_MOVEMENT; payload: { key: string; type: string } }
   | { type: typeof ADD_MOVEMENT_BY_KEY; payload: { movement: unknown } }
   | { type: typeof MOVEMENT_BY_KEY_UNAVAILABLE; payload: { key: string } }
+  | { type: typeof MOVEMENT_BY_KEY_FORBIDDEN; payload: { key: string } }
   | { type: typeof CLEAR_MOVEMENTS_BY_KEY }
   | { type: typeof DELETE_MOVEMENT; payload: { movementType: string; key: string; successAction: () => unknown } }
   | { type: typeof INIT_NEW_MOVEMENT; payload: { movementType: string } }
@@ -128,13 +130,26 @@ export function addMovementByKey(movement: unknown) {
   };
 }
 
-// Marks a by-key movement as unavailable (not found, or not readable because it
-// belongs to another pilot — e.g. an associated return flight on a shared
-// aircraft). Resolves the associated-movement view to its "not found" state
-// instead of leaving it spinning.
+// Marks a by-key movement as unavailable (not found / deleted). Resolves the
+// associated-movement view to its "not found" state instead of leaving it
+// spinning.
 export function movementByKeyUnavailable(key: string) {
   return {
     type: MOVEMENT_BY_KEY_UNAVAILABLE,
+    payload: {
+      key
+    }
+  };
+}
+
+// Marks a by-key movement as readable-only-by-others: it exists and is
+// associated, but the read rules deny it (e.g. an associated return flight
+// recorded by another pilot on a shared aircraft). The associated-movement
+// view shows a "recorded by another person" note rather than offering to
+// create a duplicate.
+export function movementByKeyForbidden(key: string) {
+  return {
+    type: MOVEMENT_BY_KEY_FORBIDDEN,
     payload: {
       key
     }

--- a/src/modules/movements/reducer.spec.ts
+++ b/src/modules/movements/reducer.spec.ts
@@ -1,6 +1,6 @@
 import ImmutableItemsArray from '../../util/ImmutableItemsArray';
 import * as actions from './actions';
-import reducer from './reducer';
+import reducer, {FORBIDDEN_MOVEMENT} from './reducer';
 
 const INITIAL_STATE = {
   data: new ImmutableItemsArray(),
@@ -93,6 +93,16 @@ describe('modules', () => {
 
           expect(newState.byKey['foreign-key']).toBeNull();
           expect(newState.byKey['existing']).toEqual({ key: 'existing' });
+        });
+      });
+
+      describe('movementByKeyForbidden', () => {
+        it('should set the by-key entry to the forbidden sentinel', () => {
+          const state = { byKey: {} };
+
+          const newState = reducer(state as any, actions.movementByKeyForbidden('foreign-key'));
+
+          expect(newState.byKey['foreign-key']).toBe(FORBIDDEN_MOVEMENT);
         });
       });
 

--- a/src/modules/movements/reducer.ts
+++ b/src/modules/movements/reducer.ts
@@ -66,6 +66,20 @@ export const movementByKeyUnavailable = (state: MovementsState, action: any) => 
   }
 });
 
+// Sentinel stored in `byKey` for a movement that exists but is not readable by
+// the current user (read rules deny it). Distinct from `null` (not found) so the
+// associated-movement view can show "recorded by another person" rather than a
+// "create" prompt. Compared by reference.
+export const FORBIDDEN_MOVEMENT = { forbidden: true } as const;
+
+export const movementByKeyForbidden = (state: MovementsState, action: any) => ({
+  ...state,
+  byKey: {
+    ...state.byKey,
+    [action.payload.key]: FORBIDDEN_MOVEMENT
+  }
+});
+
 export const clearMovementsByKey = (state: MovementsState) => ({
   ...state,
   byKey: {}
@@ -94,6 +108,7 @@ const ACTION_HANDLERS: Record<string, (state: MovementsState, action: any) => Mo
   [actions.SET_MOVEMENTS_FILTER]: setFilter,
   [actions.ADD_MOVEMENT_BY_KEY]: addMovementByKey,
   [actions.MOVEMENT_BY_KEY_UNAVAILABLE]: movementByKeyUnavailable,
+  [actions.MOVEMENT_BY_KEY_FORBIDDEN]: movementByKeyForbidden,
   [actions.CLEAR_MOVEMENTS_BY_KEY]: clearMovementsByKey,
   [actions.SET_ASSOCIATED_MOVEMENT]: setAssociatedMovement,
   [actions.CLEAR_ASSOCIATED_MOVEMENTS]: clearAssociatedMovements,

--- a/src/modules/movements/sagas.spec.ts
+++ b/src/modules/movements/sagas.spec.ts
@@ -1110,9 +1110,9 @@ describe('modules', () => {
           expect(generator.next().done).toEqual(true);
         });
 
-        it('should mark the movement unavailable when the read is rejected', () => {
+        it('should mark the movement forbidden when the read is rejected', () => {
           // e.g. an associated return flight owned by another pilot, denied by
-          // the read rules.
+          // the read rules — it exists, it just can't be shown.
           const action = actions.loadMovement('foreign-key', 'arrival');
           const generator = sagas.loadMovement(action);
 
@@ -1121,7 +1121,7 @@ describe('modules', () => {
           );
 
           expect(generator.throw(new Error('permission_denied')).value).toEqual(
-            put(actions.movementByKeyUnavailable('foreign-key'))
+            put(actions.movementByKeyForbidden('foreign-key'))
           );
           expect(generator.next().done).toEqual(true);
         });

--- a/src/modules/movements/sagas.ts
+++ b/src/modules/movements/sagas.ts
@@ -466,12 +466,12 @@ export function* loadMovement(action: any) {
 
     yield put(actions.addMovementByKey(movement));
   } catch (e) {
-    // The movement may belong to another pilot (e.g. an associated return
-    // flight on a shared aircraft) and be denied by the read rules, or the read
-    // may fail transiently. Mark it unavailable so the associated-movement view
-    // resolves instead of spinning. Do not rethrow — that would restart the
-    // movements saga.
-    yield put(actions.movementByKeyUnavailable(key));
+    // The read was rejected — typically the movement belongs to another pilot
+    // (e.g. an associated return flight on a shared aircraft) and is denied by
+    // the read rules. Mark it forbidden so the associated-movement view shows a
+    // "recorded by another person" note rather than offering to create a
+    // duplicate. Do not rethrow — that would restart the movements saga.
+    yield put(actions.movementByKeyForbidden(key));
   }
 }
 


### PR DESCRIPTION
Follow-up to the movement read-scoping change. When a movement's associated counter-movement was recorded by another pilot, the read rules deny the by-key read, so it can't be displayed. Previously this showed the "no counter-movement could be associated" message plus a create button — misleading, and a create would risk a duplicate. Now it shows a distinct note that the counter-movement exists but is not viewable here (no create action). A genuinely missing/deleted counter-movement still offers to create one. Adds saga, reducer and component tests.