### PR TITLE
Enable passkeys for lszo production

### DIFF
--- a/projects/lszo.json
+++ b/projects/lszo.json
@@ -45,7 +45,8 @@
     "production": {
       "firebaseProjectId": "lszo-prod",
       "firebaseDatabaseUrl": "https://lszo-prod-default-rtdb.europe-west1.firebasedatabase.app",
-      "firebaseApiKey": "AIzaSyCSNFVN4__gWMYKLYfxyg6Dr7SIvzpdpgE"
+      "firebaseApiKey": "AIzaSyCSNFVN4__gWMYKLYfxyg6Dr7SIvzpdpgE",
+      "passkeysEnabled": true
     }
   },
   "theme": "lszo",


### PR DESCRIPTION
## Summary

- Adds `passkeysEnabled: true` to the `production` environment in `projects/lszo.json`

## Note

The GitHub `lszo_prod` environment must have `WEBAUTHN_RPID`, `WEBAUTHN_RPNAME`, and `WEBAUTHN_ORIGINS` variables set before deploying, matching the production domain.