### PR TITLE
Rate-limit the email sign-in code endpoint

### DIFF
--- a/firebase-rules-template.json
+++ b/firebase-rules-template.json
@@ -470,6 +470,10 @@
       ".write": false,
       ".indexOn": ["email"]
     },
+    "signInRateLimits": {
+      ".read": false,
+      ".write": false
+    },
     "webauthnCredentials": {
       ".write": false,
       "$uid": {

--- a/functions/auth/cleanupExpiredSignInCodes.js
+++ b/functions/auth/cleanupExpiredSignInCodes.js
@@ -4,30 +4,44 @@ const { onSchedule } = require('firebase-functions/v2/scheduler');
 const admin = require('firebase-admin');
 
 const MAX_ATTEMPTS = 5;
+const RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour — matches generateSignInCode
 
 exports.cleanupExpiredSignInCodes = onSchedule(
   { region: 'europe-west1', schedule: 'every 60 minutes' },
   async () => {
     const db = admin.database();
+    const now = Date.now();
+
     const codesRef = db.ref('/signInCodes');
     const snapshot = await codesRef.once('value');
 
-    if (!snapshot.exists()) {
-      return;
+    if (snapshot.exists()) {
+      const updates = {};
+      snapshot.forEach(child => {
+        const val = child.val();
+        if (val.expiry <= now || val.attempts >= MAX_ATTEMPTS) {
+          updates[child.key] = null;
+        }
+      });
+      if (Object.keys(updates).length > 0) {
+        await codesRef.update(updates);
+      }
     }
 
-    const updates = {};
-    const now = Date.now();
+    const rateLimitsRef = db.ref('/signInRateLimits');
+    const rateLimitsSnapshot = await rateLimitsRef.once('value');
 
-    snapshot.forEach(child => {
-      const val = child.val();
-      if (val.expiry <= now || val.attempts >= MAX_ATTEMPTS) {
-        updates[child.key] = null;
+    if (rateLimitsSnapshot.exists()) {
+      const updates = {};
+      rateLimitsSnapshot.forEach(child => {
+        const val = child.val();
+        if (now - val.windowStart > RATE_WINDOW_MS) {
+          updates[child.key] = null;
+        }
+      });
+      if (Object.keys(updates).length > 0) {
+        await rateLimitsRef.update(updates);
       }
-    });
-
-    if (Object.keys(updates).length > 0) {
-      await codesRef.update(updates);
     }
   }
 );

--- a/functions/auth/cleanupExpiredSignInCodes.spec.js
+++ b/functions/auth/cleanupExpiredSignInCodes.spec.js
@@ -4,8 +4,11 @@ describe('functions', () => {
     let capturedHandler;
     let capturedOptions;
     let mockCodesRef;
+    let mockRateLimitsRef;
 
     const now = Date.now();
+
+    const emptySnapshot = { exists: () => false, forEach: () => {} };
 
     beforeEach(() => {
       jest.resetModules();
@@ -13,13 +16,17 @@ describe('functions', () => {
       capturedOptions = null;
 
       mockCodesRef = {
-        once: jest.fn(),
+        once: jest.fn().mockResolvedValue(emptySnapshot),
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+      mockRateLimitsRef = {
+        once: jest.fn().mockResolvedValue(emptySnapshot),
         update: jest.fn().mockResolvedValue(undefined),
       };
 
       mockAdmin = {
         database: jest.fn().mockReturnValue({
-          ref: jest.fn().mockReturnValue(mockCodesRef)
+          ref: jest.fn(path => path === '/signInRateLimits' ? mockRateLimitsRef : mockCodesRef)
         })
       };
 
@@ -117,6 +124,27 @@ describe('functions', () => {
       await capturedHandler();
 
       expect(mockCodesRef.update).toHaveBeenCalledWith({ k1: null, k2: null });
+    });
+
+    it('deletes rate-limit entries older than the window and keeps recent ones', async () => {
+      mockRateLimitsRef.once.mockResolvedValue(makeSnapshot([
+        { key: 'rl1', val: { windowStart: now - (61 * 60 * 1000) } }, // stale (> 1h)
+        { key: 'rl2', val: { windowStart: now - (10 * 60 * 1000) } }, // recent
+      ]));
+
+      await capturedHandler();
+
+      expect(mockRateLimitsRef.update).toHaveBeenCalledWith({ rl1: null });
+    });
+
+    it('does not touch rate-limit entries that are all recent', async () => {
+      mockRateLimitsRef.once.mockResolvedValue(makeSnapshot([
+        { key: 'rl1', val: { windowStart: now - (5 * 60 * 1000) } },
+      ]));
+
+      await capturedHandler();
+
+      expect(mockRateLimitsRef.update).not.toHaveBeenCalled();
     });
 
     it('is scheduled to run every 60 minutes', () => {

--- a/functions/auth/generateSignInCode.js
+++ b/functions/auth/generateSignInCode.js
@@ -9,8 +9,22 @@ const { sendSignInEmail } = require('./sendSignInEmail');
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const CODE_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
 
+// Per-email rate limiting. The login UI already enforces a 60s resend countdown
+// (OtpCodeForm RESEND_COOLDOWN_SECONDS); the server cooldown sits just under it
+// so a legitimate resend never trips it, while scripted abuse (email bombing /
+// OTP brute force) is blocked. The hourly cap is the sustained-abuse backstop.
+const COOLDOWN_MS = 55 * 1000;
+const RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const MAX_PER_WINDOW = 5;
+
 const hashCode = (code) => {
   return crypto.createHash('sha256').update(code).digest('hex');
+};
+
+// RTDB keys cannot contain '@' or '.', so the limiter is keyed by a hash of the
+// normalized email.
+const emailKey = (email) => {
+  return crypto.createHash('sha256').update(email).digest('hex');
 };
 
 const validateRequest = (method, body) => {
@@ -41,12 +55,46 @@ exports.generateSignInCode = onRequest({ region: 'europe-west1' }, (req, res) =>
 
       const { email, airportName, themeColor, language } = req.body;
       const normalizedEmail = email.toLowerCase();
+      const db = admin.database();
+      const now = Date.now();
+
+      // Per-email rate limiting: reject if a code was sent very recently
+      // (cooldown) or too many were sent within the rolling window. The limiter
+      // is checked-and-incremented before sending so a forced email failure
+      // cannot be used to bypass it.
+      const rateLimitRef = db.ref('/signInRateLimits/' + emailKey(normalizedEmail));
+      const rateLimit = await rateLimitRef.transaction(current => {
+        if (!current || now - current.windowStart >= RATE_WINDOW_MS) {
+          return { windowStart: now, lastSentAt: now, count: 1 };
+        }
+        if (now - current.lastSentAt < COOLDOWN_MS) {
+          return; // cooldown not elapsed — abort
+        }
+        if (current.count >= MAX_PER_WINDOW) {
+          return; // hourly cap reached — abort
+        }
+        return { windowStart: current.windowStart, lastSentAt: now, count: current.count + 1 };
+      });
+
+      if (!rateLimit.committed) {
+        return res.status(429).json({ error: 'Too many requests. Please try again later.' });
+      }
+
+      // Keep only one live code per email: remove any existing codes first so a
+      // caller cannot accumulate many concurrently-valid codes.
+      const codesRef = db.ref('/signInCodes');
+      const existing = await codesRef.orderByChild('email').equalTo(normalizedEmail).once('value');
+      if (existing.exists()) {
+        const deletions = {};
+        existing.forEach(child => { deletions[child.key] = null; });
+        await codesRef.update(deletions);
+      }
 
       const code = String(crypto.randomInt(0, 1000000)).padStart(6, '0');
       const codeHash = hashCode(code);
-      const expiry = Date.now() + CODE_EXPIRY_MS;
+      const expiry = now + CODE_EXPIRY_MS;
 
-      await admin.database().ref('/signInCodes').push({
+      await codesRef.push({
         email: normalizedEmail,
         codeHash,
         expiry,

--- a/functions/auth/generateSignInCode.spec.js
+++ b/functions/auth/generateSignInCode.spec.js
@@ -5,17 +5,33 @@ describe('functions', () => {
     let capturedHandler;
     let mockCors;
     let mockPush;
-    let mockCrypto;
+    let mockUpdate;
+    let mockOnce;
+    let mockTransaction;
 
     beforeEach(() => {
       jest.resetModules();
       capturedHandler = null;
 
       mockPush = jest.fn().mockResolvedValue({ key: 'code-key-123' });
+      mockUpdate = jest.fn().mockResolvedValue();
+      // default: no existing codes for the email
+      mockOnce = jest.fn().mockResolvedValue({ exists: () => false, forEach: () => {} });
+      // default: rate-limit transaction commits (request allowed)
+      mockTransaction = jest.fn().mockResolvedValue({ committed: true });
+
+      const codesRef = {
+        orderByChild: jest.fn().mockReturnValue({
+          equalTo: jest.fn().mockReturnValue({ once: mockOnce })
+        }),
+        update: mockUpdate,
+        push: mockPush,
+      };
+      const rateLimitRef = { transaction: mockTransaction };
 
       mockAdmin = {
         database: jest.fn().mockReturnValue({
-          ref: jest.fn().mockReturnValue({ push: mockPush })
+          ref: jest.fn(path => path.startsWith('/signInRateLimits') ? rateLimitRef : codesRef)
         })
       };
 
@@ -65,6 +81,38 @@ describe('functions', () => {
       await capturedHandler(req, res);
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({ error: 'Invalid email format' });
+    });
+
+    it('returns 429 and sends nothing when rate limited (cooldown / cap)', async () => {
+      mockTransaction.mockResolvedValue({ committed: false });
+
+      const req = makeReq('POST', { email: 'user@example.com' });
+      const res = makeRes();
+      await capturedHandler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(429);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Too many requests. Please try again later.' });
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(mockSendSignInEmail).not.toHaveBeenCalled();
+    });
+
+    it('deletes existing codes for the email before pushing a new one', async () => {
+      mockOnce.mockResolvedValue({
+        exists: () => true,
+        forEach: cb => {
+          cb({ key: 'old-1' });
+          cb({ key: 'old-2' });
+        }
+      });
+
+      const req = makeReq('POST', { email: 'user@example.com' });
+      const res = makeRes();
+      await capturedHandler(req, res);
+
+      expect(mockUpdate).toHaveBeenCalledWith({ 'old-1': null, 'old-2': null });
+      expect(mockPush).toHaveBeenCalled();
+      // deletion happens before the new code is pushed
+      expect(mockUpdate.mock.invocationCallOrder[0]).toBeLessThan(mockPush.mock.invocationCallOrder[0]);
     });
 
     it('stores code hash in database (not plaintext code)', async () => {


### PR DESCRIPTION
Adds per-email rate limiting to generateSignInCode: a 55s cooldown and a 5-per-hour cap, enforced server-side via a transactional signInRateLimits node (server-only rules). Also keeps a single live code per email (existing codes are removed before issuing a new one). The 55s cooldown sits just under the UI's 60s resend countdown so legitimate resends are unaffected. The hourly cleanup job prunes stale rate-limit entries. Adds tests for the cooldown/cap path, single-live-code, and cleanup pruning.