### PR TITLE
Enable passkeys for lszo test environment

### DIFF
--- a/projects/lszo.json
+++ b/projects/lszo.json
@@ -39,7 +39,8 @@
     "test": {
       "firebaseProjectId": "lszo-test",
       "firebaseDatabaseUrl": "https://lszo-test-eu.europe-west1.firebasedatabase.app",
-      "firebaseApiKey": "AIzaSyB6YhIf-vJBbSFgNZxcUH5NTk1MRWJGIAU"
+      "firebaseApiKey": "AIzaSyB6YhIf-vJBbSFgNZxcUH5NTk1MRWJGIAU",
+      "passkeysEnabled": true
     },
     "production": {
       "firebaseProjectId": "lszo-prod",


### PR DESCRIPTION
Turns on the `passkeysEnabled` flag for the `lszo-test` environment so
the existing WebAuthn passkey feature becomes available on Luzern-
Beromünster's test site. Production stays off until verified on test.

## Prerequisites (done)
- `WEBAUTHN_RPID` / `WEBAUTHN_ORIGINS` set on the `lszo_test` GitHub
  environment (`lszo-test.web.app` / `https://lszo-test.web.app`),
  matching the lszm/lszt pattern. The dev workflow writes these into
  `functions/.env.lszo-test` at deploy time.
- `loginForm` is already `email` (required for the passkey button).
- WebAuthn cloud functions and RTDB rules are shared and already
  deployed for lszo.

## Verification
- Config merge resolves to `passkeysEnabled: true`; `tsc` clean;
  passkey unit tests pass; `npm run build --project=lszo` bakes the
  flag into the bundle.
- Post-deploy: register a passkey from the profile on
  https://lszo-test.web.app, sign out, sign in with the passkey.

## Follow-up
Production enablement is a separate change: add the flag to
`environments.production` and set the WebAuthn vars on `lszo_prod`.