### PR TITLE
Show the retry time when the sign-in code is rate limited

### DIFF
--- a/functions/auth/generateSignInCode.js
+++ b/functions/auth/generateSignInCode.js
@@ -15,7 +15,7 @@ const CODE_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
 // OTP brute force) is blocked. The hourly cap is the sustained-abuse backstop.
 const COOLDOWN_MS = 55 * 1000;
 const RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
-const MAX_PER_WINDOW = 5;
+const MAX_PER_WINDOW = 10;
 
 const hashCode = (code) => {
   return crypto.createHash('sha256').update(code).digest('hex');
@@ -77,7 +77,22 @@ exports.generateSignInCode = onRequest({ region: 'europe-west1' }, (req, res) =>
       });
 
       if (!rateLimit.committed) {
-        return res.status(429).json({ error: 'Too many requests. Please try again later.' });
+        // Tell the caller when they can retry so the UI can show a clear
+        // "try again in X" message instead of a generic error. The aborted
+        // transaction's snapshot holds the current limiter state.
+        const current = rateLimit.snapshot && rateLimit.snapshot.val();
+        let retryAfterMs = COOLDOWN_MS;
+        if (current) {
+          retryAfterMs = current.count >= MAX_PER_WINDOW
+            ? current.windowStart + RATE_WINDOW_MS - now
+            : current.lastSentAt + COOLDOWN_MS - now;
+        }
+        const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+        res.set('Retry-After', String(retryAfterSeconds));
+        return res.status(429).json({
+          error: 'Too many requests. Please try again later.',
+          retryAfterSeconds,
+        });
       }
 
       // Keep only one live code per email: remove any existing codes first so a

--- a/functions/auth/generateSignInCode.spec.js
+++ b/functions/auth/generateSignInCode.spec.js
@@ -56,7 +56,8 @@ describe('functions', () => {
     const makeReq = (method, body) => ({ method, body });
     const makeRes = () => ({
       status: jest.fn().mockReturnThis(),
-      json: jest.fn()
+      json: jest.fn(),
+      set: jest.fn().mockReturnThis(),
     });
 
     it('returns 405 for GET request', async () => {
@@ -83,17 +84,44 @@ describe('functions', () => {
       expect(res.json).toHaveBeenCalledWith({ error: 'Invalid email format' });
     });
 
-    it('returns 429 and sends nothing when rate limited (cooldown / cap)', async () => {
-      mockTransaction.mockResolvedValue({ committed: false });
+    it('returns 429 with a retry time and sends nothing when rate limited', async () => {
+      const now = Date.now();
+      // hourly cap reached: window started ~20 min ago, so ~40 min remain
+      mockTransaction.mockResolvedValue({
+        committed: false,
+        snapshot: { val: () => ({ windowStart: now - 20 * 60 * 1000, lastSentAt: now - 1000, count: 10 }) },
+      });
 
       const req = makeReq('POST', { email: 'user@example.com' });
       const res = makeRes();
       await capturedHandler(req, res);
 
       expect(res.status).toHaveBeenCalledWith(429);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Too many requests. Please try again later.' });
+      const body = res.json.mock.calls[0][0];
+      expect(body.error).toBe('Too many requests. Please try again later.');
+      // ~40 minutes remaining (2400s), allow a small margin
+      expect(body.retryAfterSeconds).toBeGreaterThan(2300);
+      expect(body.retryAfterSeconds).toBeLessThanOrEqual(2400);
+      expect(res.set).toHaveBeenCalledWith('Retry-After', String(body.retryAfterSeconds));
       expect(mockPush).not.toHaveBeenCalled();
       expect(mockSendSignInEmail).not.toHaveBeenCalled();
+    });
+
+    it('uses the cooldown remaining for retryAfterSeconds when under the cap', async () => {
+      const now = Date.now();
+      // within cooldown: last send 10s ago, count under cap -> ~45s remain
+      mockTransaction.mockResolvedValue({
+        committed: false,
+        snapshot: { val: () => ({ windowStart: now - 5000, lastSentAt: now - 10000, count: 2 }) },
+      });
+
+      const req = makeReq('POST', { email: 'user@example.com' });
+      const res = makeRes();
+      await capturedHandler(req, res);
+
+      const body = res.json.mock.calls[0][0];
+      expect(body.retryAfterSeconds).toBeGreaterThan(40);
+      expect(body.retryAfterSeconds).toBeLessThanOrEqual(45);
     });
 
     it('deletes existing codes for the email before pushing a new one', async () => {

--- a/src/components/LoginPage/EmailLoginForm.tsx
+++ b/src/components/LoginPage/EmailLoginForm.tsx
@@ -8,6 +8,7 @@ import Button from '../Button';
 import GuestTokenLogin from '../../containers/GuestTokenLoginContainer'
 import OtpCodeForm from './OtpCodeForm';
 import PasskeyLoginButton from './PasskeyLoginButton';
+import {rateLimitMessage} from '../../util/rateLimitMessage';
 import { isPasskeySupported } from '../../util/webauthn';
 
 const handleSubmit = (authenticate, email, local, e) => {
@@ -69,6 +70,7 @@ const EmailLoginForm = props => {
     submitting,
     failure,
     tooManyRequests,
+    retryAfterSeconds,
     emailSent,
     otpVerificationFailure,
     updateEmail,
@@ -86,6 +88,7 @@ const EmailLoginForm = props => {
         submitting={submitting}
         failure={otpVerificationFailure}
         tooManyRequests={tooManyRequests}
+        retryAfterSeconds={retryAfterSeconds}
         onSubmit={(code) => verifyOtpCode(email, code)}
         onResend={() => sendAuthenticationEmail(email, !!queryToken)}
         onChangeEmail={resetOtp}
@@ -115,7 +118,10 @@ const EmailLoginForm = props => {
           data-cy="login-form"
         >
           <StyledLabeledComponent label={t('login.emailLabel')} component={emailInput}/>
-          {failure && <Failure failure={failure} messageKey={tooManyRequests ? 'login.tooManyRequests' : undefined}/>}
+          {failure && (() => {
+            const rl = tooManyRequests ? rateLimitMessage(retryAfterSeconds) : undefined;
+            return <Failure failure={failure} messageKey={rl && rl.key} messageValues={rl && rl.values}/>;
+          })()}
           <SubmitButton
             type="submit"
             label={t('login.loginButton')}

--- a/src/components/LoginPage/Failure.tsx
+++ b/src/components/LoginPage/Failure.tsx
@@ -12,13 +12,14 @@ const Failure = props => {
   const { t } = useTranslation();
   const messageKey = props.messageKey || 'login.failure';
   return (
-    <Wrapper>{props.failure ? t(messageKey) : '\u00a0'}</Wrapper>
+    <Wrapper>{props.failure ? (t(messageKey, props.messageValues) as string) : '\u00a0'}</Wrapper>
   );
 };
 
 Failure.propTypes = {
   failure: PropTypes.bool.isRequired,
-  messageKey: PropTypes.string
+  messageKey: PropTypes.string,
+  messageValues: PropTypes.object
 };
 
 export default Failure;

--- a/src/components/LoginPage/OtpCodeForm.spec.tsx
+++ b/src/components/LoginPage/OtpCodeForm.spec.tsx
@@ -91,6 +91,11 @@ describe('OtpCodeForm', () => {
       expect(screen.getByText('login.tooManyRequests')).toBeInTheDocument();
     });
 
+    it('shows the minutes message when the retry time is more than a minute', () => {
+      renderWithTheme(<OtpCodeForm {...baseProps} tooManyRequests={true} retryAfterSeconds={15 * 60} onResend={jest.fn()} />);
+      expect(screen.getByText('login.tooManyRequestsMinutes')).toBeInTheDocument();
+    });
+
     it('does not show the too-many-requests message by default', () => {
       renderWithTheme(<OtpCodeForm {...baseProps} onResend={jest.fn()} />);
       expect(screen.queryByText('login.tooManyRequests')).not.toBeInTheDocument();

--- a/src/components/LoginPage/OtpCodeForm.tsx
+++ b/src/components/LoginPage/OtpCodeForm.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import { useTranslation, Trans } from 'react-i18next';
 import Button from '../Button';
+import {rateLimitMessage} from '../../util/rateLimitMessage';
 
 const CODE_LENGTH = 6;
 const RESEND_COOLDOWN_SECONDS = 60;
@@ -114,12 +115,13 @@ interface OtpCodeFormProps {
   submitting: boolean;
   failure: boolean;
   tooManyRequests?: boolean;
+  retryAfterSeconds?: number;
   onSubmit: (code: string) => void;
   onResend?: () => void;
   onChangeEmail?: () => void;
 }
 
-const OtpCodeForm: React.FC<OtpCodeFormProps> = ({ email, submitting, failure, tooManyRequests, onSubmit, onResend, onChangeEmail }) => {
+const OtpCodeForm: React.FC<OtpCodeFormProps> = ({ email, submitting, failure, tooManyRequests, retryAfterSeconds, onSubmit, onResend, onChangeEmail }) => {
   const { t } = useTranslation();
   const [digits, setDigits] = useState<string[]>(Array(CODE_LENGTH).fill(''));
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
@@ -247,7 +249,10 @@ const OtpCodeForm: React.FC<OtpCodeFormProps> = ({ email, submitting, failure, t
         ))}
       </OtpInputsRow>
       {failure && <FailureMessage>{t('login.otpVerificationFailure')}</FailureMessage>}
-      {tooManyRequests && <FailureMessage>{t('login.tooManyRequests')}</FailureMessage>}
+      {tooManyRequests && (() => {
+        const rl = rateLimitMessage(retryAfterSeconds);
+        return <FailureMessage>{t(rl.key, rl.values)}</FailureMessage>;
+      })()}
       <Actions>
         <Button
           type="button"

--- a/src/containers/EmailLoginFormContainer.tsx
+++ b/src/containers/EmailLoginFormContainer.tsx
@@ -12,6 +12,7 @@ const mapStateToProps = (state: RootState) => {
   let submitting = false;
   let failure = false;
   let tooManyRequests = false;
+  let retryAfterSeconds: number | undefined;
   let otpVerificationFailure = false;
   let passkeyLoginSubmitting = false;
   let passkeyLoginFailure = false;
@@ -20,6 +21,7 @@ const mapStateToProps = (state: RootState) => {
     submitting = state.auth.submitting || false;
     failure = state.auth.failure || false;
     tooManyRequests = state.auth.emailRateLimited || false;
+    retryAfterSeconds = state.auth.emailRetryAfterSeconds;
     otpVerificationFailure = state.auth.otpVerificationFailure || false;
     passkeyLoginSubmitting = (state.auth.passkeyLogin && state.auth.passkeyLogin.submitting) || false;
     passkeyLoginFailure = (state.auth.passkeyLogin && state.auth.passkeyLogin.failure) || false;
@@ -30,6 +32,7 @@ const mapStateToProps = (state: RootState) => {
     submitting,
     failure,
     tooManyRequests,
+    retryAfterSeconds,
     emailSent,
     showCancel,
     otpVerificationFailure,

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -41,6 +41,7 @@
     "hintGuestLogin": "Wenn Sie sich als Gast anmelden, können Sie nur Ihre Ankunft und Ihren Abflug erfassen. Die erfassten Bewegungen können Sie anschliessend nicht mehr einsehen.",
     "failure": "Anmeldung fehlgeschlagen",
     "tooManyRequests": "Sie haben zu oft einen Code angefordert. Bitte warten Sie einen Moment und versuchen Sie es erneut.",
+    "tooManyRequestsMinutes": "Sie haben zu oft einen Code angefordert. Bitte versuchen Sie es in etwa {{minutes}} Minuten erneut.",
     "loginAsGuest": "Als Gast anmelden",
     "username": "Benutzername",
     "password": "Passwort",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -41,6 +41,7 @@
     "hintGuestLogin": "If you log in as a guest, you can only record your arrival and departure. You will not be able to view the recorded movements afterwards.",
     "failure": "Login failed",
     "tooManyRequests": "You have requested a code too often. Please wait a moment and try again.",
+    "tooManyRequestsMinutes": "You have requested a code too often. Please try again in about {{minutes}} minutes.",
     "loginAsGuest": "Log in as guest",
     "username": "Username",
     "password": "Password",

--- a/src/modules/auth/actions.ts
+++ b/src/modules/auth/actions.ts
@@ -44,7 +44,7 @@ export type AuthAction =
   | { type: typeof KIOSK_TOKEN_AUTHENTICATION_FAILURE }
   | { type: typeof SEND_AUTHENTICATION_EMAIL; payload: { email: string; local: boolean } }
   | { type: typeof SEND_AUTHENTICATION_EMAIL_SUCCESS }
-  | { type: typeof SEND_AUTHENTICATION_EMAIL_FAILURE; payload: { rateLimited: boolean } }
+  | { type: typeof SEND_AUTHENTICATION_EMAIL_FAILURE; payload: { rateLimited: boolean; retryAfterSeconds?: number } }
   | { type: typeof VERIFY_OTP_CODE; payload: { email: string; code: string } }
   | { type: typeof OTP_VERIFICATION_FAILURE }
   | { type: typeof REQUEST_FIREBASE_AUTHENTICATION; payload: { token: string; failureAction?: AuthAction; local?: boolean } }
@@ -141,10 +141,10 @@ export function sendAuthenticationEmailSuccess() {
   };
 }
 
-export function sendAuthenticationEmailFailure(rateLimited = false) {
+export function sendAuthenticationEmailFailure(rateLimited = false, retryAfterSeconds?: number) {
   return {
     type: SEND_AUTHENTICATION_EMAIL_FAILURE,
-    payload: { rateLimited },
+    payload: { rateLimited, retryAfterSeconds },
   };
 }
 

--- a/src/modules/auth/reducer.spec.ts
+++ b/src/modules/auth/reducer.spec.ts
@@ -73,17 +73,18 @@ describe('modules', () => {
           });
         });
 
-        it('should flag emailRateLimited when the failure is rate limited (429)', () => {
+        it('should flag emailRateLimited and store the retry time when rate limited (429)', () => {
           expect(
             reducer({
               ...INITIAL_STATE,
               submitting: true,
-            }, actions.sendAuthenticationEmailFailure(true))
+            }, actions.sendAuthenticationEmailFailure(true, 900))
           ).toEqual({
             ...INITIAL_STATE,
             submitting: false,
             failure: true,
             emailRateLimited: true,
+            emailRetryAfterSeconds: 900,
           });
         });
       });

--- a/src/modules/auth/reducer.ts
+++ b/src/modules/auth/reducer.ts
@@ -29,6 +29,7 @@ interface AuthState {
   submitting: boolean;
   failure: boolean;
   emailRateLimited?: boolean;
+  emailRetryAfterSeconds?: number;
   otpVerificationFailure?: boolean;
   guestAuthentication: GuestAuthState;
   passkeyRegistration: PasskeyRegistrationState;
@@ -48,6 +49,7 @@ const INITIAL_STATE: AuthState = {
   submitting: false,
   failure: false,
   emailRateLimited: false,
+  emailRetryAfterSeconds: undefined,
   otpVerificationFailure: false,
   guestAuthentication: {
     submitting: false,
@@ -65,6 +67,7 @@ const ACTION_HANDLERS = {
       submitting: true,
       failure: false,
       emailRateLimited: false,
+      emailRetryAfterSeconds: undefined,
       otpVerificationFailure: false,
     });
   },
@@ -72,6 +75,7 @@ const ACTION_HANDLERS = {
     return Object.assign({}, state, {
       submitting: false,
       emailRateLimited: false,
+      emailRetryAfterSeconds: undefined,
     });
   },
   [actions.SEND_AUTHENTICATION_EMAIL_FAILURE]: (state: AuthState, action: any) => {
@@ -79,6 +83,7 @@ const ACTION_HANDLERS = {
       submitting: false,
       failure: true,
       emailRateLimited: !!(action.payload && action.payload.rateLimited),
+      emailRetryAfterSeconds: action.payload && action.payload.retryAfterSeconds,
     });
   },
   [actions.REQUEST_GUEST_TOKEN_AUTHENTICATION]: (state: AuthState) => {

--- a/src/modules/auth/sagas.ts
+++ b/src/modules/auth/sagas.ts
@@ -89,8 +89,10 @@ export function* sendAuthenticationEmail(action: any) {
   } catch(e: any) {
     logError('Failed to send authentication email', e);
     // A 429 means the per-email rate limit (cooldown / hourly cap) was hit;
-    // surface a distinct "too many requests" message instead of "Login failed".
-    yield put(actions.sendAuthenticationEmailFailure(e && e.status === 429));
+    // surface a distinct "too many requests" message (with the retry time)
+    // instead of "Login failed".
+    const rateLimited = !!(e && e.status === 429);
+    yield put(actions.sendAuthenticationEmailFailure(rateLimited, rateLimited ? e.retryAfterSeconds : undefined));
   }
 }
 

--- a/src/util/firebase.ts
+++ b/src/util/firebase.ts
@@ -58,6 +58,7 @@ export function requestSignInCode(email: string, airportName: string, themeColor
         return response.json().catch(() => ({})).then((errorData: any) => {
           const error: any = new Error(errorData.error || 'Failed to send sign-in code');
           error.status = response.status;
+          error.retryAfterSeconds = errorData.retryAfterSeconds;
           throw error;
         });
       }

--- a/src/util/rateLimitMessage.spec.ts
+++ b/src/util/rateLimitMessage.spec.ts
@@ -1,0 +1,18 @@
+import {rateLimitMessage} from './rateLimitMessage';
+
+describe('rateLimitMessage', () => {
+  it('returns the generic message when no retry time is given', () => {
+    expect(rateLimitMessage(undefined)).toEqual({ key: 'login.tooManyRequests' });
+  });
+
+  it('returns the generic message for short waits (<= 60s cooldown)', () => {
+    expect(rateLimitMessage(55)).toEqual({ key: 'login.tooManyRequests' });
+    expect(rateLimitMessage(60)).toEqual({ key: 'login.tooManyRequests' });
+  });
+
+  it('returns the minutes message (rounded up) for longer waits', () => {
+    expect(rateLimitMessage(61)).toEqual({ key: 'login.tooManyRequestsMinutes', values: { minutes: 2 } });
+    expect(rateLimitMessage(15 * 60)).toEqual({ key: 'login.tooManyRequestsMinutes', values: { minutes: 15 } });
+    expect(rateLimitMessage(15 * 60 + 1)).toEqual({ key: 'login.tooManyRequestsMinutes', values: { minutes: 16 } });
+  });
+});

--- a/src/util/rateLimitMessage.ts
+++ b/src/util/rateLimitMessage.ts
@@ -1,0 +1,13 @@
+// Picks the translation key (and interpolation values) for a sign-in code rate
+// limit, based on the server-provided retry time. Short waits (the ~55s
+// cooldown) get a generic "wait a moment" message; longer waits (the hourly cap)
+// get a "try again in about X minutes" message.
+export function rateLimitMessage(retryAfterSeconds?: number): { key: string; values?: { minutes: number } } {
+  if (retryAfterSeconds && retryAfterSeconds > 60) {
+    return {
+      key: 'login.tooManyRequestsMinutes',
+      values: { minutes: Math.ceil(retryAfterSeconds / 60) },
+    };
+  }
+  return { key: 'login.tooManyRequests' };
+}


### PR DESCRIPTION
Builds on the sign-in code rate limiting. The 429 response now includes retryAfterSeconds (and a Retry-After header), threaded through to the UI so the email-login form and the OTP screen show a clear 'please try again in about X minutes' message for the hourly-cap case (short cooldowns keep the existing 'wait a moment' message). Also raises the hourly cap from 5 to 10 so legitimate retries (lost emails, spam folder) have more headroom before hitting it. Adds a rateLimitMessage helper + tests, backend retry-time tests, and reducer/OTP coverage.