### PR TITLE
Register the user-import endpoint only with member management

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -65,6 +65,14 @@ jobs:
             process.stdout.write(({ ...def, ...proj }).privacySettings === true ? 'true' : 'false');
           ")
           echo "module.exports = $PRIVACY_FUNCTIONS_ENABLED;" > functions/privacy-config.generated.js
+      - name: Generate functions/member-management.generated.js from project config
+        run: |
+          MEMBER_MANAGEMENT_ENABLED=$(node -e "
+            const def = require('./projects/default.json');
+            const proj = require('./projects/${{ vars.PROJECT }}.json');
+            process.stdout.write(({ ...def, ...proj }).memberManagement === true ? 'true' : 'false');
+          ")
+          echo "module.exports = $MEMBER_MANAGEMENT_ENABLED;" > functions/member-management.generated.js
       - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars
         run: |
           cat > functions/.env.${{ vars.FIREBASE_PROJECT }} <<EOF

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -61,6 +61,14 @@ jobs:
             process.stdout.write(({ ...def, ...proj }).privacySettings === true ? 'true' : 'false');
           ")
           echo "module.exports = $PRIVACY_FUNCTIONS_ENABLED;" > functions/privacy-config.generated.js
+      - name: Generate functions/member-management.generated.js from project config
+        run: |
+          MEMBER_MANAGEMENT_ENABLED=$(node -e "
+            const def = require('./projects/default.json');
+            const proj = require('./projects/${{ vars.PROJECT }}.json');
+            process.stdout.write(({ ...def, ...proj }).memberManagement === true ? 'true' : 'false');
+          ")
+          echo "module.exports = $MEMBER_MANAGEMENT_ENABLED;" > functions/member-management.generated.js
       - name: Write functions/.env.${{ vars.FIREBASE_PROJECT }} from environment vars
         run: |
           cat > functions/.env.${{ vars.FIREBASE_PROJECT }} <<EOF

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ database-debug.log
 .runtimeconfig.json
 functions/privacy-config.generated.js
 functions/test-config.generated.js
+functions/member-management.generated.js

--- a/functions/api/index.js
+++ b/functions/api/index.js
@@ -9,6 +9,18 @@ const fetchUserInvoiceRecipients = require('./fetchUserInvoiceRecipients')
 const {fetchInvoices, fetchCheckouts, postPrepopulatedForm, isCustomsDeclarationAppAvailable} = require('./customs/fetchFromCustoms')
 const {fbAuth, fbAdminAuth} = require('./fbAuth')
 
+// The user-import (member management) endpoint is only relevant to projects with
+// member management enabled (currently lspv). The deploy workflow writes this
+// generated flag from the project's `memberManagement` config; it is absent in
+// local dev / tests, where the endpoint stays disabled. Fail closed: if the
+// flag is missing or false, the route is not registered at all (404).
+let memberManagementEnabled = false
+try {
+  memberManagementEnabled = require('../member-management.generated.js')
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') throw e
+}
+
 const api = express()
 
 api.use(cors)
@@ -25,22 +37,24 @@ api.get('(/api)?/aerodrome/status', async (req, res) => {
   res.send(status)
 })
 
-api.post('(/api)?/users/import', basicAuth, async (req, res) => {
-  try {
-    const users = req.body.users
-    if (!Array.isArray(users)) {
-      return res.status(400).send('Invalid users format')
+if (memberManagementEnabled) {
+  api.post('(/api)?/users/import', basicAuth, async (req, res) => {
+    try {
+      const users = req.body.users
+      if (!Array.isArray(users)) {
+        return res.status(400).send('Invalid users format')
+      }
+
+      const db = admin.database()
+      await syncUsers(db, users)
+
+      res.status(200).send({ message: 'Users imported successfully' })
+    } catch (e) {
+      console.error('Failed to import users', e)
+      res.status(500).send({ error: 'Failed to import users' })
     }
-
-    const db = admin.database()
-    await syncUsers(db, users)
-
-    res.status(200).send({ message: 'Users imported successfully' })
-  } catch (e) {
-    console.error('Failed to import users', e)
-    res.status(500).send({ error: 'Failed to import users' })
-  }
-})
+  })
+}
 
 api.get('(/api)?/customs/invoices', fbAdminAuth, async (req, res) => {
   try {
@@ -101,3 +115,5 @@ api.get('(/api)?/users/me/invoice-recipients', fbAuth, async (req, res) => {
 })
 
 module.exports = onRequest({ region: 'europe-west1' }, api)
+// Exposed for tests (route registration depends on the member-management flag).
+module.exports.app = api

--- a/functions/api/index.spec.js
+++ b/functions/api/index.spec.js
@@ -1,0 +1,48 @@
+'use strict';
+
+// The /users/import (member management) route is registered only when the
+// generated member-management flag is truthy. The flag file is absent in tests,
+// so it is mocked per-case (virtual module).
+
+const FLAG_PATH = '../member-management.generated.js';
+
+const loadApi = (flag) => {
+  jest.resetModules();
+  jest.doMock(FLAG_PATH, () => flag, { virtual: true });
+  jest.doMock('firebase-functions/v2/https', () => ({
+    onRequest: (opts, app) => app,
+  }));
+  return require('./index').app;
+};
+
+const hasUsersImportRoute = (app) =>
+  app._router.stack.some(
+    layer => layer.route && String(layer.route.path).includes('/users/import')
+  );
+
+describe('functions', () => {
+  describe('api/index member-management gating', () => {
+    afterEach(() => {
+      jest.dontMock(FLAG_PATH);
+      jest.resetModules();
+    });
+
+    it('does not register /users/import when member management is disabled', () => {
+      const app = loadApi(false);
+      expect(hasUsersImportRoute(app)).toBe(false);
+    });
+
+    it('does not register /users/import when the flag file is missing', () => {
+      // Simulate the generated file being absent (MODULE_NOT_FOUND -> disabled).
+      jest.resetModules();
+      jest.doMock('firebase-functions/v2/https', () => ({ onRequest: (opts, app) => app }));
+      const app = require('./index').app;
+      expect(hasUsersImportRoute(app)).toBe(false);
+    });
+
+    it('registers /users/import when member management is enabled', () => {
+      const app = loadApi(true);
+      expect(hasUsersImportRoute(app)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
The POST /api/users/import route (member sync) is now registered only when the project has member management enabled (currently only lspv). The deploy workflow writes a generated flag from the project's memberManagement config (mirroring the privacy-functions gating); when it is false or missing, the route is not registered and the endpoint returns 404. Fails closed. Projects without member management — including lspl-test — no longer expose the endpoint. No frontend uses it (it is an external service-user integration). Adds tests for the gating.