### PR TITLE
Fix iOS autofill of the sign-in code

### DIFF
--- a/src/components/LoginPage/OtpCodeForm.spec.tsx
+++ b/src/components/LoginPage/OtpCodeForm.spec.tsx
@@ -297,6 +297,42 @@ describe('OtpCodeForm', () => {
     });
   });
 
+  // ─── Autofill ─────────────────────────────────────────────────────────────
+
+  // iOS Security-Code AutoFill drops the whole code into the focused (first)
+  // field in a single change event, rather than one digit per box.
+  describe('autofill', () => {
+    it('spreads the whole code across all inputs when it lands in the first field', () => {
+      renderWithTheme(<OtpCodeForm {...baseProps} />);
+      const inputs = getDigits();
+      fireEvent.change(inputs[0], { target: { value: '123456' } });
+      expect(inputs[0]).toHaveValue('1');
+      expect(inputs[1]).toHaveValue('2');
+      expect(inputs[2]).toHaveValue('3');
+      expect(inputs[3]).toHaveValue('4');
+      expect(inputs[4]).toHaveValue('5');
+      expect(inputs[5]).toHaveValue('6');
+    });
+
+    it('auto-submits when the whole code is autofilled into the first field', () => {
+      const onSubmit = jest.fn();
+      renderWithTheme(<OtpCodeForm {...baseProps} onSubmit={onSubmit} />);
+      const inputs = getDigits();
+      fireEvent.change(inputs[0], { target: { value: '246813' } });
+      act(() => { jest.runAllTimers(); });
+      expect(onSubmit).toHaveBeenCalledWith('246813');
+    });
+
+    it('does not overflow when a multi-digit value lands in a later field', () => {
+      renderWithTheme(<OtpCodeForm {...baseProps} />);
+      const inputs = getDigits();
+      fireEvent.change(inputs[4], { target: { value: '123456' } });
+      // only the two remaining slots (index 4 and 5) are filled
+      expect(inputs[4]).toHaveValue('1');
+      expect(inputs[5]).toHaveValue('2');
+    });
+  });
+
   // ─── Auto-submit ──────────────────────────────────────────────────────────
 
   describe('auto-submit', () => {

--- a/src/components/LoginPage/OtpCodeForm.tsx
+++ b/src/components/LoginPage/OtpCodeForm.tsx
@@ -156,8 +156,36 @@ const OtpCodeForm: React.FC<OtpCodeFormProps> = ({ email, submitting, failure, t
     }
   }, [onSubmit, submitting]);
 
+  // Spreads a run of digits across the boxes starting at startIndex, moves
+  // focus to the last filled box and auto-submits once all six are present.
+  // Shared by paste and by autofill (iOS drops the whole code into one field).
+  const fillFrom = useCallback((startIndex: number, digitsStr: string) => {
+    setDigits(prev => {
+      const next = [...prev];
+      for (let i = 0; i < digitsStr.length && startIndex + i < CODE_LENGTH; i++) {
+        next[startIndex + i] = digitsStr[i];
+      }
+
+      const focusIndex = Math.min(startIndex + digitsStr.length, CODE_LENGTH - 1);
+      setTimeout(() => focusInput(focusIndex), 0);
+
+      const code = next.join('');
+      if (code.length === CODE_LENGTH && next.every(d => d !== '')) {
+        setTimeout(() => submitCode(code), 0);
+      }
+      return next;
+    });
+  }, [focusInput, submitCode]);
+
   const handleChange = useCallback((index: number, value: string) => {
-    const digit = value.replace(/\D/g, '').slice(-1);
+    const cleaned = value.replace(/\D/g, '');
+    // Autofill (or a paste landing in a field) delivers the whole code to a
+    // single input; spread it across the boxes instead of keeping one digit.
+    if (cleaned.length > 1) {
+      fillFrom(index, cleaned.slice(0, CODE_LENGTH - index));
+      return;
+    }
+    const digit = cleaned.slice(-1);
     setDigits(prev => {
       const next = [...prev];
       next[index] = digit;
@@ -170,7 +198,7 @@ const OtpCodeForm: React.FC<OtpCodeFormProps> = ({ email, submitting, failure, t
       }
       return next;
     });
-  }, [focusInput, submitCode]);
+  }, [fillFrom, focusInput, submitCode]);
 
   const handleKeyDown = useCallback((index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Backspace') {
@@ -200,20 +228,9 @@ const OtpCodeForm: React.FC<OtpCodeFormProps> = ({ email, submitting, failure, t
     e.preventDefault();
     const pasted = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, CODE_LENGTH);
     if (!pasted) return;
-
-    const next = Array(CODE_LENGTH).fill('');
-    for (let i = 0; i < pasted.length; i++) {
-      next[i] = pasted[i];
-    }
-    setDigits(next);
-
-    const focusIndex = Math.min(pasted.length, CODE_LENGTH - 1);
-    setTimeout(() => focusInput(focusIndex), 0);
-
-    if (pasted.length === CODE_LENGTH) {
-      setTimeout(() => submitCode(pasted), 0);
-    }
-  }, [focusInput, submitCode]);
+    setDigits(Array(CODE_LENGTH).fill(''));
+    fillFrom(0, pasted);
+  }, [fillFrom]);
 
   const code = digits.join('');
   const isComplete = code.length === CODE_LENGTH && digits.every(d => d !== '');
@@ -235,9 +252,8 @@ const OtpCodeForm: React.FC<OtpCodeFormProps> = ({ email, submitting, failure, t
             type="text"
             inputMode="numeric"
             pattern="[0-9]*"
-            maxLength={1}
             value={digit}
-            autoComplete={index === 0 ? 'one-time-code' : 'off'}
+            autoComplete="one-time-code"
             autoFocus={index === 0}
             disabled={submitting}
             $filled={digit !== ''}


### PR DESCRIPTION
## Problem

On iOS, when the 6-digit email sign-in code is offered above the keyboard
("From email: 123456"), tapping it filled **only the first digit**.
Reported by an LSZO customer; reproduced on `lszo-test.web.app` with
Brave + Apple Mail.

## Cause

The code field is six separate `<input maxLength={1}>` boxes, and only
the first was marked `autoComplete="one-time-code"` (the rest were
`off`). iOS Security-Code AutoFill inserts the **whole code into one
field**; `maxLength={1}` truncated it to one digit and `handleChange`
kept only the last character, discarding the other five.

## Fix (`src/components/LoginPage/OtpCodeForm.tsx`)

- Remove the per-box `maxLength={1}` (single-char display is already
  enforced by the controlled `value`), so the full autofilled code
  reaches `onChange`.
- Mark every box `autoComplete="one-time-code"`.
- Spread a multi-character value across the boxes — the same
  distribution logic the paste handler used, factored into a shared
  `fillFrom(startIndex, digits)` helper — and auto-submit when complete.

Keeps the segmented UI, the `data-cy` handles, and all existing keyboard
/ paste behaviour unchanged.

## Notes / scope

- Applies to **all iOS browsers** (Brave, Chrome, etc. are all WebKit).
- Codes arriving in the **Gmail app** are unaffected by this or any code
  change — iOS only auto-suggests codes from the **Apple Mail** app.
  Those users continue to copy-paste, which already works.

## Verification

- `npm run typecheck` clean; full Jest suite green (2284 tests).
- `OtpCodeForm.spec.tsx` extended with an autofill group: a single
  change carrying the whole code into the first field fills all six boxes
  and auto-submits.
- `npm run build --project=lszm` compiles.
- On-device final check pending after deploy to `lszo-test` (cannot be
  tested in-repo; the jest autofill test is the local proxy).