### PR TITLE
Make counter fields directly writable in wizards

### DIFF
--- a/src/components/IncrementationField/IncrementationField.spec.tsx
+++ b/src/components/IncrementationField/IncrementationField.spec.tsx
@@ -7,12 +7,12 @@ describe('components', () => {
   describe('IncrementationField', () => {
     it('renders the provided value', () => {
       render(<IncrementationField value={42} />);
-      expect(screen.getByText('42')).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toHaveValue('42');
     });
 
     it('renders minValue when value is undefined', () => {
       render(<IncrementationField minValue={3} />);
-      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toHaveValue('3');
     });
 
     it('calls onChange with incremented value on increment click', async () => {
@@ -48,6 +48,60 @@ describe('components', () => {
       await user.click(screen.getByRole('button', { name: '-' }));
 
       expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ target: { value: 3 } });
+    });
+
+    it('commits a typed value on blur', async () => {
+      const user = userEvent.setup();
+      const handler = jest.fn();
+
+      render(<IncrementationField value={0} onChange={handler} />);
+
+      const input = screen.getByRole('textbox');
+      await user.click(input);
+      await user.type(input, '17');
+      await user.tab();
+
+      expect(handler).toHaveBeenCalledWith({ target: { value: 17 } });
+    });
+
+    it('ignores non-digit input', async () => {
+      const user = userEvent.setup();
+      const handler = jest.fn();
+
+      render(<IncrementationField value={5} onChange={handler} />);
+
+      const input = screen.getByRole('textbox');
+      await user.click(input);
+      await user.type(input, 'ab-.e');
+
+      expect(input).toHaveValue('5');
+    });
+
+    it('commits minValue when cleared and blurred', async () => {
+      const user = userEvent.setup();
+      const handler = jest.fn();
+
+      render(<IncrementationField value={5} minValue={2} onChange={handler} />);
+
+      const input = screen.getByRole('textbox');
+      await user.clear(input);
+      await user.tab();
+
+      expect(handler).toHaveBeenCalledWith({ target: { value: 2 } });
+    });
+
+    it('clamps a typed value below minValue on blur', async () => {
+      const user = userEvent.setup();
+      const handler = jest.fn();
+
+      render(<IncrementationField value={5} minValue={3} onChange={handler} />);
+
+      const input = screen.getByRole('textbox');
+      await user.clear(input);
+      await user.type(input, '1');
+      await user.tab();
+
       expect(handler).toHaveBeenCalledWith({ target: { value: 3 } });
     });
 

--- a/src/components/IncrementationField/IncrementationField.tsx
+++ b/src/components/IncrementationField/IncrementationField.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Button from './Button';
 import Value from './Value';
+import Input from './Input';
 
 interface IncrementationFieldProps {
   value?: number;
@@ -19,11 +20,32 @@ const IncrementationField: React.FC<IncrementationFieldProps> = ({
 }) => {
   const value = typeof valueProp === 'undefined' ? minValue : valueProp;
 
+  const [editingValue, setEditingValue] = useState<string | null>(null);
+
   const change = (newValue: number) => {
     if (newValue < minValue) newValue = minValue;
     if (typeof onChange === 'function') {
       onChange({ target: { value: newValue } });
     }
+  };
+
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    e.target.select();
+    setEditingValue(e.target.value);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (/^\d*$/.test(e.target.value)) {
+      setEditingValue(e.target.value);
+    }
+  };
+
+  const handleBlur = () => {
+    const parsed = /^\d+$/.test(editingValue ?? '')
+      ? parseInt(editingValue as string, 10)
+      : minValue;
+    setEditingValue(null);
+    change(parsed);
   };
 
   if (readOnly === true) {
@@ -37,7 +59,15 @@ const IncrementationField: React.FC<IncrementationFieldProps> = ({
   return (
     <div>
       <Button type="button" onClick={() => change(value - 1)} data-cy={`${dataCy}-decrement`}>-</Button>
-      <Value>{value}</Value>
+      <Input
+        type="text"
+        inputMode="numeric"
+        value={editingValue !== null ? editingValue : String(value)}
+        onFocus={handleFocus}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        data-cy={`${dataCy}-input`}
+      />
       <Button type="button" onClick={() => change(value + 1)} data-cy={`${dataCy}-increment`}>+</Button>
     </div>
   );

--- a/src/components/IncrementationField/Input.tsx
+++ b/src/components/IncrementationField/Input.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Input = styled.input`
+  border: 0;
+  background-color: transparent;
+  font-size: 1em;
+  width: 3em;
+  padding: 1em 0;
+  text-align: center;
+`;
+
+export default Input;


### PR DESCRIPTION
## Problem

In the movement wizard forms, the passenger counter (and the landing /
go-around counters, which share the same component) could only be
adjusted with the `+`/`-` buttons. Entering a large value — e.g. 17
passengers — meant clicking `+` seventeen times.

## Change

The shared `IncrementationField` now renders a text input alongside the
`+`/`-` buttons, so the value can be typed directly — mirroring how the
time fields already work.

- Digit-only input (`/^\d*$/`); non-digits and `-` are rejected as you
  type, so negative values are impossible.
- The typed value is committed on blur and clamped to `minValue`
  (default 0); an empty field resolves to `minValue`.
- The `+`/`-` buttons and the `onChange({ target: { value } })` contract
  are unchanged, so the landing/go-around fee recomputation keeps working.

Because the component is shared, passenger, landing and go-around
counters all become writable.

## Verification

- `npm run typecheck` clean; full Jest suite passes (2281 tests).
- Extended `IncrementationField.spec.tsx`: typing → commit on blur,
  clear → minValue, clamp below minValue, non-digit rejection, buttons
  unchanged.
- `npm run build --project=lszm` compiles.