### PR TITLE
Scroll to top on movement wizard step change

### DIFF
--- a/src/components/wizards/MovementWizard.spec.tsx
+++ b/src/components/wizards/MovementWizard.spec.tsx
@@ -249,6 +249,41 @@ describe('MovementWizard', () => {
     });
   });
 
+  describe('scroll to top on step change', () => {
+    let scrollToSpy: jest.Mock;
+    let originalScrollTo: typeof window.scrollTo;
+
+    beforeEach(() => {
+      originalScrollTo = window.scrollTo;
+      scrollToSpy = jest.fn();
+      (window as any).scrollTo = scrollToSpy;
+    });
+
+    afterEach(() => {
+      (window as any).scrollTo = originalScrollTo;
+    });
+
+    it('scrolls to the top when the wizard page changes', () => {
+      const props = createProps();
+      const { rerender } = render(<MovementWizard {...props} />);
+      scrollToSpy.mockClear();
+
+      rerender(<MovementWizard {...props} wizard={{ ...props.wizard, page: 2 }} />);
+
+      expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('does not scroll when the page stays the same', () => {
+      const props = createProps();
+      const { rerender } = render(<MovementWizard {...props} />);
+      scrollToSpy.mockClear();
+
+      rerender(<MovementWizard {...props} locked={true} />);
+
+      expect(scrollToSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('commit error', () => {
     it('renders CommitFailureDialog when commitError is set', () => {
       render(<MovementWizard {...createProps({

--- a/src/components/wizards/MovementWizard.tsx
+++ b/src/components/wizards/MovementWizard.tsx
@@ -73,6 +73,14 @@ const MovementWizard = (props: MovementWizardProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Wizard steps change a Redux page index without a route change, so the
+  // app-level scroll-to-top (keyed on the location) never fires between
+  // steps. Reset the scroll on every step change so the flight type and
+  // step header at the top of the page stay visible on mobile.
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [props.wizard.page]);
+
   const isUpdate = typeof params.key === 'string' && params.key.length > 0;
 
   const breadcrumbItems = props.pages.map(page => ({


### PR DESCRIPTION
## Problem

Customer (LSZO) feedback: on mobile, the flight type (Private, Para Drop,
etc.) is not always visible when moving through the movement wizard —
switching to the next step keeps the previous scroll position, leaving
the flight-type field and step header (both near the top) off-screen.

## Cause

Wizard steps are driven by a Redux `page` index, **without a URL
change**. The app-level scroll-to-top (`App.tsx`, keyed on the route
location) therefore never fires between wizard steps. On mobile the whole
window scrolls, so the retained position carries over.

## Fix

Add a `useEffect` in `MovementWizard.tsx` that calls
`window.scrollTo(0, 0)` whenever `wizard.page` changes — firing on both
Next and Back. Reuses the exact call already used in `App.tsx`.

## Verification

- `npm run typecheck` clean; full Jest suite green (2286 tests).
- Added `MovementWizard.spec.tsx` tests: scrolls to top on page change,
  does not scroll on an unrelated re-render.
- `npm run build --project=lszm` compiles.
- Manual mobile check pending after deploy: scroll down on a step, tap
  Next/Back, confirm the new step opens at the top.