### PR TITLE
Show a clear message when the sign-in code is rate limited

### DIFF
--- a/src/components/LoginPage/EmailLoginForm.tsx
+++ b/src/components/LoginPage/EmailLoginForm.tsx
@@ -68,6 +68,7 @@ const EmailLoginForm = props => {
     email,
     submitting,
     failure,
+    tooManyRequests,
     emailSent,
     otpVerificationFailure,
     updateEmail,
@@ -84,6 +85,7 @@ const EmailLoginForm = props => {
         email={email}
         submitting={submitting}
         failure={otpVerificationFailure}
+        tooManyRequests={tooManyRequests}
         onSubmit={(code) => verifyOtpCode(email, code)}
         onResend={() => sendAuthenticationEmail(email, !!queryToken)}
         onChangeEmail={resetOtp}
@@ -113,7 +115,7 @@ const EmailLoginForm = props => {
           data-cy="login-form"
         >
           <StyledLabeledComponent label={t('login.emailLabel')} component={emailInput}/>
-          {failure && <Failure failure={failure}/>}
+          {failure && <Failure failure={failure} messageKey={tooManyRequests ? 'login.tooManyRequests' : undefined}/>}
           <SubmitButton
             type="submit"
             label={t('login.loginButton')}

--- a/src/components/LoginPage/Failure.tsx
+++ b/src/components/LoginPage/Failure.tsx
@@ -10,13 +10,15 @@ const Wrapper = styled.div`
 
 const Failure = props => {
   const { t } = useTranslation();
+  const messageKey = props.messageKey || 'login.failure';
   return (
-    <Wrapper>{props.failure ? t('login.failure') : '\u00a0'}</Wrapper>
+    <Wrapper>{props.failure ? t(messageKey) : '\u00a0'}</Wrapper>
   );
 };
 
 Failure.propTypes = {
-  failure: PropTypes.bool.isRequired
+  failure: PropTypes.bool.isRequired,
+  messageKey: PropTypes.string
 };
 
 export default Failure;

--- a/src/components/LoginPage/OtpCodeForm.spec.tsx
+++ b/src/components/LoginPage/OtpCodeForm.spec.tsx
@@ -86,6 +86,16 @@ describe('OtpCodeForm', () => {
       expect(screen.getByText('login.otpResendIn')).toBeInTheDocument();
     });
 
+    it('shows the too-many-requests message when rate limited', () => {
+      renderWithTheme(<OtpCodeForm {...baseProps} tooManyRequests={true} onResend={jest.fn()} />);
+      expect(screen.getByText('login.tooManyRequests')).toBeInTheDocument();
+    });
+
+    it('does not show the too-many-requests message by default', () => {
+      renderWithTheme(<OtpCodeForm {...baseProps} onResend={jest.fn()} />);
+      expect(screen.queryByText('login.tooManyRequests')).not.toBeInTheDocument();
+    });
+
     it('submit button is disabled when no digits are entered', () => {
       renderWithTheme(<OtpCodeForm {...baseProps} />);
       expect(screen.getByRole('button', { name: /login.loginButton/ })).toBeDisabled();

--- a/src/components/LoginPage/OtpCodeForm.tsx
+++ b/src/components/LoginPage/OtpCodeForm.tsx
@@ -113,12 +113,13 @@ interface OtpCodeFormProps {
   email: string;
   submitting: boolean;
   failure: boolean;
+  tooManyRequests?: boolean;
   onSubmit: (code: string) => void;
   onResend?: () => void;
   onChangeEmail?: () => void;
 }
 
-const OtpCodeForm: React.FC<OtpCodeFormProps> = ({ email, submitting, failure, onSubmit, onResend, onChangeEmail }) => {
+const OtpCodeForm: React.FC<OtpCodeFormProps> = ({ email, submitting, failure, tooManyRequests, onSubmit, onResend, onChangeEmail }) => {
   const { t } = useTranslation();
   const [digits, setDigits] = useState<string[]>(Array(CODE_LENGTH).fill(''));
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
@@ -246,6 +247,7 @@ const OtpCodeForm: React.FC<OtpCodeFormProps> = ({ email, submitting, failure, o
         ))}
       </OtpInputsRow>
       {failure && <FailureMessage>{t('login.otpVerificationFailure')}</FailureMessage>}
+      {tooManyRequests && <FailureMessage>{t('login.tooManyRequests')}</FailureMessage>}
       <Actions>
         <Button
           type="button"

--- a/src/containers/EmailLoginFormContainer.tsx
+++ b/src/containers/EmailLoginFormContainer.tsx
@@ -11,6 +11,7 @@ const mapStateToProps = (state: RootState) => {
 
   let submitting = false;
   let failure = false;
+  let tooManyRequests = false;
   let otpVerificationFailure = false;
   let passkeyLoginSubmitting = false;
   let passkeyLoginFailure = false;
@@ -18,6 +19,7 @@ const mapStateToProps = (state: RootState) => {
   if (state.auth) {
     submitting = state.auth.submitting || false;
     failure = state.auth.failure || false;
+    tooManyRequests = state.auth.emailRateLimited || false;
     otpVerificationFailure = state.auth.otpVerificationFailure || false;
     passkeyLoginSubmitting = (state.auth.passkeyLogin && state.auth.passkeyLogin.submitting) || false;
     passkeyLoginFailure = (state.auth.passkeyLogin && state.auth.passkeyLogin.failure) || false;
@@ -27,6 +29,7 @@ const mapStateToProps = (state: RootState) => {
     email,
     submitting,
     failure,
+    tooManyRequests,
     emailSent,
     showCancel,
     otpVerificationFailure,

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -40,6 +40,7 @@
     "or": "oder",
     "hintGuestLogin": "Wenn Sie sich als Gast anmelden, können Sie nur Ihre Ankunft und Ihren Abflug erfassen. Die erfassten Bewegungen können Sie anschliessend nicht mehr einsehen.",
     "failure": "Anmeldung fehlgeschlagen",
+    "tooManyRequests": "Sie haben zu oft einen Code angefordert. Bitte warten Sie einen Moment und versuchen Sie es erneut.",
     "loginAsGuest": "Als Gast anmelden",
     "username": "Benutzername",
     "password": "Passwort",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -40,6 +40,7 @@
     "or": "or",
     "hintGuestLogin": "If you log in as a guest, you can only record your arrival and departure. You will not be able to view the recorded movements afterwards.",
     "failure": "Login failed",
+    "tooManyRequests": "You have requested a code too often. Please wait a moment and try again.",
     "loginAsGuest": "Log in as guest",
     "username": "Username",
     "password": "Password",

--- a/src/modules/auth/actions.ts
+++ b/src/modules/auth/actions.ts
@@ -44,7 +44,7 @@ export type AuthAction =
   | { type: typeof KIOSK_TOKEN_AUTHENTICATION_FAILURE }
   | { type: typeof SEND_AUTHENTICATION_EMAIL; payload: { email: string; local: boolean } }
   | { type: typeof SEND_AUTHENTICATION_EMAIL_SUCCESS }
-  | { type: typeof SEND_AUTHENTICATION_EMAIL_FAILURE }
+  | { type: typeof SEND_AUTHENTICATION_EMAIL_FAILURE; payload: { rateLimited: boolean } }
   | { type: typeof VERIFY_OTP_CODE; payload: { email: string; code: string } }
   | { type: typeof OTP_VERIFICATION_FAILURE }
   | { type: typeof REQUEST_FIREBASE_AUTHENTICATION; payload: { token: string; failureAction?: AuthAction; local?: boolean } }
@@ -141,9 +141,10 @@ export function sendAuthenticationEmailSuccess() {
   };
 }
 
-export function sendAuthenticationEmailFailure() {
+export function sendAuthenticationEmailFailure(rateLimited = false) {
   return {
     type: SEND_AUTHENTICATION_EMAIL_FAILURE,
+    payload: { rateLimited },
   };
 }
 

--- a/src/modules/auth/reducer.spec.ts
+++ b/src/modules/auth/reducer.spec.ts
@@ -6,6 +6,7 @@ const INITIAL_STATE = {
   authenticated: false,
   submitting: false,
   failure: false,
+  emailRateLimited: false,
   otpVerificationFailure: false,
   guestAuthentication: {
     submitting: false,
@@ -69,6 +70,20 @@ describe('modules', () => {
             ...INITIAL_STATE,
             submitting: false,
             failure: true,
+          });
+        });
+
+        it('should flag emailRateLimited when the failure is rate limited (429)', () => {
+          expect(
+            reducer({
+              ...INITIAL_STATE,
+              submitting: true,
+            }, actions.sendAuthenticationEmailFailure(true))
+          ).toEqual({
+            ...INITIAL_STATE,
+            submitting: false,
+            failure: true,
+            emailRateLimited: true,
           });
         });
       });

--- a/src/modules/auth/reducer.ts
+++ b/src/modules/auth/reducer.ts
@@ -28,6 +28,7 @@ interface AuthState {
   authenticated: boolean;
   submitting: boolean;
   failure: boolean;
+  emailRateLimited?: boolean;
   otpVerificationFailure?: boolean;
   guestAuthentication: GuestAuthState;
   passkeyRegistration: PasskeyRegistrationState;
@@ -46,6 +47,7 @@ const INITIAL_STATE: AuthState = {
   authenticated: false,
   submitting: false,
   failure: false,
+  emailRateLimited: false,
   otpVerificationFailure: false,
   guestAuthentication: {
     submitting: false,
@@ -62,18 +64,21 @@ const ACTION_HANDLERS = {
     return Object.assign({}, state, {
       submitting: true,
       failure: false,
+      emailRateLimited: false,
       otpVerificationFailure: false,
     });
   },
   [actions.SEND_AUTHENTICATION_EMAIL_SUCCESS]: (state: AuthState) => {
     return Object.assign({}, state, {
       submitting: false,
+      emailRateLimited: false,
     });
   },
-  [actions.SEND_AUTHENTICATION_EMAIL_FAILURE]: (state: AuthState) => {
+  [actions.SEND_AUTHENTICATION_EMAIL_FAILURE]: (state: AuthState, action: any) => {
     return Object.assign({}, state, {
       submitting: false,
       failure: true,
+      emailRateLimited: !!(action.payload && action.payload.rateLimited),
     });
   },
   [actions.REQUEST_GUEST_TOKEN_AUTHENTICATION]: (state: AuthState) => {

--- a/src/modules/auth/sagas.ts
+++ b/src/modules/auth/sagas.ts
@@ -86,9 +86,11 @@ export function* sendAuthenticationEmail(action: any) {
 
       yield put(actions.sendAuthenticationEmailSuccess());
     }
-  } catch(e) {
+  } catch(e: any) {
     logError('Failed to send authentication email', e);
-    yield put(actions.sendAuthenticationEmailFailure());
+    // A 429 means the per-email rate limit (cooldown / hourly cap) was hit;
+    // surface a distinct "too many requests" message instead of "Login failed".
+    yield put(actions.sendAuthenticationEmailFailure(e && e.status === 429));
   }
 }
 

--- a/src/util/firebase.ts
+++ b/src/util/firebase.ts
@@ -55,8 +55,10 @@ export function requestSignInCode(email: string, airportName: string, themeColor
   })
     .then(response => {
       if (!response.ok) {
-        return response.json().then(errorData => {
-          throw new Error(errorData.error || 'Failed to send sign-in code');
+        return response.json().catch(() => ({})).then((errorData: any) => {
+          const error: any = new Error(errorData.error || 'Failed to send sign-in code');
+          error.status = response.status;
+          throw error;
         });
       }
     });


### PR DESCRIPTION
Follow-up to the sign-in code rate limiting. When generateSignInCode returns 429 (cooldown or hourly cap), the email login form and the OTP screen now show a clear 'you have requested a code too often, please wait a moment and try again' message instead of the generic 'Login failed' — which was generating support tickets. The HTTP status is threaded from requestSignInCode through the auth saga into a new emailRateLimited flag in auth state, surfaced on both screens. Adds DE/EN copy and reducer + OtpCodeForm tests.