### PR TITLE
Add aerodrome quick-picks to movement wizard

### DIFF
--- a/src/components/AerodromeDropdown/AerodromeDropdown.spec.tsx
+++ b/src/components/AerodromeDropdown/AerodromeDropdown.spec.tsx
@@ -14,7 +14,8 @@ describe('AerodromeDropdown', () => {
       keys.map(key => ({key, name: key})).sort(aerodromesComparator()).map(a => a.key);
 
     it('places the home aerodrome first', () => {
-      expect(sortKeys(['LSGG', 'LSZO', 'LFSB'])).toEqual(['LSZO', 'LFSB', 'LSGG']);
+      // After home (LSZO), Swiss LS aerodromes rank before non-LS ones.
+      expect(sortKeys(['LSGG', 'LSZO', 'LFSB'])).toEqual(['LSZO', 'LSGG', 'LFSB']);
     });
 
     it('keeps the home aerodrome ahead of other LS aerodromes', () => {

--- a/src/components/AerodromeDropdown/AerodromeDropdown.spec.tsx
+++ b/src/components/AerodromeDropdown/AerodromeDropdown.spec.tsx
@@ -1,0 +1,33 @@
+import {aerodromesComparator} from './AerodromeDropdown';
+
+describe('AerodromeDropdown', () => {
+  describe('aerodromesComparator', () => {
+    beforeEach(() => {
+      (global as any).__CONF__ = {aerodrome: {ICAO: 'LSZO'}};
+    });
+
+    afterEach(() => {
+      delete (global as any).__CONF__;
+    });
+
+    const sortKeys = (keys: string[]) =>
+      keys.map(key => ({key, name: key})).sort(aerodromesComparator()).map(a => a.key);
+
+    it('places the home aerodrome first', () => {
+      expect(sortKeys(['LSGG', 'LSZO', 'LFSB'])).toEqual(['LSZO', 'LFSB', 'LSGG']);
+    });
+
+    it('keeps the home aerodrome ahead of other LS aerodromes', () => {
+      expect(sortKeys(['LSZR', 'LSGG', 'LSZO'])).toEqual(['LSZO', 'LSGG', 'LSZR']);
+    });
+
+    it('still places LS aerodromes before non-LS ones', () => {
+      expect(sortKeys(['EDNY', 'LSGG', 'LFSB'])).toEqual(['LSGG', 'EDNY', 'LFSB']);
+    });
+
+    it('falls back to alphabetical when no home is configured', () => {
+      (global as any).__CONF__ = {};
+      expect(sortKeys(['LSZR', 'LSGG', 'LSZO'])).toEqual(['LSGG', 'LSZO', 'LSZR']);
+    });
+  });
+});

--- a/src/components/AerodromeDropdown/AerodromeDropdown.tsx
+++ b/src/components/AerodromeDropdown/AerodromeDropdown.tsx
@@ -8,7 +8,19 @@ const optionRenderer = (option, focussed) => (
   <Option code={option.key} name={option.name} focussed={focussed}/>
 );
 
-const aerodromesComparator = (filter?) => (aerodrome1, aerodrome2) => {
+export const aerodromesComparator = (filter?) => (aerodrome1, aerodrome2) => {
+  // Place the home aerodrome first (most common location: circuits/local flights)
+  const homeIcao = typeof __CONF__ !== 'undefined' && __CONF__.aerodrome
+    ? __CONF__.aerodrome.ICAO
+    : undefined;
+  if (homeIcao) {
+    const isHome1 = aerodrome1.key.toUpperCase() === homeIcao;
+    const isHome2 = aerodrome2.key.toUpperCase() === homeIcao;
+
+    if (isHome1 && !isHome2) return -1;
+    if (!isHome1 && isHome2) return 1;
+  }
+
   // Place "LS" aerodromes first
   const isLS1 = aerodrome1.key.toUpperCase().startsWith("LS");
   const isLS2 = aerodrome2.key.toUpperCase().startsWith("LS");

--- a/src/components/LabeledComponent/LabeledComponent.spec.tsx
+++ b/src/components/LabeledComponent/LabeledComponent.spec.tsx
@@ -8,5 +8,16 @@ describe('components', () => {
       const { container } = render(<LabeledComponent label="My label" component={<input type="text" id="my-input"/>}/>);
       expect(container).toMatchSnapshot();
     });
+
+    it('renders a footer when provided', () => {
+      const { getByTestId } = render(
+        <LabeledComponent
+          label="My label"
+          component={<input type="text" id="my-input"/>}
+          footer={<div data-testid="footer">chips</div>}
+        />
+      );
+      expect(getByTestId('footer')).toBeTruthy();
+    });
   });
 });

--- a/src/components/LabeledComponent/LabeledComponent.tsx
+++ b/src/components/LabeledComponent/LabeledComponent.tsx
@@ -11,6 +11,10 @@ interface LabeledComponentProps {
   className?: string;
   validationError?: string | null;
   tooltip?: string;
+  // Rendered inside the field wrapper, below the input but outside the input's
+  // ComponentContainer, so it shares the field width without inheriting the input
+  // sizing (e.g. quick-pick chips under a dropdown).
+  footer?: React.ReactNode;
 }
 
 const LabeledComponent: React.FC<LabeledComponentProps> = ({
@@ -19,6 +23,7 @@ const LabeledComponent: React.FC<LabeledComponentProps> = ({
   className,
   validationError,
   tooltip,
+  footer,
 }) => {
   const [tooltipVisible, setTooltipVisible] = useState(false);
 
@@ -27,6 +32,7 @@ const LabeledComponent: React.FC<LabeledComponentProps> = ({
       <Label>{label}</Label>
       {validationError && <ValidationMessage error={validationError}/>}
       <ComponentContainer>{component}</ComponentContainer>
+      {footer}
       {tooltipVisible && tooltip && <Tooltip>{tooltip}</Tooltip>}
     </Wrapper>
   );

--- a/src/components/wizards/AerodromeQuickPicks.spec.tsx
+++ b/src/components/wizards/AerodromeQuickPicks.spec.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react';
+import {ThemeProvider} from 'styled-components';
+import {Provider} from 'react-redux';
+import AerodromeQuickPicks from './AerodromeQuickPicks';
+import {loadFrequentAerodromes} from '../../modules/frequentAerodromes';
+
+const theme: any = {colors: {main: '#003863', background: '#fafafa', danger: '#e00f00'}};
+
+const makeStore = (state: any) => ({
+  getState: () => state,
+  subscribe: () => () => undefined,
+  dispatch: jest.fn(),
+});
+
+const baseState = (overrides: any = {}) => ({
+  auth: {data: {email: 'pilot@example.com', guest: false, kiosk: false, admin: false}},
+  movements: {data: {array: [
+    {location: 'LSGG', createdBy: 'pilot@example.com'},
+    {location: 'LSGG', createdBy: 'pilot@example.com'},
+    {location: 'LSZR', createdBy: 'pilot@example.com'},
+  ]}},
+  frequentAerodromes: {data: [], loaded: false},
+  ...overrides,
+});
+
+const renderWith = (state: any, props: any = {}) => {
+  const store = makeStore(state);
+  const utils = render(
+    <Provider store={store as any}>
+      <ThemeProvider theme={theme}>
+        <AerodromeQuickPicks value="" onSelect={jest.fn()} {...props}/>
+      </ThemeProvider>
+    </Provider>
+  );
+  return {store, ...utils};
+};
+
+describe('AerodromeQuickPicks', () => {
+  beforeEach(() => {
+    (global as any).__CONF__ = {aerodrome: {ICAO: 'LSZO'}, profileEnabled: true};
+  });
+
+  afterEach(() => {
+    delete (global as any).__CONF__;
+  });
+
+  it('renders the home chip plus the pilot\'s frequent aerodromes', () => {
+    const {getByTestId} = renderWith(baseState());
+    expect(getByTestId('quickpick-home').textContent).toContain('LSZO');
+    expect(getByTestId('quickpick-LSGG')).toBeTruthy();
+    expect(getByTestId('quickpick-LSZR')).toBeTruthy();
+  });
+
+  it('calls onSelect with the ICAO when a chip is clicked', () => {
+    const onSelect = jest.fn();
+    const {getByTestId} = renderWith(baseState(), {onSelect});
+    fireEvent.click(getByTestId('quickpick-LSGG'));
+    expect(onSelect).toHaveBeenCalledWith('LSGG');
+    fireEvent.click(getByTestId('quickpick-home'));
+    expect(onSelect).toHaveBeenCalledWith('LSZO');
+  });
+
+  it('shows only the home chip for a guest', () => {
+    const {getByTestId, queryByTestId} = renderWith(baseState({
+      auth: {data: {email: null, guest: true, kiosk: false}},
+    }));
+    expect(getByTestId('quickpick-home')).toBeTruthy();
+    expect(queryByTestId('quickpick-LSGG')).toBeNull();
+  });
+
+  it('renders nothing when readOnly', () => {
+    const {container} = renderWith(baseState(), {readOnly: true});
+    expect(container.querySelector('.AerodromeQuickPicks')).toBeNull();
+  });
+
+  it('does not trigger any fetch for a regular user (zero extra reads)', () => {
+    const {store} = renderWith(baseState());
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('fetches once for an admin, whose loaded list is club-wide', () => {
+    const {store, getByTestId} = renderWith(baseState({
+      auth: {data: {email: 'admin@example.com', admin: true, guest: false, kiosk: false}},
+      movements: {data: {array: [{location: 'LFSB', createdBy: 'someone@else.com'}]}},
+      frequentAerodromes: {data: ['LSZR'], loaded: false, session: []},
+    }));
+    expect(store.dispatch).toHaveBeenCalledWith(loadFrequentAerodromes());
+    // uses the fetched slice, not the club-wide movement list
+    expect(getByTestId('quickpick-LSZR')).toBeTruthy();
+  });
+});

--- a/src/components/wizards/AerodromeQuickPicks.spec.tsx
+++ b/src/components/wizards/AerodromeQuickPicks.spec.tsx
@@ -20,7 +20,7 @@ const baseState = (overrides: any = {}) => ({
     {location: 'LSGG', createdBy: 'pilot@example.com'},
     {location: 'LSZR', createdBy: 'pilot@example.com'},
   ]}},
-  frequentAerodromes: {data: [], loaded: false},
+  frequentAerodromes: {data: [], loaded: false, session: []},
   ...overrides,
 });
 
@@ -33,7 +33,8 @@ const renderWith = (state: any, props: any = {}) => {
       </ThemeProvider>
     </Provider>
   );
-  return {store, ...utils};
+  const chip = (cy: string) => utils.container.querySelector(`[data-cy="${cy}"]`);
+  return {store, chip, ...utils};
 };
 
 describe('AerodromeQuickPicks', () => {
@@ -46,27 +47,27 @@ describe('AerodromeQuickPicks', () => {
   });
 
   it('renders the home chip plus the pilot\'s frequent aerodromes', () => {
-    const {getByTestId} = renderWith(baseState());
-    expect(getByTestId('quickpick-home').textContent).toContain('LSZO');
-    expect(getByTestId('quickpick-LSGG')).toBeTruthy();
-    expect(getByTestId('quickpick-LSZR')).toBeTruthy();
+    const {chip} = renderWith(baseState());
+    expect(chip('quickpick-home')!.textContent).toContain('LSZO');
+    expect(chip('quickpick-LSGG')).toBeTruthy();
+    expect(chip('quickpick-LSZR')).toBeTruthy();
   });
 
   it('calls onSelect with the ICAO when a chip is clicked', () => {
     const onSelect = jest.fn();
-    const {getByTestId} = renderWith(baseState(), {onSelect});
-    fireEvent.click(getByTestId('quickpick-LSGG'));
+    const {chip} = renderWith(baseState(), {onSelect});
+    fireEvent.click(chip('quickpick-LSGG')!);
     expect(onSelect).toHaveBeenCalledWith('LSGG');
-    fireEvent.click(getByTestId('quickpick-home'));
+    fireEvent.click(chip('quickpick-home')!);
     expect(onSelect).toHaveBeenCalledWith('LSZO');
   });
 
   it('shows only the home chip for a guest', () => {
-    const {getByTestId, queryByTestId} = renderWith(baseState({
+    const {chip} = renderWith(baseState({
       auth: {data: {email: null, guest: true, kiosk: false}},
     }));
-    expect(getByTestId('quickpick-home')).toBeTruthy();
-    expect(queryByTestId('quickpick-LSGG')).toBeNull();
+    expect(chip('quickpick-home')).toBeTruthy();
+    expect(chip('quickpick-LSGG')).toBeNull();
   });
 
   it('renders nothing when readOnly', () => {
@@ -80,13 +81,14 @@ describe('AerodromeQuickPicks', () => {
   });
 
   it('fetches once for an admin, whose loaded list is club-wide', () => {
-    const {store, getByTestId} = renderWith(baseState({
+    const {store, chip} = renderWith(baseState({
       auth: {data: {email: 'admin@example.com', admin: true, guest: false, kiosk: false}},
       movements: {data: {array: [{location: 'LFSB', createdBy: 'someone@else.com'}]}},
       frequentAerodromes: {data: ['LSZR'], loaded: false, session: []},
     }));
     expect(store.dispatch).toHaveBeenCalledWith(loadFrequentAerodromes());
     // uses the fetched slice, not the club-wide movement list
-    expect(getByTestId('quickpick-LSZR')).toBeTruthy();
+    expect(chip('quickpick-LSZR')).toBeTruthy();
+    expect(chip('quickpick-LFSB')).toBeNull();
   });
 });

--- a/src/components/wizards/AerodromeQuickPicks.tsx
+++ b/src/components/wizards/AerodromeQuickPicks.tsx
@@ -1,0 +1,85 @@
+import React, {useEffect} from 'react';
+import {shallowEqual, useDispatch, useSelector} from 'react-redux';
+import {useTranslation} from 'react-i18next';
+import styled from 'styled-components';
+import MaterialIcon from '../MaterialIcon';
+import {Chip, FavouritesBar, StarIcon} from './QuickPickBar';
+import {loadFrequentAerodromes, selectFrequentAerodromes} from '../../modules/frequentAerodromes';
+import {canSeeAllMovements} from '../../modules/movements/sagas';
+
+// Rendered in the field wrapper below the dropdown (LabeledComponent `footer`).
+// Unlike the aircraft quick-picks, this bar has no grey box — it reads as part of
+// the field.
+const Bar = styled(FavouritesBar)`
+  margin: 0.4em 0 0;
+  padding: 0;
+  background-color: transparent;
+  border-radius: 0;
+`;
+
+interface AerodromeQuickPicksProps {
+  value?: string;
+  onSelect: (icao: string) => void;
+  readOnly?: boolean;
+}
+
+const AerodromeQuickPicks: React.FC<AerodromeQuickPicksProps> = ({value, onSelect, readOnly}) => {
+  const {t} = useTranslation();
+  const dispatch = useDispatch();
+  const auth = useSelector((state: any) => state.auth.data);
+  // selectFrequentAerodromes returns a fresh array each call; shallowEqual avoids
+  // re-rendering when its contents are unchanged.
+  const frequent = useSelector(selectFrequentAerodromes, shallowEqual);
+
+  useEffect(() => {
+    if (canSeeAllMovements(auth)) {
+      dispatch(loadFrequentAerodromes());
+    }
+  }, [dispatch, auth]);
+
+  if (readOnly) {
+    return null;
+  }
+
+  const homeIcao = typeof __CONF__ !== 'undefined' && __CONF__.aerodrome
+    ? String(__CONF__.aerodrome.ICAO).toUpperCase()
+    : undefined;
+
+  if (!homeIcao && frequent.length === 0) {
+    return null;
+  }
+
+  const normalizedValue = value ? value.toUpperCase() : undefined;
+
+  return (
+    <Bar className="AerodromeQuickPicks">
+      <StarIcon><MaterialIcon icon="star"/></StarIcon>
+      {homeIcao && (
+        <Chip
+          type="button"
+          $active={normalizedValue === homeIcao}
+          onClick={() => onSelect(homeIcao)}
+          title={t('routes.localFlight')}
+          aria-label={t('routes.localFlight')}
+          data-cy="quickpick-home"
+        >
+          <MaterialIcon icon="place" size={16}/>
+          {homeIcao}
+        </Chip>
+      )}
+      {frequent.map(icao => (
+        <Chip
+          key={icao}
+          type="button"
+          $active={normalizedValue === icao}
+          onClick={() => onSelect(icao)}
+          data-cy={`quickpick-${icao}`}
+        >
+          {icao}
+        </Chip>
+      ))}
+    </Bar>
+  );
+};
+
+export default AerodromeQuickPicks;

--- a/src/components/wizards/ArrivalWizard/pages/DepartureArrivalPage.tsx
+++ b/src/components/wizards/ArrivalWizard/pages/DepartureArrivalPage.tsx
@@ -7,6 +7,7 @@ import validate from '../../validate';
 import {renderAerodromeDropdown, renderDateField, renderIncrementationField, renderTimeField} from '../../renderField';
 import FieldSet from '../../FieldSet';
 import WizardNavigation from '../../../WizardNavigation';
+import AerodromeQuickPicks from '../../AerodromeQuickPicks';
 import {getAircraftOrigin, updateFeesTotal, updateGoAroundFees, updateLandingFees} from '../../../../util/landingFees'
 
 const toNumber = value => {
@@ -28,7 +29,7 @@ const DepartureArrivalPage = (props) => {
       validate={validate('arrival', ['location', 'date', 'time', 'landingCount'], hiddenFields)}
       onSubmit={onSubmit}
     >
-      {({handleSubmit, form}) => (
+      {({handleSubmit, form, values}) => (
         <form onSubmit={handleSubmit} className="DepartureArrivalPage">
           <FieldSet>
             <Field
@@ -45,6 +46,13 @@ const DepartureArrivalPage = (props) => {
                   },
                   meta,
                   label: t('movement.details.origin'),
+                  footer: (
+                    <AerodromeQuickPicks
+                      value={values.location}
+                      onSelect={icao => form.change('location', icao)}
+                      readOnly={readOnly}
+                    />
+                  ),
                 })
               }
             </Field>

--- a/src/components/wizards/DepartureWizard/pages/DepartureArrivalPage.tsx
+++ b/src/components/wizards/DepartureWizard/pages/DepartureArrivalPage.tsx
@@ -6,6 +6,7 @@ import validate from '../../validate';
 import {renderAerodromeDropdown, renderDateField, renderDurationField, renderTimeField,} from '../../renderField';
 import FieldSet from '../../FieldSet';
 import WizardNavigation from '../../../WizardNavigation';
+import AerodromeQuickPicks from '../../AerodromeQuickPicks';
 
 const DepartureArrivalPage = (props) => {
   const { t } = useTranslation();
@@ -16,7 +17,7 @@ const DepartureArrivalPage = (props) => {
       validate={validate('departure', ['date', 'time', 'location', 'duration'], hiddenFields)}
       onSubmit={onSubmit}
     >
-      {({handleSubmit, form}) => (
+      {({handleSubmit, form, values}) => (
         <form onSubmit={handleSubmit} className="DepartureArrivalPage">
           <FieldSet>
             <Field
@@ -47,6 +48,13 @@ const DepartureArrivalPage = (props) => {
                   },
                   meta,
                   label: t('movement.details.destination'),
+                  footer: (
+                    <AerodromeQuickPicks
+                      value={values.location}
+                      onSelect={icao => form.change('location', icao)}
+                      readOnly={readOnly}
+                    />
+                  ),
                 })
               }
             </Field>

--- a/src/components/wizards/QuickPickBar/index.tsx
+++ b/src/components/wizards/QuickPickBar/index.tsx
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+
+// Shared styling for the wizard "quick pick" chip bars (aircraft favourites,
+// aerodrome favourites). Keep visual parity across both usages.
+
+export const FavouritesBar = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6em;
+  padding: 0.4em 1em;
+  margin: 0 1em 1em;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  overflow: hidden;
+`;
+
+export const StarIcon = styled.span`
+  color: #e8a735;
+  display: flex;
+  align-items: center;
+  font-size: 1.1em;
+`;
+
+export const Chip = styled.button<{ $active?: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4em;
+  padding: 0.5em 0.9em;
+  min-height: 44px;
+  line-height: 1;
+  border: 1px solid ${props => props.$active ? props.theme.colors.main : '#ddd'};
+  border-radius: 3px;
+  background-color: ${props => props.$active ? props.theme.colors.main : '#fff'};
+  color: ${props => props.$active ? '#fff' : '#555'};
+  font-family: inherit;
+  font-size: 0.9em;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    border-color: ${props => props.theme.colors.main};
+    color: ${props => props.$active ? '#fff' : props.theme.colors.main};
+  }
+`;

--- a/src/components/wizards/pages/AircraftPage.tsx
+++ b/src/components/wizards/pages/AircraftPage.tsx
@@ -1,53 +1,15 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import styled from 'styled-components';
 import {Field, Form} from 'react-final-form'
 import validate from '../validate';
 import {renderAircraftCategoryDropdown, renderAircraftDropdown, renderInputField} from '../renderField';
 import FieldSet from '../FieldSet';
 import WizardNavigation from '../../WizardNavigation';
 import MaterialIcon from '../../MaterialIcon';
+import {Chip, FavouritesBar, StarIcon} from '../QuickPickBar';
 import {getAircraftOrigin, updateFeesTotal, updateGoAroundFees, updateLandingFees} from '../../../util/landingFees'
 import type { Aircraft } from '../../../modules/profile/migration';
-
-const FavouritesBar = styled.div`
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.6em;
-  padding: 0.4em 1em;
-  margin: 0 1em 1em;
-  background-color: #f5f5f5;
-  border-radius: 4px;
-  overflow: hidden;
-`;
-
-const StarIcon = styled.span`
-  color: #e8a735;
-  display: flex;
-  align-items: center;
-  font-size: 1.1em;
-`;
-
-const Chip = styled.button<{ $active?: boolean }>`
-  padding: 0.5em 0.9em;
-  min-height: 44px;
-  border: 1px solid ${props => props.$active ? props.theme.colors.main : '#ddd'};
-  border-radius: 3px;
-  background-color: ${props => props.$active ? props.theme.colors.main : '#fff'};
-  color: ${props => props.$active ? '#fff' : '#555'};
-  font-family: inherit;
-  font-size: 0.9em;
-  font-weight: bold;
-  cursor: pointer;
-  transition: all 0.15s ease;
-
-  &:hover {
-    border-color: ${props => props.theme.colors.main};
-    color: ${props => props.$active ? '#fff' : props.theme.colors.main};
-  }
-`;
 
 function applyAircraft(form: any, aircraft: { key: string; type?: string; mtow?: number; category?: string }, aircraftSettings: any) {
   form.change('immatriculation', aircraft.key);

--- a/src/components/wizards/renderField.tsx
+++ b/src/components/wizards/renderField.tsx
@@ -28,7 +28,7 @@ const StyledLabeledComponent = styled(LabeledComponent)`
 `;
 
 const renderLabeledComponent = (props, component) => {
-  const { name, label, tooltip, hidden, meta: { touched, error } } = props;
+  const { name, label, tooltip, hidden, footer, meta: { touched, error } } = props;
   if (hidden) {
     return null
   }
@@ -39,6 +39,7 @@ const renderLabeledComponent = (props, component) => {
       component={component}
       validationError={touched && error ? error : null}
       tooltip={tooltip}
+      footer={footer}
     />
   );
 };
@@ -115,6 +116,8 @@ export const renderTextArea = (props) => {
 
 export const renderAerodromeDropdown = (props) => {
   const cmp = <AerodromeDropdown {...props.input} readOnly={props.readOnly} dataCy={props.input.name}/>;
+  // `props.footer` (e.g. quick-pick chips) is forwarded to LabeledComponent, which
+  // renders it below the input but outside the input container — see renderLabeledComponent.
   return renderLabeledComponent(props, cmp);
 };
 

--- a/src/modules/frequentAerodromes/actions.ts
+++ b/src/modules/frequentAerodromes/actions.ts
@@ -1,0 +1,19 @@
+export const LOAD_FREQUENT_AERODROMES = 'LOAD_FREQUENT_AERODROMES' as const;
+export const FREQUENT_AERODROMES_LOADED = 'FREQUENT_AERODROMES_LOADED' as const;
+
+export type FrequentAerodromesAction =
+  | { type: typeof LOAD_FREQUENT_AERODROMES }
+  | { type: typeof FREQUENT_AERODROMES_LOADED; payload: { data: string[] } };
+
+export function loadFrequentAerodromes() {
+  return {
+    type: LOAD_FREQUENT_AERODROMES,
+  };
+}
+
+export function frequentAerodromesLoaded(data: string[]) {
+  return {
+    type: FREQUENT_AERODROMES_LOADED,
+    payload: { data },
+  };
+}

--- a/src/modules/frequentAerodromes/index.ts
+++ b/src/modules/frequentAerodromes/index.ts
@@ -1,0 +1,58 @@
+import { loadFrequentAerodromes } from './actions';
+import reducer from './reducer';
+import sagas from './sagas';
+import { canSeeAllMovements } from '../movements/sagas';
+import { frequentAerodromesFrom, MAX_FREQUENT } from '../../util/frequentAerodromes';
+
+/**
+ * Personal most-frequent aerodromes (ICAO codes) for the current user.
+ *
+ * Base list:
+ * - Regular users: derived client-side from the already-loaded movements
+ *   (`state.movements`), which are bounded to their own `createdBy` — no request.
+ * - Admins / `allMovements` operators: taken from the dedicated per-email fetch
+ *   (`state.frequentAerodromes`), because their loaded movement list is club-wide.
+ *
+ * Aerodromes used earlier in this session (recorded on movement save) are merged
+ * in first, so a destination just flown to shows up immediately in the next form
+ * without waiting for the movement list to reload.
+ */
+export function selectFrequentAerodromes(state: any): string[] {
+  const auth = state.auth.data;
+
+  if ((typeof __CONF__ !== 'undefined' && __CONF__.profileEnabled === false)
+    || !auth || auth.guest || auth.kiosk || !auth.email) {
+    return [];
+  }
+
+  const homeIcao = typeof __CONF__ !== 'undefined' && __CONF__.aerodrome
+    ? String(__CONF__.aerodrome.ICAO).toUpperCase()
+    : undefined;
+
+  const base = canSeeAllMovements(auth)
+    ? state.frequentAerodromes.data
+    : frequentAerodromesFrom(state.movements && state.movements.data ? state.movements.data.array : [], auth);
+
+  const session = state.frequentAerodromes.session || [];
+
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const icao of [...session, ...base]) {
+    const up = String(icao).toUpperCase();
+    if (up === homeIcao || seen.has(up)) {
+      continue;
+    }
+    seen.add(up);
+    result.push(up);
+    if (result.length >= MAX_FREQUENT) {
+      break;
+    }
+  }
+  return result;
+}
+
+export { loadFrequentAerodromes };
+
+export { sagas };
+
+export default reducer;

--- a/src/modules/frequentAerodromes/reducer.spec.ts
+++ b/src/modules/frequentAerodromes/reducer.spec.ts
@@ -1,0 +1,41 @@
+import reducer from './reducer';
+import * as actions from './actions';
+import { saveMovementSuccess } from '../movements/actions';
+
+describe('modules', () => {
+  describe('frequentAerodromes', () => {
+    describe('reducer', () => {
+      it('has an empty, unloaded initial state', () => {
+        const state = reducer(undefined, {type: '@@INIT'} as any);
+        expect(state).toEqual({data: [], loaded: false, session: []});
+      });
+
+      it('stores the loaded data and marks loaded', () => {
+        const state = reducer(undefined, actions.frequentAerodromesLoaded(['LSGG', 'LSZR']));
+        expect(state).toEqual({data: ['LSGG', 'LSZR'], loaded: true, session: []});
+      });
+
+      it('stays loaded when set to an empty list', () => {
+        const state = reducer({data: ['LSGG'], loaded: true, session: []}, actions.frequentAerodromesLoaded([]));
+        expect(state).toEqual({data: [], loaded: true, session: []});
+      });
+
+      it('records a saved movement\'s location (uppercased) most-recent-first', () => {
+        const state = reducer(undefined, saveMovementSuccess('k1', {location: 'lsgg'}));
+        expect(state.session).toEqual(['LSGG']);
+      });
+
+      it('moves a re-used location back to the front without duplicating', () => {
+        let state = reducer(undefined, saveMovementSuccess('k1', {location: 'LSGG'}));
+        state = reducer(state, saveMovementSuccess('k2', {location: 'LSZR'}));
+        state = reducer(state, saveMovementSuccess('k3', {location: 'LSGG'}));
+        expect(state.session).toEqual(['LSGG', 'LSZR']);
+      });
+
+      it('ignores a save with no location', () => {
+        const state = reducer(undefined, saveMovementSuccess('k1', {}));
+        expect(state.session).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/modules/frequentAerodromes/reducer.ts
+++ b/src/modules/frequentAerodromes/reducer.ts
@@ -1,0 +1,54 @@
+import * as actions from './actions';
+import { FrequentAerodromesAction } from './actions';
+import { SAVE_MOVEMENT_SUCCESS } from '../movements/actions';
+import reducer from '../../util/reducer';
+
+// This reducer also reacts to the movements SAVE_MOVEMENT_SUCCESS action, so its
+// action type is broader than its own action union.
+type ReducerAction = FrequentAerodromesAction | { type: typeof SAVE_MOVEMENT_SUCCESS; payload: { key: string; values: unknown } };
+
+interface FrequentAerodromesState {
+  data: string[];
+  loaded: boolean;
+  session: string[];
+}
+
+function frequentAerodromesLoaded(
+  state: FrequentAerodromesState,
+  action: FrequentAerodromesAction & { type: typeof actions.FREQUENT_AERODROMES_LOADED }
+) {
+  return {
+    ...state,
+    data: action.payload.data,
+    loaded: true,
+  };
+}
+
+// Records the aerodrome of a just-saved movement so it shows up as a favourite
+// immediately in the next movement form, without waiting for the movement list to
+// reload. Most-recently-used first, de-duplicated.
+function movementSaved(state: FrequentAerodromesState, action: any) {
+  const values = action.payload && action.payload.values;
+  const location = values && typeof values.location === 'string' ? values.location.toUpperCase() : null;
+  if (!location) {
+    return state;
+  }
+  return {
+    ...state,
+    session: [location, ...state.session.filter(icao => icao !== location)],
+  };
+}
+
+const ACTION_HANDLERS = {
+  [actions.FREQUENT_AERODROMES_LOADED]: frequentAerodromesLoaded,
+  [SAVE_MOVEMENT_SUCCESS]: movementSaved,
+};
+
+const INITIAL_STATE: FrequentAerodromesState = {
+  data: [],
+  loaded: false,
+  session: [],
+};
+
+export type { FrequentAerodromesState };
+export default reducer<FrequentAerodromesState, ReducerAction>(INITIAL_STATE, ACTION_HANDLERS);

--- a/src/modules/frequentAerodromes/sagas.spec.ts
+++ b/src/modules/frequentAerodromes/sagas.spec.ts
@@ -1,0 +1,73 @@
+import {call, put, select} from 'redux-saga/effects';
+import * as actions from './actions';
+import * as sagas from './sagas';
+import * as remote from '../movements/remote';
+import {authSelector} from '../movements/sagas';
+import FakeFirebaseSnapshot from '../../../test/FakeFirebaseSnapshot';
+
+jest.mock('../movements/remote');
+jest.mock('firebase/database', () => ({
+  onChildAdded: jest.fn(() => jest.fn()),
+  onChildChanged: jest.fn(() => jest.fn()),
+  onChildRemoved: jest.fn(() => jest.fn()),
+}));
+
+const admin = {email: 'admin@example.com', admin: true, guest: false, kiosk: false};
+
+const snapshotOf = (movements: any[]) => ({
+  snapshot: new FakeFirebaseSnapshot(null, movements.map((m, i) => new FakeFirebaseSnapshot(String(i), m))),
+});
+
+describe('modules', () => {
+  describe('frequentAerodromes', () => {
+    describe('sagas', () => {
+      describe('loadFrequentAerodromes', () => {
+        beforeEach(() => {
+          (global as any).__CONF__ = {aerodrome: {ICAO: 'LSZO'}, profileEnabled: true};
+        });
+
+        afterEach(() => {
+          delete (global as any).__CONF__;
+        });
+
+        it('does nothing for a regular (non-admin) user', () => {
+          const generator = sagas.loadFrequentAerodromes();
+          expect(generator.next().value).toEqual(select(authSelector));
+          expect(generator.next({email: 'pilot@example.com', admin: false}).done).toEqual(true);
+        });
+
+        it('does nothing when already loaded', () => {
+          const generator = sagas.loadFrequentAerodromes();
+          expect(generator.next().value).toEqual(select(authSelector));
+          expect(generator.next(admin).value).toEqual(select(sagas.stateSelector));
+          expect(generator.next({loaded: true}).done).toEqual(true);
+        });
+
+        it('fetches the admin\'s own movements and dispatches the aggregated list', () => {
+          const generator = sagas.loadFrequentAerodromes();
+
+          expect(generator.next().value).toEqual(select(authSelector));
+          expect(generator.next(admin).value).toEqual(select(sagas.stateSelector));
+
+          expect(generator.next({loaded: false}).value)
+            .toEqual(call(remote.loadLimited, '/departures', null, 50, null, admin.email));
+
+          const departures = snapshotOf([
+            {location: 'LSGG', createdBy: admin.email},
+            {location: 'LSGG', createdBy: admin.email},
+          ]);
+          expect(generator.next(departures).value)
+            .toEqual(call(remote.loadLimited, '/arrivals', null, 50, null, admin.email));
+
+          const arrivals = snapshotOf([
+            {location: 'LSZR', createdBy: admin.email},
+          ]);
+          expect(generator.next(arrivals).value)
+            .toEqual(put(actions.frequentAerodromesLoaded(['LSGG', 'LSZR'])));
+
+          expect(generator.next().done).toEqual(true);
+        });
+      });
+    });
+  });
+});

--- a/src/modules/frequentAerodromes/sagas.ts
+++ b/src/modules/frequentAerodromes/sagas.ts
@@ -1,0 +1,62 @@
+import {all, call, put, select, takeLatest} from 'redux-saga/effects'
+import * as actions from './actions';
+import * as remote from '../movements/remote';
+import {authSelector, canSeeAllMovements} from '../movements/sagas';
+import {frequentAerodromesFrom} from '../../util/frequentAerodromes';
+
+const FETCH_LIMIT = 50;
+
+export const stateSelector = (state: any) => state.frequentAerodromes;
+
+function toMovements(result: any): any[] {
+  const movements: any[] = [];
+  if (result && result.snapshot) {
+    result.snapshot.forEach((child: any) => {
+      movements.push(child.val());
+    });
+  }
+  return movements;
+}
+
+/**
+ * Only admins / `allMovements` operators need this fetch: their movement list is
+ * club-wide, so their own movements may not be in the loaded window (the "row 51"
+ * problem). Regular users already have their own movements in `state.movements`
+ * and derive favourites client-side without any request.
+ */
+export function* loadFrequentAerodromes() {
+  try {
+    if (typeof __CONF__ !== 'undefined' && __CONF__.profileEnabled === false) {
+      return;
+    }
+
+    const auth = yield select(authSelector);
+
+    if (!canSeeAllMovements(auth) || !auth.email || auth.guest || auth.kiosk) {
+      return;
+    }
+
+    const state = yield select(stateSelector);
+    if (state.loaded) {
+      return;
+    }
+
+    const departures = yield call(remote.loadLimited, '/departures', null, FETCH_LIMIT, null, auth.email);
+    const arrivals = yield call(remote.loadLimited, '/arrivals', null, FETCH_LIMIT, null, auth.email);
+
+    const movements = toMovements(departures).concat(toMovements(arrivals));
+    const data = frequentAerodromesFrom(movements, auth);
+
+    yield put(actions.frequentAerodromesLoaded(data));
+  } catch (e) {
+    if (console && typeof console.error === 'function') {
+      console.error('Failed to load frequent aerodromes', e);
+    }
+  }
+}
+
+export default function* sagas() {
+  yield all([
+    takeLatest(actions.LOAD_FREQUENT_AERODROMES, loadFrequentAerodromes),
+  ])
+}

--- a/src/modules/frequentAerodromes/selector.spec.ts
+++ b/src/modules/frequentAerodromes/selector.spec.ts
@@ -1,0 +1,68 @@
+import {selectFrequentAerodromes} from './index';
+
+jest.mock('../movements/remote');
+jest.mock('firebase/database', () => ({
+  onChildAdded: jest.fn(() => jest.fn()),
+  onChildChanged: jest.fn(() => jest.fn()),
+  onChildRemoved: jest.fn(() => jest.fn()),
+}));
+
+const mv = (location: string, createdBy: string) => ({location, createdBy});
+
+const state = (overrides: any = {}) => ({
+  auth: {data: {email: 'pilot@example.com', guest: false, kiosk: false, admin: false}},
+  movements: {data: {array: [
+    mv('LSGG', 'pilot@example.com'),
+    mv('LSGG', 'pilot@example.com'),
+    mv('LSZR', 'pilot@example.com'),
+  ]}},
+  frequentAerodromes: {data: [], loaded: false, session: []},
+  ...overrides,
+});
+
+describe('modules', () => {
+  describe('frequentAerodromes', () => {
+    describe('selectFrequentAerodromes', () => {
+      beforeEach(() => {
+        (global as any).__CONF__ = {aerodrome: {ICAO: 'LSZO'}, profileEnabled: true};
+      });
+
+      afterEach(() => {
+        delete (global as any).__CONF__;
+      });
+
+      it('derives from the pilot\'s own loaded movements (regular user)', () => {
+        expect(selectFrequentAerodromes(state())).toEqual(['LSGG', 'LSZR']);
+      });
+
+      it('uses the fetched slice for admins, not the club-wide movement list', () => {
+        const s = state({
+          auth: {data: {email: 'admin@example.com', admin: true, guest: false, kiosk: false}},
+          movements: {data: {array: [mv('LFSB', 'someone-else@example.com')]}},
+          frequentAerodromes: {data: ['LSZR'], loaded: true, session: []},
+        });
+        expect(selectFrequentAerodromes(s)).toEqual(['LSZR']);
+      });
+
+      it('surfaces a just-used aerodrome first, even before the list reloads', () => {
+        const s = state({frequentAerodromes: {data: [], loaded: false, session: ['LFSB']}});
+        expect(selectFrequentAerodromes(s)).toEqual(['LFSB', 'LSGG', 'LSZR']);
+      });
+
+      it('does not duplicate a session aerodrome that is also in the base list', () => {
+        const s = state({frequentAerodromes: {data: [], loaded: false, session: ['LSGG']}});
+        expect(selectFrequentAerodromes(s)).toEqual(['LSGG', 'LSZR']);
+      });
+
+      it('never includes the home aerodrome', () => {
+        const s = state({frequentAerodromes: {data: [], loaded: false, session: ['LSZO']}});
+        expect(selectFrequentAerodromes(s)).toEqual(['LSGG', 'LSZR']);
+      });
+
+      it('returns [] for a guest', () => {
+        const s = state({auth: {data: {email: null, guest: true, kiosk: false}}});
+        expect(selectFrequentAerodromes(s)).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -15,6 +15,7 @@ import reports, {sagas as reportsSagas} from './reports';
 import ui, {sagas as uiSagas} from './ui';
 import users, {sagas as usersSagas} from './users';
 import profile, {sagas as profileSagas} from './profile';
+import frequentAerodromes, {sagas as frequentAerodromesSagas} from './frequentAerodromes';
 
 const createRootReducer = () => combineReducers({
   aerodromes,
@@ -29,7 +30,8 @@ const createRootReducer = () => combineReducers({
   reports,
   ui,
   users,
-  profile
+  profile,
+  frequentAerodromes
 });
 
 export type RootState = ReturnType<ReturnType<typeof createRootReducer>>;
@@ -51,6 +53,7 @@ export const sagas = function* rootSaga() {
     uiSagas,
     usersSagas,
     profileSagas,
+    frequentAerodromesSagas,
     customsSagas
   ]))
 };

--- a/src/util/frequentAerodromes.spec.ts
+++ b/src/util/frequentAerodromes.spec.ts
@@ -1,0 +1,75 @@
+import {frequentAerodromesFrom} from './frequentAerodromes';
+
+describe('util', () => {
+  describe('frequentAerodromesFrom', () => {
+    const auth = {email: 'pilot@example.com', guest: false, kiosk: false};
+
+    const mv = (location: string, createdBy = auth.email) => ({location, createdBy});
+
+    beforeEach(() => {
+      (global as any).__CONF__ = {aerodrome: {ICAO: 'LSZO'}, profileEnabled: true};
+    });
+
+    afterEach(() => {
+      delete (global as any).__CONF__;
+    });
+
+    it('returns the most frequent aerodromes, most frequent first', () => {
+      const movements = [
+        mv('LSGG'), mv('LSGG'), mv('LSGG'),
+        mv('LSZR'), mv('LSZR'),
+        mv('LFSB'),
+      ];
+      expect(frequentAerodromesFrom(movements, auth)).toEqual(['LSGG', 'LSZR', 'LFSB']);
+    });
+
+    it('excludes the home aerodrome', () => {
+      const movements = [mv('LSZO'), mv('LSZO'), mv('LSGG')];
+      expect(frequentAerodromesFrom(movements, auth)).toEqual(['LSGG']);
+    });
+
+    it('only counts the current user\'s own movements (createdBy filter)', () => {
+      const movements = [
+        mv('LSGG', 'other@example.com'),
+        mv('LSGG', 'other@example.com'),
+        mv('LSZR', auth.email),
+      ];
+      expect(frequentAerodromesFrom(movements, auth)).toEqual(['LSZR']);
+    });
+
+    it('caps the result at 5 entries', () => {
+      const movements = [
+        mv('AAAA'), mv('BBBB'), mv('CCCC'), mv('DDDD'), mv('EEEE'), mv('FFFF'),
+      ];
+      expect(frequentAerodromesFrom(movements, auth)).toHaveLength(5);
+    });
+
+    it('normalises casing and ignores empty locations', () => {
+      const movements = [mv('lsgg'), mv('LSGG'), {location: '', createdBy: auth.email}];
+      expect(frequentAerodromesFrom(movements, auth)).toEqual(['LSGG']);
+    });
+
+    it('returns [] for guests', () => {
+      expect(frequentAerodromesFrom([mv('LSGG')], {...auth, guest: true})).toEqual([]);
+    });
+
+    it('returns [] for kiosk', () => {
+      expect(frequentAerodromesFrom([mv('LSGG')], {...auth, kiosk: true})).toEqual([]);
+    });
+
+    it('returns [] when there is no email', () => {
+      expect(frequentAerodromesFrom([mv('LSGG')], {email: null})).toEqual([]);
+    });
+
+    it('returns [] when profile is disabled', () => {
+      (global as any).__CONF__ = {aerodrome: {ICAO: 'LSZO'}, profileEnabled: false};
+      expect(frequentAerodromesFrom([mv('LSGG')], auth)).toEqual([]);
+    });
+
+    it('returns [] for empty or missing input', () => {
+      expect(frequentAerodromesFrom([], auth)).toEqual([]);
+      expect(frequentAerodromesFrom(null, auth)).toEqual([]);
+      expect(frequentAerodromesFrom(undefined, auth)).toEqual([]);
+    });
+  });
+});

--- a/src/util/frequentAerodromes.ts
+++ b/src/util/frequentAerodromes.ts
@@ -1,0 +1,63 @@
+export const MAX_FREQUENT = 5;
+
+interface FrequencyAuth {
+  email?: string | null;
+  guest?: boolean;
+  kiosk?: boolean;
+}
+
+interface FrequencyMovement {
+  location?: string | null;
+  createdBy?: string | null;
+}
+
+/**
+ * Derives a pilot's most-frequent aerodromes (ICAO codes) from a list of
+ * movements, keyed on the movement's `createdBy` (the user's email).
+ *
+ * Both departures (destinations) and arrivals (origins) may be passed in;
+ * combined they describe the pilot's full aerodrome repertoire. The home
+ * aerodrome (`__CONF__.aerodrome.ICAO`) is excluded — it is a local flight, not a
+ * destination, and is surfaced separately as a pinned quick-pick.
+ *
+ * Returns the top {@link MAX_FREQUENT} ICAO codes, most-frequent first, or an empty
+ * list when the feature does not apply (guest/kiosk, no email, or profile disabled).
+ */
+export function frequentAerodromesFrom(
+  movements: FrequencyMovement[] | null | undefined,
+  auth: FrequencyAuth | null | undefined
+): string[] {
+  if (typeof __CONF__ !== 'undefined' && __CONF__.profileEnabled === false) {
+    return [];
+  }
+
+  if (!auth || auth.guest || auth.kiosk || !auth.email) {
+    return [];
+  }
+
+  if (!Array.isArray(movements) || movements.length === 0) {
+    return [];
+  }
+
+  const homeIcao = typeof __CONF__ !== 'undefined' && __CONF__.aerodrome
+    ? String(__CONF__.aerodrome.ICAO).toUpperCase()
+    : undefined;
+
+  const counts = new Map<string, number>();
+
+  for (const movement of movements) {
+    if (!movement || movement.createdBy !== auth.email || !movement.location) {
+      continue;
+    }
+    const icao = String(movement.location).toUpperCase();
+    if (icao === homeIcao) {
+      continue;
+    }
+    counts.set(icao, (counts.get(icao) || 0) + 1);
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, MAX_FREQUENT)
+    .map(([icao]) => icao);
+}


### PR DESCRIPTION
## What & why

Logging a movement means re-typing the same aerodrome ICAO codes into the
destination/origin field every time. Aircraft already have profile-based
quick-picks; aerodromes had nothing. This adds a quick-pick chip bar under
the destination/origin field in both the departure and arrival wizards.

## Two complementary parts

**1. Home aerodrome first — for everyone (incl. guests / kiosk)**
The most common `location` at a small field is the field itself (circuits /
local flights). `__CONF__.aerodrome.ICAO` is pinned as the first chip and
sorted first in the aerodrome dropdown. It's labelled **"local flight"** (the
app's own `routes.localFlight` term), not "home" — a house icon would clash
with the existing "home base = aircraft based here" concept and mislead
visiting pilots whose base is elsewhere.

**2. Personal most-frequent destinations — for logged-in pilots**
Derived from the pilot's own movements, keyed on `createdBy` (their email):

- **Regular users**: computed client-side from the already-loaded
  `state.movements` (which is bounded to their own `createdBy`) — **no extra
  Firebase read**.
- **Admins / `allMovements` operators**: their loaded list is club-wide, so
  filtering it by their email can return nothing even though their movements
  exist further down (the "row 51" problem). They instead do one bounded,
  session-cached fetch via the existing `createdBy_orderKey` index.

## Freshness

An aerodrome just flown to is recorded on `SAVE_MOVEMENT_SUCCESS` and shown
immediately (first) in the next form — no dependency on the movement-list
realtime listener, which previously meant a new destination only appeared
after a full page reload.

## Layout

Chips render in a new `LabeledComponent` `footer` slot, so they sit inside the
destination field and share its width without inheriting the input styling.
Shared chip styling was extracted from `AircraftPage` into `QuickPickBar`.

## Cost

Zero additional hosting cost for the common case (regular users reuse
already-downloaded data); only the few admin sessions issue one small bounded,
cached read. No new Firebase index, Cloud Function, or stored data.

## Scope / limitations

- Personal list applies on email-login projects (movements carry `createdBy`);
  elsewhere only the home chip shows. Gated by `profileEnabled`.
- Attribution keys on the email a movement was filed under.

## Tests

Specs added for the dropdown comparator, aggregation helper, reducer (incl.
session recording), admin fetch saga, selector (regular/admin/session/home/
guest), the component (render/click/guest/readOnly + fetch behaviour), and the
`LabeledComponent` footer slot.

Note: Jest was not run in the authoring sandbox (platform-mismatched
`node_modules` vs Jest 30's native resolver); `npm run typecheck` passes and
CI runs the suites.
