### PR TITLE
Enable passkeys for lszm production

### DIFF
--- a/projects/lszm.json
+++ b/projects/lszm.json
@@ -61,7 +61,8 @@
     "production": {
       "firebaseProjectId": "lszm-prod",
       "firebaseDatabaseUrl": "https://lszm-prod-eu.europe-west1.firebasedatabase.app",
-      "firebaseApiKey": "AIzaSyBeSPI8y2oli06U-29zBC6Ehce_sWWnkSE"
+      "firebaseApiKey": "AIzaSyBeSPI8y2oli06U-29zBC6Ehce_sWWnkSE",
+      "passkeysEnabled": true
     }
   },
   "theme": "lszm",


### PR DESCRIPTION
Enables passkey (WebAuthn) login for lszm production, matching the
existing lszo production setup.

Two parts are required:

1. **Config flag** (this diff): adds `passkeysEnabled: true` to the
   lszm production environment in `projects/lszm.json`. This gates the
   passkey UI in the frontend.

2. **GitHub Actions environment variables** (already applied to the
   `lszm_prod` environment, not part of this diff): the WebAuthn Cloud
   Functions require RP config at runtime, otherwise they throw.
   - `WEBAUTHN_RPID = lszm.flightbox.aero`
   - `WEBAUTHN_ORIGINS = https://lszm.flightbox.aero`

   `WEBAUTHN_RPNAME` is intentionally omitted (defaults to `Flightbox`,
   same as lszo).

No new secrets or infra: the webauthn functions already deploy for
`lszm_prod` (present in the prod matrix) and challenges use the
existing RTDB.

**Deploy note:** the prod workflow triggers on push to `master`, so this
must reach `master` for passkeys to go live.

**Caveat:** RPID must exactly match the host users load the app from. If
lszm prod is served on a domain other than `lszm.flightbox.aero`,
registration/auth will fail and both variables need adjusting.
